### PR TITLE
contract: TM-A1 Compose stack + raw table defaults (TM-3)

### DIFF
--- a/.claude/adrs/005-raw-table-defaults.md
+++ b/.claude/adrs/005-raw-table-defaults.md
@@ -1,0 +1,47 @@
+# 005 — DB-side defaults on raw.* tables
+
+Status: accepted
+Date: 2026-04-23
+
+## Context
+
+`contracts/sql/001_raw_tables.sql` defines `raw.line_status`,
+`raw.arrivals`, and `raw.disruptions` as append-only landing tables for
+Kafka events. Producers always ship the full envelope, but several
+auxiliary paths insert rows without an explicit `event_id` or
+`ingested_at`:
+
+- Ad-hoc psql sessions during incident triage.
+- Backfill scripts replaying raw JSON from MinIO into the warehouse.
+- Integration tests that smoke-check the initialisation contract.
+
+Without DB-side defaults, each of these paths has to generate UUIDs and
+timestamps client-side, which diverges across callers and silently drops
+rows when a caller forgets either column (the `NOT NULL` on
+`ingested_at` surfaces as a blunt failure hours into a backfill).
+
+## Decision
+
+- Enable `pgcrypto` on the Postgres init path so `gen_random_uuid()` is
+  available even on PG < 13 images (we lock to PG 16 today, but the
+  extension keeps the contract portable if the image is swapped for a
+  managed instance that pins a different version).
+- Set `DEFAULT gen_random_uuid()` on `event_id` and
+  `DEFAULT now()` on `ingested_at` across the three raw tables.
+- Ship an idempotent `ALTER TABLE ... SET DEFAULT` block after each
+  `CREATE TABLE IF NOT EXISTS` so existing Postgres volumes from prior
+  scaffolds converge to the new contract on the next SQL re-apply —
+  `CREATE TABLE IF NOT EXISTS` alone is a no-op on pre-existing tables.
+- Producers continue to send explicit `event_id` and `ingested_at` off
+  the Kafka envelope; the defaults are a floor, not a replacement.
+
+## Consequences
+
+- **Pros**: ad-hoc inserts and backfills round-trip without per-caller
+  UUID/timestamp plumbing; existing dev environments converge without
+  manual `docker volume rm`.
+- **Cons**: `pgcrypto` is redundant on PG 13+ (`gen_random_uuid()` is
+  built-in). We keep it for cross-version portability; the cost is a
+  single extension row in `pg_extension`.
+- **Contract surface**: schema shape unchanged — only column defaults
+  change. No downstream regeneration required.

--- a/.claude/current-wp.md
+++ b/.claude/current-wp.md
@@ -1,1 +1,1 @@
-TM-000 — Contracts and scaffold (in progress)
+TM-A1 — Docker Compose: Postgres + Redpanda + Airflow + MinIO (done 2026-04-23)

--- a/.claude/specs/TM-A1-plan.md
+++ b/.claude/specs/TM-A1-plan.md
@@ -1,0 +1,111 @@
+# TM-A1 — Implementation plan (Phase 2)
+
+Source: TM-3 acceptance criteria + Round 3 follow-up comment on TM-3 + the
+Phase 1 research at `TM-A1-research.md`.
+
+## Summary
+
+The Compose stack was delivered as part of the TM-000 scaffold. The real TM-A1
+work is: (a) fold the Round 3 DB-default follow-up into
+`contracts/sql/001_raw_tables.sql`, (b) prove the stack boots healthy, (c) add
+a narrow smoke test so the DDL contract is checked automatically when Postgres
+is reachable. No new services, no new Make targets.
+
+## What we're NOT doing
+
+- Adding a dedicated Airflow metadata Postgres (→ ADR 003 / TM-A3).
+- Provisioning hosted Postgres or Redpanda (→ Phase 7).
+- Writing Airflow DAGs, consumers, or producers (→ TM-A2 / TM-B*).
+- Swapping Docker images, renaming services, or touching the frontend.
+- Running `make up` inside CI. Docker-dependent tests are gated on
+  `DATABASE_URL` and only executed on demand.
+
+## Sub-phases
+
+### Phase 3.1 — SQL defaults (Round 3 follow-up)
+
+- Edit `contracts/sql/001_raw_tables.sql`:
+  - Add `CREATE EXTENSION IF NOT EXISTS pgcrypto;` at the top (before the
+    `CREATE SCHEMA` statement).
+  - For each of `raw.line_status`, `raw.arrivals`, `raw.disruptions`:
+    - `event_id UUID PRIMARY KEY DEFAULT gen_random_uuid()`
+    - `ingested_at TIMESTAMPTZ NOT NULL DEFAULT now()`
+- Keep `event_type`, `source`, `payload` unchanged.
+- Re-run `uv run task dbt-parse` to confirm dbt sources still resolve against
+  the updated DDL (no column rename, only defaults — should be inert).
+
+### Phase 3.2 — Compose boot validation
+
+- From a clean state: `make clean && make up`.
+- Wait, then `docker compose ps` — every declared service (excluding the
+  `ui`-profile `redpanda-console`) must be `healthy` or, for `airflow-init`,
+  `exited (0)`.
+- Spot-check:
+  - `docker compose exec postgres psql -U tflmonitor -d tflmonitor -c '\dn'`
+    → lists `raw` and `ref`.
+  - `docker compose exec postgres psql -U tflmonitor -d tflmonitor -c '\dt raw.*'`
+    → three tables.
+  - `docker compose exec redpanda rpk cluster info` → broker up.
+  - `curl -fsS http://localhost:8082/health` → Airflow 200.
+  - `curl -fsS http://localhost:9000/minio/health/live` → MinIO 200.
+- If any check fails: STOP and surface the failure with logs.
+
+### Phase 3.3 — Smoke test
+
+- Add `tests/integration/test_sql_init.py`:
+  - Uses `pytest.importorskip("psycopg")`.
+  - Skips unless `DATABASE_URL` env var is set (prevents CI/dev test runs
+    from failing when Docker is absent).
+  - Asserts:
+    - Extension `pgcrypto` is installed.
+    - `raw.line_status`, `raw.arrivals`, `raw.disruptions` exist with the
+      expected columns.
+    - `event_id` default starts with `gen_random_uuid` (matches
+      `pg_attrdef.adsrc` / `pg_get_expr`).
+    - `ingested_at` default resolves to `now()`.
+- No new Makefile target; author runs `DATABASE_URL=... uv run pytest tests/integration` manually.
+- Conftest: reuse root `conftest.py` (pure additive).
+
+### Phase 3.4 — Documentation + progress
+
+- Update `PROGRESS.md`: TM-A1 status ✅ with the completion date and a one-line
+  note referring back to the Round 3 follow-up.
+- Update `.claude/current-wp.md` after TM-A1 wraps.
+- No ARCHITECTURE.md changes unless something genuinely new landed.
+
+### Phase 3.5 — Verification gate
+
+Before opening the PR, run:
+
+```bash
+make check
+DATABASE_URL=postgresql://tflmonitor:change_me@localhost:5432/tflmonitor \
+  uv run pytest tests/integration -v
+```
+
+Expect both to exit 0.
+
+## Success criteria (copy of research, now checkable)
+
+- [ ] `contracts/sql/001_raw_tables.sql` contains `pgcrypto` extension and
+  the two defaults on all three raw tables, NOT NULL preserved.
+- [ ] `make up` reports every non-profile service `healthy` (or `exited (0)`
+  for `airflow-init`).
+- [ ] `tests/integration/test_sql_init.py` passes when `DATABASE_URL` is set;
+  skips cleanly when unset.
+- [ ] `make check` still passes.
+- [ ] `PROGRESS.md` reflects the new status.
+- [ ] PR opened against `main` with description in English.
+
+## Open questions (need author confirmation)
+
+- **Q1** Is smoke-testing via `DATABASE_URL`-gated pytest acceptable, or
+  should I set up a GitHub Actions service container to run it in CI now?
+  Recommendation: gate locally for now; CI service containers can come in
+  TM-A3 when we touch the pipeline anyway.
+- **Q2** Should `make up` wait for health (blocking) instead of printing
+  `docker compose ps` and exiting? Recommendation: leave it non-blocking —
+  `docker compose up --wait` adds ~90s to every dev loop and authors can
+  re-run `docker compose ps` themselves.
+
+Proceed to Phase 3 once these are answered (or silently accepted via Auto).

--- a/.claude/specs/TM-A1-research.md
+++ b/.claude/specs/TM-A1-research.md
@@ -1,0 +1,73 @@
+# TM-A1 — Research (Phase 1)
+
+## Objective recap
+
+Bring up all local services via `docker compose` with healthchecks and verify
+they satisfy the TM-A1 acceptance criteria + Round 3 follow-up from PR #25.
+
+## What already exists (inherited from TM-000)
+
+- `docker-compose.yml` at repo root declares:
+  - `postgres` (Postgres 16) — port 5432, volume `postgres-data`, SQL init
+    files mounted read-only from `./contracts/sql`, healthcheck via
+    `pg_isready`, scram-sha-256 auth.
+  - `redpanda` (redpandadata/redpanda:v24.2.7) — external listener 19092,
+    volume `redpanda-data`, healthcheck via `rpk cluster info`.
+  - `redpanda-console` (redpandadata/console:v2.7.2) — guarded by Compose
+    profile `ui` (not started by default).
+  - `airflow-init`, `airflow-webserver`, `airflow-scheduler` (built from
+    `./airflow/Dockerfile = apache/airflow:2.10.3`) — LocalExecutor, metadata
+    in the same Postgres (isolation deferred to TM-A3 per ADR 003 pending),
+    webserver on port 8082 → 8080.
+  - `minio` (minio/minio:RELEASE.2024-10-29T16-01-48Z) — ports 9000 + 9001,
+    volume `minio-data`, healthcheck via `/minio/health/live`.
+- `Makefile` targets present: `bootstrap`, `up`, `down`, `clean`, `check`,
+  `seed`, `openapi-ts`, `sync-dbt-sources`.
+- `contracts/sql/001_raw_tables.sql` creates `raw.line_status`,
+  `raw.arrivals`, `raw.disruptions` — all with `event_id UUID PRIMARY KEY`
+  and `ingested_at TIMESTAMPTZ NOT NULL`, **no DB-side defaults**.
+- `contracts/sql/002_reference_tables.sql` creates `ref.lines`,
+  `ref.stations` with `loaded_at DEFAULT NOW()`.
+- `contracts/sql/003_indexes.sql` adds BTREE+GIN per raw table.
+
+## What is missing
+
+1. **DB-side defaults on raw tables** (Round 3 follow-up on TM-3):
+   - Producers currently must supply `event_id` and `ingested_at`. Ad-hoc
+     inserts and backfills break.
+   - Add `CREATE EXTENSION IF NOT EXISTS pgcrypto;` (for `gen_random_uuid()`)
+     ahead of the raw DDL.
+   - Add `DEFAULT gen_random_uuid()` on `event_id` and `DEFAULT now()` on
+     `ingested_at` on all three raw tables.
+   - `NOT NULL` guarantees stay — defaults strengthen, they do not weaken.
+2. **End-to-end boot validation** — the author has not yet run
+   `docker compose up` against the scaffold. Need to confirm healthchecks
+   reach `healthy` and the init SQL runs cleanly.
+3. **Lightweight smoke test** — nothing today asserts the schemas and tables
+   exist after Postgres starts. A small integration test (pytest, skipped
+   when `DATABASE_URL` absent) would catch init regressions in CI later.
+
+## What is explicitly out of scope
+
+- Airflow metadata DB isolation → deferred to TM-A3 / ADR 003 (Phase 7).
+- DAGs → TM-A2 (Phase 5).
+- Seed loader → TM-B1+ populates fixtures.
+- Supabase / Redpanda Cloud provisioning → Phase 7 WPs.
+
+## Open questions (none blocking)
+
+- Smoke test format: stand-alone pytest marker, or leave validation to manual
+  `make up` + `docker compose ps`? Recommendation: single pytest with
+  `pytest.importorskip("psycopg")` + env-var gate, runs only when explicitly
+  asked — avoids needing Docker in CI.
+
+## Success criteria (from TM-3 + Round 3 comment)
+
+- [ ] `docker compose up -d` boots Postgres, Redpanda, Airflow (init →
+  webserver + scheduler), MinIO. All report `healthy` within start periods.
+- [ ] `contracts/sql/*` executes without error on first Postgres boot.
+- [ ] `raw.*` tables have `DEFAULT now()` on `ingested_at` and
+  `DEFAULT gen_random_uuid()` on `event_id`, plus `NOT NULL`.
+- [ ] `make down` stops everything cleanly.
+- [ ] `make clean` drops volumes (destructive, documented).
+- [ ] `make check` still passes (lint + tests + dbt-parse + web).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  python:
+  lint:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -29,7 +29,6 @@ jobs:
       - name: Verify dbt sources mirror the contract
         run: diff contracts/dbt_sources.yml dbt/sources/tfl.yml
       - run: uv run task lint
-      - run: uv run task test
       - run: uv run bandit -r src contracts scripts --severity-level high
       - run: uv run task dbt-parse
         env:
@@ -38,6 +37,14 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync --frozen
+      - run: uv run task test
 
   frontend:
     runs-on: ubuntu-latest

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,7 +5,7 @@ Current state of work packages. Update the status column as WPs land.
 | Phase | WP | Title | Track | Status | Notes |
 |---|---|---|---|---|---|
 | 0 | TM-000 | Contracts and scaffold | — | ✅ 2026-04-22 | Scaffold, contracts, tier-1/tier-2 schemas, fixtures fetched |
-| 1 | TM-A1 | Docker Compose + Postgres + Redpanda + Airflow | A-infra | ⬜ | |
+| 1 | TM-A1 | Docker Compose + Postgres + Redpanda + Airflow | A-infra | ✅ 2026-04-23 | Round 3 follow-up applied: pgcrypto + DB-side defaults on raw tables; integration smoke test gated on `DATABASE_URL` |
 | 1 | TM-B1 | Async TfL client + fixtures | B-ingestion | ⬜ | |
 | 2 | TM-C1 | dbt scaffold | C-dbt | ⬜ | |
 | 2 | TM-D1 | FastAPI skeleton + Logfire wiring | D-api-agent | ⬜ | |

--- a/contracts/sql/001_raw_tables.sql
+++ b/contracts/sql/001_raw_tables.sql
@@ -1,28 +1,33 @@
 -- Raw append-only tables receiving events off Kafka.
 -- Each row stores the full envelope plus the JSONB payload for downstream
 -- modelling in dbt.
+--
+-- DB-side defaults on event_id and ingested_at harden ad-hoc inserts and
+-- backfills; producers still supply explicit values off the Kafka envelope.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 CREATE SCHEMA IF NOT EXISTS raw;
 
 CREATE TABLE IF NOT EXISTS raw.line_status (
-    event_id UUID PRIMARY KEY,
-    ingested_at TIMESTAMPTZ NOT NULL,
+    event_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     event_type TEXT NOT NULL,
     source TEXT NOT NULL,
     payload JSONB NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS raw.arrivals (
-    event_id UUID PRIMARY KEY,
-    ingested_at TIMESTAMPTZ NOT NULL,
+    event_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     event_type TEXT NOT NULL,
     source TEXT NOT NULL,
     payload JSONB NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS raw.disruptions (
-    event_id UUID PRIMARY KEY,
-    ingested_at TIMESTAMPTZ NOT NULL,
+    event_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     event_type TEXT NOT NULL,
     source TEXT NOT NULL,
     payload JSONB NOT NULL

--- a/contracts/sql/001_raw_tables.sql
+++ b/contracts/sql/001_raw_tables.sql
@@ -17,6 +17,10 @@ CREATE TABLE IF NOT EXISTS raw.line_status (
     payload JSONB NOT NULL
 );
 
+ALTER TABLE raw.line_status
+    ALTER COLUMN event_id SET DEFAULT gen_random_uuid(),
+    ALTER COLUMN ingested_at SET DEFAULT now();
+
 CREATE TABLE IF NOT EXISTS raw.arrivals (
     event_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     ingested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -25,6 +29,10 @@ CREATE TABLE IF NOT EXISTS raw.arrivals (
     payload JSONB NOT NULL
 );
 
+ALTER TABLE raw.arrivals
+    ALTER COLUMN event_id SET DEFAULT gen_random_uuid(),
+    ALTER COLUMN ingested_at SET DEFAULT now();
+
 CREATE TABLE IF NOT EXISTS raw.disruptions (
     event_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     ingested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -32,3 +40,7 @@ CREATE TABLE IF NOT EXISTS raw.disruptions (
     source TEXT NOT NULL,
     payload JSONB NOT NULL
 );
+
+ALTER TABLE raw.disruptions
+    ALTER COLUMN event_id SET DEFAULT gen_random_uuid(),
+    ALTER COLUMN ingested_at SET DEFAULT now();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ exclude = ["scripts/"]
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 asyncio_mode = "auto"
+addopts = "-m 'not integration'"
+markers = [
+    "integration: requires live services (Postgres, Kafka, etc.); opt in with -m integration",
+]
 
 [tool.taskipy.tasks]
 # --exitfirst-on-collection-errors via Python wrapper: treat "no tests collected" (exit 5) as success.

--- a/tests/integration/test_sql_init.py
+++ b/tests/integration/test_sql_init.py
@@ -1,0 +1,109 @@
+"""Integration test for contracts/sql/*.sql executed by Postgres init.
+
+Gated on the DATABASE_URL environment variable so CI and day-to-day unit
+runs skip cleanly when Postgres is not reachable. Run locally against
+`make up` with:
+
+    DATABASE_URL=postgresql://tflmonitor:change_me@localhost:5432/tflmonitor \
+        uv run pytest tests/integration -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg")
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not DATABASE_URL,
+    reason="DATABASE_URL not set; skipping Postgres-dependent integration tests",
+)
+
+
+RAW_TABLES = ("line_status", "arrivals", "disruptions")
+
+
+@pytest.fixture(scope="module")
+def pg_conn():
+    """Yield a single psycopg connection for all assertions in this module."""
+    with psycopg.connect(DATABASE_URL) as conn:
+        yield conn
+
+
+def test_pgcrypto_extension_installed(pg_conn) -> None:
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto'")
+        assert cur.fetchone() is not None, "pgcrypto extension missing"
+
+
+def test_raw_schema_and_tables_exist(pg_conn) -> None:
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_namespace WHERE nspname = 'raw'")
+        assert cur.fetchone() is not None, "schema `raw` not created"
+
+        for table in RAW_TABLES:
+            cur.execute(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema = 'raw' AND table_name = %s",
+                (table,),
+            )
+            assert cur.fetchone() is not None, f"table raw.{table} missing"
+
+
+@pytest.mark.parametrize("table", RAW_TABLES)
+def test_raw_event_id_defaults_to_gen_random_uuid(pg_conn, table: str) -> None:
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_default, is_nullable "
+            "FROM information_schema.columns "
+            "WHERE table_schema = 'raw' AND table_name = %s "
+            "AND column_name = 'event_id'",
+            (table,),
+        )
+        row = cur.fetchone()
+        assert row is not None, f"event_id column missing on raw.{table}"
+        column_default, is_nullable = row
+        assert column_default is not None and "gen_random_uuid" in column_default, (
+            f"raw.{table}.event_id should default to gen_random_uuid(); got {column_default!r}"
+        )
+        assert is_nullable == "NO", f"raw.{table}.event_id must remain NOT NULL"
+
+
+@pytest.mark.parametrize("table", RAW_TABLES)
+def test_raw_ingested_at_defaults_to_now(pg_conn, table: str) -> None:
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_default, is_nullable "
+            "FROM information_schema.columns "
+            "WHERE table_schema = 'raw' AND table_name = %s "
+            "AND column_name = 'ingested_at'",
+            (table,),
+        )
+        row = cur.fetchone()
+        assert row is not None, f"ingested_at column missing on raw.{table}"
+        column_default, is_nullable = row
+        assert column_default is not None and "now()" in column_default.lower(), (
+            f"raw.{table}.ingested_at should default to now(); got {column_default!r}"
+        )
+        assert is_nullable == "NO", f"raw.{table}.ingested_at must remain NOT NULL"
+
+
+@pytest.mark.parametrize("table", RAW_TABLES)
+def test_raw_insert_with_defaults_round_trip(pg_conn, table: str) -> None:
+    """Insert supplying only the non-defaulted columns and verify defaults fire."""
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO raw.{table} (event_type, source, payload) "
+            "VALUES (%s, %s, %s::jsonb) "
+            "RETURNING event_id, ingested_at",
+            ("smoke.test", "integration", "{}"),
+        )
+        event_id, ingested_at = cur.fetchone()
+        assert event_id is not None
+        assert ingested_at is not None
+        cur.execute(f"DELETE FROM raw.{table} WHERE event_id = %s", (event_id,))
+    pg_conn.commit()

--- a/tests/integration/test_sql_init.py
+++ b/tests/integration/test_sql_init.py
@@ -1,46 +1,52 @@
 """Integration test for contracts/sql/*.sql executed by Postgres init.
 
-Gated on the DATABASE_URL environment variable so CI and day-to-day unit
-runs skip cleanly when Postgres is not reachable. Run locally against
-`make up` with:
+Gated on the `integration` pytest marker so the default `uv run task test`
+run stays hermetic even when the developer already has `DATABASE_URL`
+exported. Run explicitly with:
 
     DATABASE_URL=postgresql://tflmonitor:change_me@localhost:5432/tflmonitor \
-        uv run pytest tests/integration -v
+        uv run pytest -m integration tests/integration -v
 """
 
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
+from typing import Any
 
 import pytest
 
 psycopg = pytest.importorskip("psycopg")
+psycopg_sql = pytest.importorskip("psycopg.sql")
 
 DATABASE_URL = os.environ.get("DATABASE_URL")
 
-pytestmark = pytest.mark.skipif(
-    not DATABASE_URL,
-    reason="DATABASE_URL not set; skipping Postgres-dependent integration tests",
-)
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not DATABASE_URL,
+        reason="DATABASE_URL not set; skipping Postgres-dependent integration tests",
+    ),
+]
 
 
 RAW_TABLES = ("line_status", "arrivals", "disruptions")
 
 
 @pytest.fixture(scope="module")
-def pg_conn():
+def pg_conn() -> Iterator[Any]:
     """Yield a single psycopg connection for all assertions in this module."""
     with psycopg.connect(DATABASE_URL) as conn:
         yield conn
 
 
-def test_pgcrypto_extension_installed(pg_conn) -> None:
+def test_pgcrypto_extension_installed(pg_conn: Any) -> None:
     with pg_conn.cursor() as cur:
         cur.execute("SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto'")
         assert cur.fetchone() is not None, "pgcrypto extension missing"
 
 
-def test_raw_schema_and_tables_exist(pg_conn) -> None:
+def test_raw_schema_and_tables_exist(pg_conn: Any) -> None:
     with pg_conn.cursor() as cur:
         cur.execute("SELECT 1 FROM pg_namespace WHERE nspname = 'raw'")
         assert cur.fetchone() is not None, "schema `raw` not created"
@@ -55,7 +61,7 @@ def test_raw_schema_and_tables_exist(pg_conn) -> None:
 
 
 @pytest.mark.parametrize("table", RAW_TABLES)
-def test_raw_event_id_defaults_to_gen_random_uuid(pg_conn, table: str) -> None:
+def test_raw_event_id_defaults_to_gen_random_uuid(pg_conn: Any, table: str) -> None:
     with pg_conn.cursor() as cur:
         cur.execute(
             "SELECT column_default, is_nullable "
@@ -74,7 +80,7 @@ def test_raw_event_id_defaults_to_gen_random_uuid(pg_conn, table: str) -> None:
 
 
 @pytest.mark.parametrize("table", RAW_TABLES)
-def test_raw_ingested_at_defaults_to_now(pg_conn, table: str) -> None:
+def test_raw_ingested_at_defaults_to_now(pg_conn: Any, table: str) -> None:
     with pg_conn.cursor() as cur:
         cur.execute(
             "SELECT column_default, is_nullable "
@@ -93,17 +99,21 @@ def test_raw_ingested_at_defaults_to_now(pg_conn, table: str) -> None:
 
 
 @pytest.mark.parametrize("table", RAW_TABLES)
-def test_raw_insert_with_defaults_round_trip(pg_conn, table: str) -> None:
+def test_raw_insert_with_defaults_round_trip(pg_conn: Any, table: str) -> None:
     """Insert supplying only the non-defaulted columns and verify defaults fire."""
+    table_identifier = psycopg_sql.Identifier("raw", table)
     with pg_conn.cursor() as cur:
-        cur.execute(
-            f"INSERT INTO raw.{table} (event_type, source, payload) "
-            "VALUES (%s, %s, %s::jsonb) "
-            "RETURNING event_id, ingested_at",
-            ("smoke.test", "integration", "{}"),
-        )
-        event_id, ingested_at = cur.fetchone()
-        assert event_id is not None
-        assert ingested_at is not None
-        cur.execute(f"DELETE FROM raw.{table} WHERE event_id = %s", (event_id,))
-    pg_conn.commit()
+        try:
+            cur.execute(
+                psycopg_sql.SQL(
+                    "INSERT INTO {table} (event_type, source, payload) "
+                    "VALUES (%s, %s, %s::jsonb) "
+                    "RETURNING event_id, ingested_at"
+                ).format(table=table_identifier),
+                ("smoke.test", "integration", "{}"),
+            )
+            event_id, ingested_at = cur.fetchone()
+            assert event_id is not None
+            assert ingested_at is not None
+        finally:
+            pg_conn.rollback()


### PR DESCRIPTION
## Summary                                                      
  - Apply Round 3 follow-up from PR #25: pgcrypto extension + DB-side defaults (gen_random_uuid, now()) on raw.line_status / raw.arrivals /            
  raw.disruptions. NOT NULL preserved.                                                                                                                 
  - Add DATABASE_URL-gated integration smoke test (tests/integration/test_sql_init.py) covering extension, tables, defaults, and insert round-trip.  
  - Compose stack from TM-000 validated end-to-end locally: Postgres, Redpanda, Airflow (LocalExecutor), MinIO all healthy; airflow-init exits 0.      
                                                                                                                                                       
  ## Acceptance criteria                                                                                                                               
  - [x] docker-compose.yml boots Postgres, Redpanda, Airflow (LocalExecutor), MinIO                                                                    
  - [x] Each service has healthcheck + depends_on ordering                                                                                           
  - [x] make up / make down work                                                                                                                       
  - [x] Volumes persist across restarts                                                                                                                
  - [x] No sidecars beyond what services need (redpanda-console gated behind 'ui' profile)                                                             
  - [x] Round 3 follow-up: pgcrypto + DB defaults on raw tables                                                                                   
                                                                                                                                                       
  ## Out of scope                                                                                                                                      
  - Airflow metadata DB isolation → deferred to TM-A3 / ADR 003.                                                                                  
  - DAGs → TM-A2.                                                                                                                                      
                                                                                                                                                       
  ## Test plan                                                                                                                                         
  - [ ] make check passes                                                                                                                              
  - [ ] make up -> docker compose ps shows every non-profile service healthy                                                                           
  - [ ] DATABASE_URL=postgresql://tflmonitor:change_me@localhost:5432/tflmonitor uv run pytest tests/integration -v -> 11 passed                       
                                                                                                                                                       
  Closes TM-3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database tables now auto-generate unique event IDs and ingestion timestamps by default.

* **Tests**
  * Added integration tests that validate DB initialization, extensions, schema, and default generation (gated when a database URL is provided).

* **Documentation**
  * Updated specs, progress, and planning docs to reflect Phase 2 changes and verification steps; work package marked complete.

* **Chores**
  * CI workflow split into separate lint and test jobs; local smoke-test/validation steps documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->