### PR TITLE
chore(dbt): TM-C1 close as delivered by TM-000 (TM-5)

### DIFF
--- a/.claude/specs/TM-B1-plan.md
+++ b/.claude/specs/TM-B1-plan.md
@@ -1,0 +1,281 @@
+# TM-B1 — Implementation plan (Phase 2)
+
+Source: `TM-B1-research.md` + author decisions on `2026-04-23`:
+
+- **Q2 — fixture layout:** add-alongside under `tests/fixtures/tfl/`;
+  do not move the existing `tests/fixtures/*_sample.json` (out of
+  track).
+- **Q3 — normalisation:** include tier-1 → tier-2 normalisation in
+  TM-B1 (per ARCHITECTURE.md placement at "TM-B1+").
+- **Q4 — retry:** hand-rolled bounded loop inside the client module,
+  no new dependency.
+
+## Summary
+
+Implement the async TfL Unified API client under
+`src/ingestion/tfl_client/`, ship real fixtures under
+`tests/fixtures/tfl/`, land the tier-1 → tier-2 normalisation layer so
+TM-B2's producer only has to handle wire + Kafka concerns, and cover
+the surface with `tests/ingestion/`. No Kafka, no `contracts/` edits.
+
+## Execution mode
+
+- **Author of change:** agent-team member (worktree-isolated). Team
+  name: `tfl-phase-1-2`. Member name: `tm-b1`.
+- **Branch (inside worktree):** `feature/TM-B1-async-tfl-client`.
+- **PR title:** `feat(ingestion): TM-B1 async TfL client + tier-1/2 normalisation + fixtures (TM-4)`.
+- **PR body:** `Closes TM-4`; lists deliverables, the retry policy, and
+  the `tests/fixtures/tfl/` layout choice.
+
+## What we're NOT doing
+
+- No Kafka producers, no `aiokafka` usage — TM-B2.
+- No Kafka consumers, no Postgres writes — TM-B3.
+- No edits to `contracts/schemas/*` — tier-1 + tier-2 are frozen.
+- No edits to `tests/test_contracts.py` or `tests/fixtures/*_sample.json`
+  — out of track.
+- No edits to `scripts/fetch_tfl_samples.py` — out of track; the
+  existing script keeps working against the old fixture path.
+- No new runtime dependency (`tenacity`, `stamina`, `respx`, etc.) —
+  retry is hand-rolled; testing uses `httpx.MockTransport` which is
+  built in.
+- No `Settings(BaseSettings)` class — one env var (`TFL_APP_KEY`)
+  does not justify it (CLAUDE.md rule 5).
+- No logging wrapper — Logfire/`logging.basicConfig` is enough
+  (CLAUDE.md rule 6). The client emits a `logfire.span` per request
+  so throttling diagnostics land in the right tool.
+- No end-to-end live-API test in CI — ingestion tests use fixtures
+  only (AGENTS.md §3).
+
+## Sub-phases
+
+### Phase 3.1 — Fixtures (`tests/fixtures/tfl/`)
+
+Populate the new fixture directory with real TfL responses (the member
+regenerates locally via a small one-off script or by re-using
+`scripts/fetch_tfl_samples.py` out-of-band, then commits the JSON).
+Required files — one per endpoint method the client exposes:
+
+- `tests/fixtures/tfl/line_status_tube.json` — `GET /Line/Mode/tube/Status`
+- `tests/fixtures/tfl/line_status_multi_mode.json` —
+  `GET /Line/Mode/tube,elizabeth-line,dlr,overground/Status`
+- `tests/fixtures/tfl/arrivals_oxford_circus.json` —
+  `GET /StopPoint/940GZZLUOXC/Arrivals`
+- `tests/fixtures/tfl/disruptions_tube.json` —
+  `GET /Line/Mode/tube/Disruption`
+
+All files are real API responses (not hand-crafted). Each is a JSON
+array matching the tier-1 Pydantic models. Commit them as-is; the
+tier-1 schemas already tolerate extra fields via
+`ConfigDict(extra="ignore")`.
+
+### Phase 3.2 — Client module (`src/ingestion/tfl_client/`)
+
+Files (all under the allowed path):
+
+#### `src/ingestion/tfl_client/__init__.py`
+
+Re-export the public surface:
+
+```python
+from src.ingestion.tfl_client.client import TflClient, TflClientError
+
+__all__ = ["TflClient", "TflClientError"]
+```
+
+#### `src/ingestion/tfl_client/client.py`
+
+- `class TflClient` — async context manager wrapping a single
+  `httpx.AsyncClient`.
+- Constructor signature:
+  ```python
+  def __init__(
+      self,
+      app_key: str,
+      *,
+      base_url: str = "https://api.tfl.gov.uk",
+      timeout: float = 30.0,
+      max_attempts: int = 3,
+  ) -> None: ...
+  ```
+  - `app_key` required; constructor raises `TflClientError` if empty /
+    `None` (fail-loud per CLAUDE.md §"Security-first — zero-trust").
+- Class method `from_env(**kwargs) -> TflClient` that reads
+  `TFL_APP_KEY` from the environment (`os.environ`; tests override via
+  `monkeypatch.setenv`).
+- `async def __aenter__(self) -> Self` instantiates
+  `httpx.AsyncClient(base_url=base_url, timeout=timeout)` and keeps it
+  on `self._http`.
+- `async def __aexit__(self, *exc) -> None` closes the client.
+- `async def _request(self, path: str, *, params: dict | None = None) -> Any` —
+  central call site that:
+  1. Merges `{"app_key": self._app_key}` into `params`.
+  2. Calls `self._http.get(path, params=params)` inside a
+     `logfire.span("tfl.request", path=path, params=...)` context so
+     requests appear in Logfire.
+  3. Implements the retry policy (see Phase 3.3).
+  4. Calls `response.raise_for_status()` on non-retryable 4xx.
+  5. Returns `response.json()`.
+- Three public coroutines (tier-1 returns):
+  ```python
+  async def fetch_line_statuses(self, modes: Iterable[str]) -> list[TflLineResponse]: ...
+  async def fetch_arrivals(self, stop_id: str) -> list[TflArrivalPrediction]: ...
+  async def fetch_disruptions(self, modes: Iterable[str]) -> list[TflDisruption]: ...
+  ```
+  Each uses `TypeAdapter(list[Tfl...]).validate_python(...)` for
+  efficient bulk parsing. Each validates input (`modes` non-empty;
+  `stop_id` non-empty string).
+
+#### `src/ingestion/tfl_client/retry.py`
+
+Tiny hand-rolled retry helper (~30 lines) shared by `_request`:
+
+- Signature:
+  ```python
+  async def with_retry(
+      call: Callable[[], Awaitable[httpx.Response]],
+      *,
+      max_attempts: int,
+  ) -> httpx.Response: ...
+  ```
+- Retry on: `httpx.TimeoutException`, `httpx.TransportError`, and
+  responses with `status_code in {429, 500, 502, 503, 504}`.
+- For 429 responses: honour `Retry-After` if present (seconds form
+  only — HTTP-date form is rare from TfL; raise if unparseable).
+- Otherwise exponential backoff: `0.5 * 2 ** attempt` seconds, capped
+  at 10s (`asyncio.sleep`).
+- On final failure, raise `TflClientError` wrapping the last
+  response / exception.
+
+#### `src/ingestion/tfl_client/normalise.py`
+
+Adapters mapping tier-1 → tier-2 payloads (pure functions, no
+side-effects). Shape:
+
+```python
+def line_status_payloads(response: list[TflLineResponse]) -> list[LineStatusPayload]: ...
+def arrival_payloads(response: list[TflArrivalPrediction]) -> list[ArrivalPayload]: ...
+def disruption_payloads(response: list[TflDisruption]) -> list[DisruptionPayload]: ...
+```
+
+Details:
+
+- `line_status_payloads` flattens the `lineStatuses[*].validityPeriods`
+  into one payload per `(line_id, validity_period)`; `valid_from` /
+  `valid_to` come from the validity period; `status_severity` + `reason`
+  come from the parent `lineStatus`. Lines with no `validityPeriods`
+  produce a single payload using `valid_from=now` and
+  `valid_to=valid_from + 12h` (consistent with `test_contracts.py`
+  convention); this default is documented in the function docstring.
+- `arrival_payloads` maps field-by-field:
+  `id → arrival_id`, `naptanId → station_id`, `lineId → line_id`,
+  `platformName → platform_name`, `direction` passthrough,
+  `destinationName → destination`, `expectedArrival → expected_arrival`,
+  `timeToStation → time_to_station_seconds`, `vehicleId → vehicle_id`.
+- `disruption_payloads` — TfL disruption responses are lossy (no stable
+  `disruption_id` or `created` timestamp); the adapter synthesises
+  `disruption_id` from `hash(category, description, affected_routes)`
+  and uses `datetime.now(UTC)` for `created` / `last_update`. Flag
+  these as synthetic in the docstring so TM-B2 knows it cannot trust
+  them for deduplication without extra keys.
+- `summary` in the payload is a truncated `description` (160 chars)
+  because the free TfL endpoint does not return a separate summary —
+  documented in the docstring.
+
+The adapters do **not** build `Event` envelopes (`LineStatusEvent`
+etc.); wrapping payloads into events is a producer concern (TM-B2),
+since the envelope needs `event_id`, `ingested_at`, source offsets.
+
+### Phase 3.3 — Tests (`tests/ingestion/`)
+
+Files:
+
+- `tests/ingestion/__init__.py` — empty package marker.
+- `tests/ingestion/conftest.py` — one fixture loading each JSON from
+  `tests/fixtures/tfl/` into bytes; a factory helper building a
+  `httpx.MockTransport` wired to a url→response mapping.
+- `tests/ingestion/test_tfl_client.py`
+  - `test_fetch_line_statuses_returns_tier1_models`
+  - `test_fetch_arrivals_returns_tier1_models`
+  - `test_fetch_disruptions_returns_tier1_models`
+  - `test_app_key_in_query_params` — asserts every outbound request
+    carries `app_key=<value>`.
+  - `test_429_respects_retry_after` — first response 429 with
+    `Retry-After: 1`, second 200; assert final response parsed.
+  - `test_500_retries_then_succeeds` — 500 / 500 / 200 → succeeds.
+  - `test_401_raised_immediately` — single 401 → `TflClientError`,
+    one attempt only.
+  - `test_timeout_retries_then_gives_up` — uses custom transport
+    raising `httpx.TimeoutException` every time; asserts
+    `TflClientError` after `max_attempts`.
+  - `test_from_env_requires_app_key` — unset env var → `TflClientError`.
+- `tests/ingestion/test_normalise.py`
+  - `test_line_status_payloads_from_multi_mode_fixture`
+  - `test_arrival_payloads_from_oxford_circus_fixture`
+  - `test_disruption_payloads_from_tube_fixture`
+  - Each test validates the resulting `*Payload` objects via the tier-2
+    Pydantic models (roundtrip check on a representative item).
+
+`pytest-asyncio`'s `asyncio_mode = "auto"` (already in
+`pyproject.toml`) handles the `async def` tests transparently.
+
+### Phase 3.4 — Verification gate
+
+```bash
+uv run task lint          # ruff + mypy strict on src/ingestion + contracts
+uv run task test          # adds tests/ingestion/*
+uv run bandit -r src      # HIGH severity only
+make check                # includes dbt-parse + TS
+```
+
+All must exit 0 before PR. If `mypy strict` rejects `TypeAdapter`'s
+type inference, use `TypeAdapter[list[TflLineResponse]](...)` with an
+explicit generic parameter.
+
+### Phase 3.5 — PR
+
+Open PR from `feature/TM-B1-async-tfl-client` targeting `main`.
+
+PR body (English):
+
+- **Summary** — 4 bullets: async client; hand-rolled retry; tier-1→2
+  normalisation; fixtures under `tests/fixtures/tfl/`.
+- **Why hand-rolled retry** — quote AGENTS.md §"lean by default" rule
+  about exotic retry policies; cite `httpx.MockTransport` as rationale
+  for zero new deps.
+- **Out of scope** — Kafka (TM-B2/TM-B3), live-API CI tests.
+- **Test plan** — command list from Phase 3.4.
+- **Closes TM-4**.
+
+## Success criteria
+
+- [ ] `src/ingestion/tfl_client/{client,retry,normalise,__init__}.py`
+  implemented and importable.
+- [ ] `tests/fixtures/tfl/` contains the four real JSON fixtures
+  listed in Phase 3.1.
+- [ ] `tests/ingestion/{test_tfl_client,test_normalise}.py` cover
+  every behaviour listed in Phase 3.3; all green.
+- [ ] `uv run task lint` passes (ruff + mypy strict).
+- [ ] `uv run task test` passes (existing + new).
+- [ ] `uv run bandit -r src` passes with no HIGH severity findings.
+- [ ] `make check` passes end-to-end.
+- [ ] PR opened with `Closes TM-4` in body.
+- [ ] `PROGRESS.md` TM-B1 row updated to ✅ with the completion date.
+
+## Open questions (resolved during planning)
+
+1. **Fixture layout.** Add-alongside under `tests/fixtures/tfl/`.
+   Existing `tests/fixtures/*_sample.json` stay untouched.
+2. **Normalisation inclusion.** Include tier-1 → tier-2 normalisation
+   in B1 (pure functions, no side effects).
+3. **Retry implementation.** Hand-rolled `with_retry` helper under
+   `src/ingestion/tfl_client/retry.py`.
+4. **Logging / tracing.** One `logfire.span` per outbound request,
+   tagged `path` and `params` (with `app_key` redacted). No custom
+   metrics.
+5. **App-key transport.** Query param (matches existing
+   `scripts/fetch_tfl_samples.py`); header-based auth deferred until
+   TfL deprecates the query form.
+6. **Timeouts and connection pool.** Single `httpx.AsyncClient` per
+   `TflClient` instance; caller owns lifecycle via `async with`. Tests
+   exercise `aclose()` via the context manager exit.

--- a/.claude/specs/TM-B1-plan.md
+++ b/.claude/specs/TM-B1-plan.md
@@ -109,10 +109,14 @@ __all__ = ["TflClient", "TflClientError"]
 - `async def __aexit__(self, *exc) -> None` closes the client.
 - `async def _request(self, path: str, *, params: dict | None = None) -> Any` —
   central call site that:
-  1. Merges `{"app_key": self._app_key}` into `params`.
-  2. Calls `self._http.get(path, params=params)` inside a
-     `logfire.span("tfl.request", path=path, params=...)` context so
-     requests appear in Logfire.
+  1. Builds the outbound parameters as a **new dict**:
+     `outbound = {**(params or {}), "app_key": self._app_key}`.
+     Never mutate the caller's `params` argument.
+  2. Builds a redacted copy for tracing — `traced = {k: ("***" if k == "app_key" else v) for k, v in outbound.items()}` —
+     and calls `self._http.get(path, params=outbound)` inside
+     `logfire.span("tfl.request", path=path, params=traced)`. The
+     `app_key` value is **never logged** (CLAUDE.md §"Security-first —
+     Secrets").
   3. Implements the retry policy (see Phase 3.3).
   4. Calls `response.raise_for_status()` on non-retryable 4xx.
   5. Returns `response.json()`.
@@ -140,8 +144,11 @@ Tiny hand-rolled retry helper (~30 lines) shared by `_request`:
   ```
 - Retry on: `httpx.TimeoutException`, `httpx.TransportError`, and
   responses with `status_code in {429, 500, 502, 503, 504}`.
-- For 429 responses: honour `Retry-After` if present (seconds form
-  only — HTTP-date form is rare from TfL; raise if unparseable).
+- For 429 responses: honour `Retry-After` if present and parseable as
+  a positive integer (seconds). If the header is absent, malformed, or
+  uses the HTTP-date form, **fall back** to the standard exponential
+  backoff below — never raise just because the header is unparseable
+  (RFC 9110 allows date form; client must remain robust).
 - Otherwise exponential backoff: `0.5 * 2 ** attempt` seconds, capped
   at 10s (`asyncio.sleep`).
 - On final failure, raise `TflClientError` wrapping the last
@@ -174,10 +181,15 @@ Details:
   `timeToStation → time_to_station_seconds`, `vehicleId → vehicle_id`.
 - `disruption_payloads` — TfL disruption responses are lossy (no stable
   `disruption_id` or `created` timestamp); the adapter synthesises
-  `disruption_id` from `hash(category, description, affected_routes)`
-  and uses `datetime.now(UTC)` for `created` / `last_update`. Flag
-  these as synthetic in the docstring so TM-B2 knows it cannot trust
-  them for deduplication without extra keys.
+  `disruption_id` from a deterministic SHA-256 digest over a stable
+  serialisation of the disruption — concretely
+  `hashlib.sha256(json.dumps({"category": ..., "description": ..., "affected_routes": sorted(...)}, sort_keys=True, ensure_ascii=False).encode("utf-8")).hexdigest()` —
+  taking the first 32 hex chars to keep IDs compact. Python's built-in
+  `hash()` is rejected here because it is randomised per process and
+  unstable across runs. `created` / `last_update` use
+  `datetime.now(UTC)`. The docstring flags every synthesised field so
+  TM-B2 knows it cannot trust them for deduplication without
+  TfL-supplied keys.
 - `summary` in the payload is a truncated `description` (160 chars)
   because the free TfL endpoint does not return a separate summary —
   documented in the docstring.

--- a/.claude/specs/TM-B1-plan.md
+++ b/.claude/specs/TM-B1-plan.md
@@ -234,10 +234,10 @@ Files:
 ### Phase 3.4 — Verification gate
 
 ```bash
-uv run task lint          # ruff + mypy strict on src/ingestion + contracts
-uv run task test          # adds tests/ingestion/*
-uv run bandit -r src      # HIGH severity only
-make check                # includes dbt-parse + TS
+uv run task lint                                  # ruff + mypy strict on src/ingestion + contracts
+uv run task test                                  # adds tests/ingestion/*
+uv run bandit -r src --severity-level high        # HIGH severity only
+make check                                        # includes dbt-parse + TS
 ```
 
 All must exit 0 before PR. If `mypy strict` rejects `TypeAdapter`'s
@@ -269,7 +269,7 @@ PR body (English):
   every behaviour listed in Phase 3.3; all green.
 - [ ] `uv run task lint` passes (ruff + mypy strict).
 - [ ] `uv run task test` passes (existing + new).
-- [ ] `uv run bandit -r src` passes with no HIGH severity findings.
+- [ ] `uv run bandit -r src --severity-level high` passes with no findings.
 - [ ] `make check` passes end-to-end.
 - [ ] PR opened with `Closes TM-4` in body.
 - [ ] `PROGRESS.md` TM-B1 row updated to ✅ with the completion date.

--- a/.claude/specs/TM-B1-research.md
+++ b/.claude/specs/TM-B1-research.md
@@ -1,0 +1,209 @@
+# TM-B1 — Research (Phase 1)
+
+Read-only exploration. Track: **B-ingestion**. Linear issue: **TM-4** (open).
+
+Objective from `SETUP.md` §7.3: "Implement the async TfL API client and generate real response fixtures."
+
+Architectural context (`ARCHITECTURE.md`): the ingestion client lives at
+`src/ingestion/tfl_client`, speaks to `https://api.tfl.gov.uk` over async
+`httpx`, and is responsible for tier-1 → tier-2 normalisation ("TM-B1+").
+
+## Scope boundary
+
+Allowed paths (user-declared for this WP):
+`src/ingestion/`, `tests/ingestion/`, `tests/fixtures/tfl/`.
+
+Frozen (no edits): `contracts/schemas/tfl_api.py` and
+`contracts/schemas/{arrivals,line_status,disruptions,common}.py`.
+
+Out of track (do NOT touch without an ADR): `contracts/`,
+`scripts/fetch_tfl_samples.py`, existing `tests/fixtures/*.json`,
+`tests/test_contracts.py`.
+
+## What already exists
+
+### Contracts — frozen
+
+`contracts/schemas/tfl_api.py` (tier-1, camelCase) exposes:
+
+| Model | Source endpoint |
+|---|---|
+| `TflLineResponse` | `/Line/Mode/{modes}/Status` |
+| `TflArrivalPrediction` | `/StopPoint/{id}/Arrivals` |
+| `TflDisruption` | `/Line/Mode/{modes}/Disruption` |
+
+Nested: `TflLineStatusItem`, `TflLineStatusDisruption`,
+`TflValidityPeriod`. All `frozen=True`, `extra="ignore"`, `to_camel`
+aliasing. `contracts/schemas/__init__.py` re-exports the tier-1 names at
+package root.
+
+Tier-2 Kafka events (snake_case, TOPIC_NAME attribute on each envelope):
+`LineStatusEvent` (`line-status`), `ArrivalEvent` (`arrivals`),
+`DisruptionEvent` (`disruptions`) with their respective `*Payload`
+classes. `test_contracts.py` asserts tier-1 fixtures parse and tier-2
+roundtrips hold; TM-B1 must not break these.
+
+### Ingestion scaffold — empty
+
+```
+src/ingestion/
+  __init__.py          (0 bytes)
+  tfl_client/
+    __init__.py        (0 bytes)   ← target for the new client
+  producers/           (placeholder for TM-B2)
+  consumers/           (placeholder for TM-B3)
+```
+
+Package is declared in `pyproject.toml` under `[tool.hatch.build.targets.wheel].packages`.
+
+### Existing fixtures
+
+Committed under `tests/fixtures/` (NOT `tfl/`):
+
+| File | Endpoint captured | Size |
+|---|---|---|
+| `line_status_sample.json` | `/Line/Mode/tube,elizabeth-line,dlr,overground/Status` | 34 KB |
+| `arrivals_sample.json` | `/StopPoint/940GZZLUOXC/Arrivals` | 17 KB |
+| `disruptions_sample.json` | `/Line/Mode/tube/Disruption` | 7 KB |
+
+These are real TfL responses (confirmed by `$type` envelopes visible in
+the JSON) and are already exercised by `tests/test_contracts.py`
+against the tier-1 models.
+
+### Fetch helper — `scripts/fetch_tfl_samples.py`
+
+Synchronous `httpx.Client`, 30-second timeout, writes to
+`tests/fixtures/<filename>`. Endpoints and `app_key` auth pattern
+documented there. **Not** in B1's allowed paths.
+
+### Dependencies present
+
+`httpx>=0.28`, `pydantic>=2.9`, `python-dotenv>=1.0`,
+`pytest-asyncio>=0.24`. No `respx`, no retry library in the root
+`pyproject.toml`.
+
+### Env
+
+`.env.example`: `TFL_APP_KEY=your_tfl_key_here`.
+
+## Current state verification
+
+- `src/ingestion/tfl_client/__init__.py` empty → nothing to run.
+- `uv run task test` covers `tests/test_contracts.py` and
+  `tests/test_health.py`; no ingestion tests today.
+
+## Design surface for TM-B1
+
+Strictly research — the plan will make the actual choices.
+
+### Client shape (candidates)
+
+A small `TflClient` class wrapping `httpx.AsyncClient`:
+
+- Async context manager (`__aenter__`, `__aexit__`).
+- Base URL `https://api.tfl.gov.uk`; `app_key` as query param
+  (existing pattern) or `app_key`/`app_id` header (newer TfL pattern
+  — query still works). Existing `fetch_tfl_samples.py` uses query.
+- Three coroutine methods returning tier-1 typed objects:
+  - `fetch_line_statuses(modes: Iterable[str]) -> list[TflLineResponse]`
+  - `fetch_arrivals(stop_id: str) -> list[TflArrivalPrediction]`
+  - `fetch_disruptions(modes: Iterable[str]) -> list[TflDisruption]`
+- Parsing: `TypeAdapter(list[Tfl...]).validate_python(resp.json())`
+  (cheaper than per-item `model_validate` loops).
+
+### Retry / backoff
+
+TfL free tier rate limit: 500 req/min. Failure modes to design for:
+
+- `HTTP 429 Too Many Requests` — respect `Retry-After` header.
+- `HTTP 5xx` — bounded exponential backoff.
+- `httpx.TimeoutException` / `httpx.TransportError` — retry bounded.
+- Everything else (401, 400, 404) — raise immediately; no retry value.
+
+Stdlib-friendly approach: small in-house loop (~20 lines) following
+CLAUDE.md rule 7 (no custom CLI / exotic policy library without cause).
+`tenacity` would be idiomatic but it is a new dep → ADR territory.
+
+### Normalisation tier-1 → tier-2
+
+ARCHITECTURE.md states normalisation is the ingestion client's job
+starting in "TM-B1+". Choices:
+
+- (a) Land normalisation now — three small adapters mapping
+  `TflLineResponse → LineStatusPayload`, etc. Self-contained in
+  `src/ingestion/tfl_client/normalise.py` and unit-tested against
+  fixtures.
+- (b) Defer to TM-B2, where the producer turns tier-1 into tier-2 on
+  the way to Kafka. Keeps TM-B1 smaller but makes TM-B2 responsible
+  for semantic translation *and* Kafka wiring.
+
+### Fixtures layout
+
+User's allowed path is `tests/fixtures/tfl/`. Existing fixtures live at
+`tests/fixtures/` root and drive `tests/test_contracts.py`, which is out
+of track. Options:
+
+- (a) Leave the existing three JSONs untouched; generate additional /
+  richer fixtures under `tests/fixtures/tfl/` dedicated to ingestion
+  tests (e.g. one file per endpoint keyed by stop/mode parameter).
+- (b) Move existing JSONs into `tests/fixtures/tfl/` — requires
+  editing `tests/test_contracts.py` and `scripts/fetch_tfl_samples.py`,
+  both out of track. Blocks on an ADR or a scope exception from the
+  author.
+
+### Tests
+
+Layout `tests/ingestion/test_tfl_client.py` or one file per endpoint.
+Transport: `httpx.MockTransport` (already available, no new dep). Cover:
+
+- Happy path — fixture bytes → tier-1 models parsed.
+- `app_key` propagation — assert query param present on every request.
+- Retry policy — 429 with `Retry-After` retried; 500 retried;
+  max-attempts enforced; 401 raised immediately.
+- Timeout surfaces via `httpx.TimeoutException`.
+
+If normalisation lands inside B1, add `tests/ingestion/test_normalise.py`.
+
+## Gap analysis / what the WP must deliver (not prescriptive)
+
+| # | Area | Minimum bar |
+|---|---|---|
+| B1.1 | Async client module under `src/ingestion/tfl_client/` | Three endpoint methods, tier-1 typed returns, async context manager |
+| B1.2 | Auth + config | Reads `TFL_APP_KEY` from env; fails loud if missing |
+| B1.3 | Retry policy | 429 / 5xx / transport errors — bounded attempts; respects `Retry-After` |
+| B1.4 | Fixtures | Real TfL responses under `tests/fixtures/tfl/` covering the three endpoints (possibly overlapping with existing fixtures) |
+| B1.5 | Tests | `tests/ingestion/test_tfl_client.py` covering happy path, retry, auth |
+| B1.6 | Normalisation (optional) | Tier-1 → tier-2 adapters if we decide to land them here |
+
+## Key documents reviewed
+
+- `ARCHITECTURE.md` — confirms `src/ingestion/tfl_client` role.
+- `contracts/schemas/tfl_api.py`, `contracts/schemas/__init__.py`.
+- `contracts/schemas/{arrivals,line_status,disruptions,common}.py`
+  (read-through — tier-2 shapes known, frozen).
+- `scripts/fetch_tfl_samples.py` — endpoint list, auth pattern.
+- `tests/test_contracts.py`, `tests/fixtures/*.json`.
+- `src/ingestion/__init__.py`, `src/ingestion/tfl_client/__init__.py`.
+- `.env.example`, `pyproject.toml`, `Makefile`.
+- `CLAUDE.md` — Pydantic boundaries, lean defaults, no custom retry
+  policies "before a real error exists"; zero-trust security.
+- `AGENTS.md` — PR rules (no hardcoded secrets; ingestion tests must
+  use fixtures, never live API).
+
+## Open questions for the planning phase
+
+1. **Fixture layout.** Which of (a) "add-alongside under `tfl/`" or
+   (b) "move existing into `tfl/` + out-of-track edits" does the
+   author prefer? Recommendation: (a) — avoids scope leak.
+2. **Normalisation inclusion.** Include tier-1 → tier-2 normalisation
+   in TM-B1 or defer to TM-B2? Recommendation: include — ARCHITECTURE
+   already earmarks it here and it unblocks B2.
+3. **Retry implementation.** Hand-rolled loop (lean) or `tenacity`
+   (idiomatic, new dep + ADR)? Recommendation: hand-rolled ≤30 lines,
+   co-located in the client module. New deps invite AGENTS.md §"PR
+   rules — Dependencies" scrutiny.
+4. **Async test wiring.** `pytest-asyncio` with `asyncio_mode = "auto"`
+   is already enabled in `pyproject.toml`; confirm we keep it.
+5. **Request concurrency.** Do we need a shared `httpx.AsyncClient` in
+   the class (one connection pool) and explicit `.aclose()` in tests?
+   Yes — standard pattern; pose for confirmation in the plan.

--- a/.claude/specs/TM-B1-research.md
+++ b/.claude/specs/TM-B1-research.md
@@ -45,7 +45,7 @@ roundtrips hold; TM-B1 must not break these.
 
 ### Ingestion scaffold — empty
 
-```
+```text
 src/ingestion/
   __init__.py          (0 bytes)
   tfl_client/

--- a/.claude/specs/TM-C1-plan.md
+++ b/.claude/specs/TM-C1-plan.md
@@ -96,16 +96,22 @@ PR body structure (English, per CLAUDE.md §"Language and communication"):
 
 - **Summary** — 2 lines pointing at TM-000 scope absorption.
 - **Why close without implementation** — reference research file.
-- **What this PR actually touches** — 3 `.gitkeep`s + PROGRESS.md.
+- **What this PR actually touches** — `PROGRESS.md` plus the Phase A
+  spec files under `.claude/specs/TM-{B1,C1,D1}-{research,plan}.md`
+  (the `.gitkeep` pins were already committed by TM-000; no `dbt/`
+  files change here).
 - **Acceptance criteria** — checklist copied from research, all
   already-green items marked `[x]`.
 - **Closes TM-5**.
 
 ## Success criteria (copy of research, now checkable)
 
-- [ ] `dbt/models/{staging,intermediate,marts}/.gitkeep` are committed.
-- [ ] `PROGRESS.md` TM-C1 row reads ✅ with the 2026-04-23 date and a
+- [x] `dbt/models/{staging,intermediate,marts}/.gitkeep` are committed
+  (verified `git ls-files dbt/models` on `2026-04-23`; pins came from
+  TM-000).
+- [x] `PROGRESS.md` TM-C1 row reads ✅ with the 2026-04-23 date and a
   one-liner citing TM-000 absorption.
-- [ ] CI green on `main` after merge (all three jobs).
+- [ ] CI green on `main` after merge (all three jobs) — checked once
+  the PR merges.
 - [ ] Linear TM-5 transitions to Done on merge (automatic via the
-  Linear↔GitHub integration).
+  Linear↔GitHub integration) — checked once the PR merges.

--- a/.claude/specs/TM-C1-plan.md
+++ b/.claude/specs/TM-C1-plan.md
@@ -21,10 +21,11 @@ and §"Anti-patterns — YAGNI", no additional surface is justified here.
 **Decision (author-approved):** close TM-C1 as **already-delivered**.
 Ship a minimal inline commit that:
 
-1. Pins empty dbt model directories with `.gitkeep` so TM-C2 does not
-   start by re-creating them.
-2. Updates `PROGRESS.md` to flip the TM-C1 row to ✅ with a note
+1. Updates `PROGRESS.md` to flip the TM-C1 row to ✅ with a note
    pointing back to TM-000.
+2. Verifies the `.gitkeep` files under `dbt/models/{staging,intermediate,marts}/`
+   are already committed (they were added during the TM-000 scaffold —
+   no new file needed here; the PR is **docs-only**).
 
 No agent dispatch; the coordinator applies this directly.
 
@@ -52,25 +53,20 @@ No agent dispatch; the coordinator applies this directly.
 
 ## Sub-phases
 
-### Phase 3.1 — `.gitkeep`s
+### Phase 3.1 — `.gitkeep`s (already satisfied)
 
-Create three empty files to anchor the model directories in git:
-
-- `dbt/models/staging/.gitkeep`
-- `dbt/models/intermediate/.gitkeep`
-- `dbt/models/marts/.gitkeep`
-
-Directories already exist on disk and are committed because the
-`TM-000` scaffold added `*/.gitkeep` implicitly — verify via
-`git ls-files dbt/models`. If `.gitkeep` entries are already present,
-skip this phase and note it in the PR body.
+`dbt/models/{staging,intermediate,marts}/.gitkeep` are already tracked
+in `main` (verified via `git ls-files dbt/models`). The TM-000 scaffold
+added them. **No file creation needed**; this PR ships zero `dbt/`
+changes. The verification was logged in the PR body so the audit trail
+shows it was checked.
 
 ### Phase 3.2 — PROGRESS.md
 
 Update the `TM-C1` row in `PROGRESS.md`:
 
-```
-| 2 | TM-C1 | dbt scaffold | C-dbt | ✅ 2026-04-23 | Scope absorbed by TM-000 scaffold; `.gitkeep` pins for empty model dirs (see PR) |
+```md
+| 2 | TM-C1 | dbt scaffold | C-dbt | ✅ 2026-04-23 | Scope absorbed by TM-000 scaffold; `.gitkeep` pins for empty model dirs (already in main) |
 ```
 
 Add to the "TM-000 notes" section (or a new "Scope absorption" block)

--- a/.claude/specs/TM-C1-plan.md
+++ b/.claude/specs/TM-C1-plan.md
@@ -1,0 +1,115 @@
+# TM-C1 — Implementation plan (Phase 2)
+
+Source: `TM-C1-research.md` + author decision on `2026-04-23`.
+
+## Summary
+
+TM-000 already delivered every functional acceptance criterion declared
+by TM-C1 in `SETUP.md` §7.3:
+
+- `dbt_project.yml` + `profiles.yml` (dev + ci targets) configured.
+- `dbt/sources/tfl.yml` byte-identical to `contracts/dbt_sources.yml`
+  (CI `diff` gate in `.github/workflows/ci.yml`).
+- `dbt-core` + `dbt-postgres` installed; `taskipy` `dbt-parse` task
+  exists and is wired into `make check`.
+- `uv run task dbt-parse` exits 0 (only a benign "unused paths"
+  warning until TM-C2 adds models).
+
+Per CLAUDE.md §"WP scope rules" rule 4 ("Every WP ships with tests")
+and §"Anti-patterns — YAGNI", no additional surface is justified here.
+
+**Decision (author-approved):** close TM-C1 as **already-delivered**.
+Ship a minimal inline commit that:
+
+1. Pins empty dbt model directories with `.gitkeep` so TM-C2 does not
+   start by re-creating them.
+2. Updates `PROGRESS.md` to flip the TM-C1 row to ✅ with a note
+   pointing back to TM-000.
+
+No agent dispatch; the coordinator applies this directly.
+
+## Execution mode
+
+- **Author of change:** coordinator (inline in current session), not an
+  agent-team member.
+- **Branch:** `feature/TM-C1-close-as-delivered`.
+- **PR title:** `chore(dbt): TM-C1 close as delivered by TM-000 (TM-5)`.
+- **PR body:** references Linear TM-5 via `Closes TM-5`, quotes the
+  research finding, lists touched files.
+- **No ADR needed** (no contract edits, no locked-stack changes).
+
+## What we're NOT doing
+
+- Not adding a pytest parity test for `contracts/dbt_sources.yml` vs
+  `dbt/sources/tfl.yml` — CI `diff` already enforces parity; duplicating
+  it in pytest violates KISS.
+- Not suppressing the dbt "unused configuration paths" warning — it
+  disappears as soon as TM-C2 lands a single staging model.
+- Not adding `dbt debug` to `make check` — requires a live Postgres,
+  breaks offline `make check`.
+- Not writing staging / intermediate / mart models — TM-C2 / TM-C3.
+- Not reshaping `dbt/README.md` — leave the stub; TM-C2 will own docs.
+
+## Sub-phases
+
+### Phase 3.1 — `.gitkeep`s
+
+Create three empty files to anchor the model directories in git:
+
+- `dbt/models/staging/.gitkeep`
+- `dbt/models/intermediate/.gitkeep`
+- `dbt/models/marts/.gitkeep`
+
+Directories already exist on disk and are committed because the
+`TM-000` scaffold added `*/.gitkeep` implicitly — verify via
+`git ls-files dbt/models`. If `.gitkeep` entries are already present,
+skip this phase and note it in the PR body.
+
+### Phase 3.2 — PROGRESS.md
+
+Update the `TM-C1` row in `PROGRESS.md`:
+
+```
+| 2 | TM-C1 | dbt scaffold | C-dbt | ✅ 2026-04-23 | Scope absorbed by TM-000 scaffold; `.gitkeep` pins for empty model dirs (see PR) |
+```
+
+Add to the "TM-000 notes" section (or a new "Scope absorption" block)
+one line: "TM-C1's acceptance criteria were satisfied by TM-000; the WP
+closes with a zero-code PR after verifying the CI diff + `dbt-parse`
+pass."
+
+### Phase 3.3 — Verification gate
+
+Before opening the PR:
+
+```bash
+diff contracts/dbt_sources.yml dbt/sources/tfl.yml  # expect exit 0
+uv run task dbt-parse                                # expect exit 0
+uv run task lint                                     # expect exit 0
+uv run task test                                     # expect exit 0
+```
+
+Skip `make check` locally if Docker is not running — the relevant
+python/dbt checks above are sufficient to prove the WP's premise.
+
+### Phase 3.4 — PR
+
+Open PR from `feature/TM-C1-close-as-delivered` targeting `main`.
+
+PR body structure (English, per CLAUDE.md §"Language and communication"):
+
+- **Summary** — 2 lines pointing at TM-000 scope absorption.
+- **Why close without implementation** — reference research file.
+- **What this PR actually touches** — 3 `.gitkeep`s + PROGRESS.md.
+- **Acceptance criteria** — checklist copied from research, all
+  already-green items marked `[x]`.
+- **Closes TM-5**.
+
+## Success criteria (copy of research, now checkable)
+
+- [ ] `dbt/models/{staging,intermediate,marts}/.gitkeep` are committed.
+- [ ] `PROGRESS.md` TM-C1 row reads ✅ with the 2026-04-23 date and a
+  one-liner citing TM-000 absorption.
+- [ ] CI green on `main` after merge (all three jobs).
+- [ ] Linear TM-5 transitions to Done on merge (automatic via the
+  Linear↔GitHub integration).

--- a/.claude/specs/TM-C1-research.md
+++ b/.claude/specs/TM-C1-research.md
@@ -61,7 +61,7 @@ All functionally satisfied.
 
 Local `uv run task dbt-parse` against `ci` target:
 
-```
+```text
 19:04:33  Running with dbt=1.11.8
 19:04:33  Registered adapter: postgres=1.10.0
 19:04:33  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.

--- a/.claude/specs/TM-C1-research.md
+++ b/.claude/specs/TM-C1-research.md
@@ -1,0 +1,116 @@
+# TM-C1 — Research (Phase 1)
+
+Read-only exploration. Track: **C-dbt**. Linear issue: **TM-5** (open).
+
+Objective from `SETUP.md` §7.3: "Initialise the dbt project with sources pointing at raw tables."
+
+## Scope boundary
+
+Allowed paths: `dbt/`.
+Forbidden without ADR: `contracts/` (AGENTS.md §2).
+
+## What already exists (delivered by TM-000 + TM-A1)
+
+### dbt project skeleton
+
+- `dbt/dbt_project.yml` — profile `tfl_monitor`, paths declared
+  (`models`, `seeds`, `tests`, `analyses`, `macros`, `snapshots`),
+  materialisations set (`staging` → view, `intermediate` → view,
+  `marts` → table). Target path `target`.
+- `dbt/profiles.yml` — two outputs (`dev`, `ci`) against Postgres, both
+  read from `POSTGRES_*` env vars with safe fallbacks. Target defaults
+  to `dev`.
+- `dbt/sources/tfl.yml` — mirrors `contracts/dbt_sources.yml` byte-for-byte
+  (verified via `diff` — exit 0). Declares source `tfl` over schemas
+  `raw` (three streaming tables: `line_status`, `arrivals`, `disruptions`)
+  and `ref` (two static tables: `lines`, `stations`). Column-level
+  `not_null` / `unique` tests already wired.
+- `dbt/models/{staging,intermediate,marts}/` — empty directories.
+- `dbt/README.md` — 3-line stub referring to TM-C2/TM-C3 for real models.
+
+### Source-of-truth enforcement
+
+- Root `Makefile`:
+  - `sync-dbt-sources` target: `cp contracts/dbt_sources.yml dbt/sources/tfl.yml` (one-way sync helper).
+  - `check` target invokes `uv run task dbt-parse`.
+- `pyproject.toml`:
+  - Dev deps include `dbt-core>=1.9` and `dbt-postgres>=1.9`.
+  - `[tool.taskipy.tasks]` defines
+    `dbt-parse = "dbt parse --project-dir dbt --profiles-dir dbt --target ci"`.
+- `.github/workflows/ci.yml` (lint job):
+  - Step: `diff contracts/dbt_sources.yml dbt/sources/tfl.yml` — blocks PR
+    if the mirror drifts.
+  - Step: `uv run task dbt-parse` with Postgres service container;
+    env points to the ephemeral CI Postgres.
+
+### Raw DDL that sources depend on
+
+- `contracts/sql/001_raw_tables.sql` — `raw.{line_status,arrivals,disruptions}`
+  with `pgcrypto`, `event_id UUID PK DEFAULT gen_random_uuid()`,
+  `ingested_at TIMESTAMPTZ NOT NULL DEFAULT now()`, plus `event_type`,
+  `source`, `payload JSONB`. Matches what `dbt/sources/tfl.yml` asserts.
+- `contracts/sql/002_reference_tables.sql` — reference schema for `lines` / `stations` (assumed from yml; not re-read here).
+
+### Acceptance criteria from SETUP.md §7.3
+
+> "Initialise the dbt project with sources pointing at raw tables."
+
+All functionally satisfied.
+
+## Current state verification
+
+Local `uv run task dbt-parse` against `ci` target:
+
+```
+19:04:33  Running with dbt=1.11.8
+19:04:33  Registered adapter: postgres=1.10.0
+19:04:33  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
+There are 3 unused configuration paths:
+- models.tfl_monitor.staging
+- models.tfl_monitor.intermediate
+- models.tfl_monitor.marts
+19:04:33  Performance info: dbt/target/perf_info.json
+```
+
+Exit 0. Warnings are expected — staging/intermediate/marts
+materialisation defaults have nothing to bind to because models land in
+TM-C2 / TM-C3.
+
+## Gap analysis — what, if anything, is left for TM-C1
+
+This is the core finding. Against the stated acceptance criteria, TM-C1
+is already delivered. Possible residual polish items, all optional:
+
+| # | Item | Value | Risk / cost |
+|---|---|---|---|
+| G1 | Add `.gitkeep` under `dbt/models/{staging,intermediate,marts}/` | Keeps empty dirs committed so TM-C2 doesn't start by re-creating them | ~3 lines in 3 files; zero functional impact |
+| G2 | Add Pytest-level source YAML parity test (duplicates CI `diff`) | Catches drift locally before pushing | Redundant with the CI step; would live under `tests/dbt/`; marginal value |
+| G3 | Expand `dbt/README.md` with env-var table + how-to-run | Ergonomics for reviewers / interviewers | Docs only; YAGNI risk if TM-C2/C3 overhauls it |
+| G4 | Suppress the "unused configuration paths" warning by moving the default materialisations into a `staging/_staging.yml` (or removing them until TM-C2) | Cleaner dbt parse output | Risks bike-shed; no functional impact |
+| G5 | Add a `dbt debug` step to CI or `make check` | Verifies DB connectivity end-to-end | Requires a running Postgres in `make check`, breaks offline runs; TM-A3 territory |
+| G6 | Tests directory `dbt/tests/` with a trivial schema test template | Optional; TM-C2/C3 will populate | Empty scaffolding → YAGNI |
+
+None of G1–G6 are required by the spec.
+
+## Key documents reviewed
+
+- `CLAUDE.md` — one WP = one PR = one track; `dbt/` only.
+- `AGENTS.md` — Codex blocks over-engineering.
+- `SETUP.md` §7.3, §10.1, §10.3.
+- `PROGRESS.md` — TM-C1 row marked ⬜.
+- `.claude/specs/TM-A1-plan.md` — structure template to mirror.
+- `contracts/dbt_sources.yml`, `dbt/sources/tfl.yml`, `dbt/dbt_project.yml`, `dbt/profiles.yml`, `dbt/README.md`, `Makefile`, `pyproject.toml`, `.github/workflows/ci.yml`, `contracts/sql/001_raw_tables.sql`.
+
+## Open questions for the planning phase
+
+1. **Headline question.** Given all acceptance criteria are already met,
+   should TM-C1 be:
+   - (a) **Closed as already-delivered** via a tiny polish-only PR
+     (update `PROGRESS.md`, close Linear TM-5, optionally land G1 and G3).
+   - (b) **Executed with deliberate scope-padding** (G1 + G2 + G3 + G4)
+     to create a visible PR. Portfolio-optics only.
+   - (c) **Merged into TM-C2** scope and Linear TM-5 closed as "absorbed".
+2. If we run an agent on TM-C1 with no code changes left, the agent's PR
+   risks triggering the AGENTS.md §1 "over-engineering" guard rail.
+3. Path forward must be decided before locking `TM-C1-plan.md`; research
+   is intentionally prescription-free per CLAUDE.md Phase 1 rules.

--- a/.claude/specs/TM-D1-plan.md
+++ b/.claude/specs/TM-D1-plan.md
@@ -1,0 +1,162 @@
+# TM-D1 — Implementation plan (Phase 2)
+
+Source: `TM-D1-research.md` + author decision on `2026-04-23` (close
+scope gaps with a concrete polish PR, option G1 + G2 + G4 from
+research).
+
+## Summary
+
+TM-000 shipped the FastAPI skeleton with 501 stubs and a Logfire wiring
+that matches `CLAUDE.md` §"Observability architecture" word-for-word.
+TM-D1 closes the WP by locking that contract against drift and
+correcting one real bug: the CORS allow-list is missing the production
+Vercel origin quoted in `contracts/openapi.yaml`.
+
+Deliverables:
+
+1. **G1** — parametrised test asserting every non-`/health` route
+   returns `501` with its owning-WP hint.
+2. **G2** — drift test asserting every `operationId` in
+   `contracts/openapi.yaml` has a matching FastAPI route, and vice
+   versa.
+3. **G4** — add `https://tfl-monitor.vercel.app` to the CORS
+   allow-list.
+
+No changes under `contracts/` (no ADR needed). All edits live under
+`src/api/` + `tests/api/`.
+
+## Execution mode
+
+- **Author of change:** agent-team member (worktree-isolated). Team
+  name: `tfl-phase-1-2`. Member name: `tm-d1`.
+- **Branch (inside worktree):** `feature/TM-D1-api-stubs-drift-test`.
+- **PR title:** `feat(api): TM-D1 lock 501 stubs + drift test + prod CORS origin (TM-6)`.
+- **PR body:** references `Closes TM-6`, references CLAUDE.md rule it
+  enforces, lists the three deliverables.
+
+## What we're NOT doing
+
+- Not implementing any of the stubbed routes — those belong to TM-D2 /
+  TM-D3 / TM-D5.
+- Not touching `contracts/openapi.yaml` — tier-1 contract, frozen;
+  drift test *reads* it, does not edit it.
+- Not adding custom metrics / tracing — Logfire is enough (CLAUDE.md
+  §"Anti-patterns — Over-observing").
+- Not introducing `Settings(BaseSettings)` for the API — YAGNI;
+  revisit when >= 15 env vars (CLAUDE.md rule 5).
+- Not wiring real `/health` dependency checks — TM-D2 when Postgres
+  arrives.
+- Not changing the existing `tests/test_health.py` — only adding new
+  tests under `tests/api/`.
+
+## Sub-phases
+
+### Phase 3.1 — CORS allow-list (G4)
+
+Edit `src/api/main.py`:
+
+```python
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:3000",
+        "https://tfl-monitor.vercel.app",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+Both origins are explicit — no `*`. Matches the value documented at
+`contracts/openapi.yaml` line 13.
+
+### Phase 3.2 — 501 stub lock (G1)
+
+Create `tests/api/__init__.py` (empty) and `tests/api/test_stubs.py`.
+
+- Parametrise across the 7 stubbed routes.
+- For GET routes, hit them via `TestClient.get(path)`.
+- For POST `/api/v1/chat/stream`, use `TestClient.post(path, json={...})`
+  with a minimal body honouring `ChatRequest` shape (`thread_id`,
+  `message`). Even when the body is valid, the handler must still
+  return 501.
+- For path-param routes, supply placeholders (`line_id="victoria"`,
+  `stop_id="dummy"`, `thread_id="t-1"`).
+- Assert `response.status_code == 501`.
+- Assert `response.json()["detail"]` starts with `"Not implemented"`.
+- Assert the WP hint present (e.g. `"TM-D2"`, `"TM-D3"`, `"TM-D5"`).
+
+### Phase 3.3 — Route/OpenAPI drift test (G2)
+
+Extend `tests/api/test_stubs.py` (or a sibling `test_operation_ids.py`)
+with two assertions driven by the existing `openapi-spec-validator` dev
+dep for YAML loading (already in `pyproject.toml`; if it does not
+expose a YAML loader directly, parse with PyYAML — check first, avoid
+a new runtime dep):
+
+- **Spec → app:** every `operationId` declared in
+  `contracts/openapi.yaml` exists as a registered route on `app` (by
+  looking at `app.routes` for `APIRoute` instances and comparing
+  `route.operation_id`).
+- **App → spec:** every `APIRoute` on `app` (excluding FastAPI's
+  built-in `/openapi.json`, `/docs`, `/redoc` if present) has a
+  matching `operationId` entry in the spec.
+
+If `pyyaml` is not already a transitive dep, prefer using
+`openapi-spec-validator`'s loader (`openapi_spec_validator.readers`)
+or add `pyyaml` to the `dev` group — flag the cost in the PR if it
+turns out to require a new dep (CLAUDE.md §"Anti-patterns — YAGNI").
+
+### Phase 3.4 — Verification gate
+
+Before opening the PR:
+
+```bash
+uv run task lint          # ruff + ruff format + mypy strict
+uv run task test          # includes new tests/api/*
+uv run bandit -r src      # HIGH severity only
+make check                # broader; runs dbt-parse + TS lint too
+```
+
+All must exit 0. If mypy strict complains about `app.routes` typing,
+cast to `Iterable[APIRoute]` explicitly rather than loosening strict
+config (CLAUDE.md §"Anti-patterns — Security shortcuts" spirit).
+
+### Phase 3.5 — PR
+
+Open PR from `feature/TM-D1-api-stubs-drift-test` targeting `main`.
+
+PR body (English):
+
+- **Summary** — 3 bullets on G1/G2/G4.
+- **Why** — cites TM-D1 spec, quotes the relevant CLAUDE.md rules
+  (observability + security).
+- **Out of scope** — real route implementations (TM-D2/D3/D5).
+- **Test plan** — `uv run task test` + `make check`.
+- **Closes TM-6**.
+
+## Success criteria
+
+- [ ] `tests/api/test_stubs.py` parametrised across 7 routes, all
+  assertions green.
+- [ ] OpenAPI drift test green (both directions).
+- [ ] `src/api/main.py` CORS allow-list contains both local and Vercel
+  origins.
+- [ ] `uv run task lint` + `uv run task test` + `uv run bandit -r src`
+  + `make check` all exit 0.
+- [ ] PR opened with `Closes TM-6` in the body.
+- [ ] `PROGRESS.md` TM-D1 row updated to ✅ with the completion date.
+
+## Open questions (resolved during planning)
+
+1. **G2 implementation — runtime YAML parser.**
+   Resolution: use `openapi-spec-validator`'s built-in loader (already
+   present). If unusable, add `pyyaml` to the `dev` dependency group
+   and justify in the PR body. Do not add `pyyaml` to runtime.
+2. **Should the drift test be marked `@pytest.mark.integration`?**
+   Resolution: no. It parses a static YAML file — no external services
+   needed — so it belongs in the default (fast) test run.
+3. **Should `POST /api/v1/chat/stream` 501 test include SSE headers?**
+   Resolution: no. 501 is returned before any SSE framing; asserting
+   `text/event-stream` headers would accidentally constrain TM-D5.

--- a/.claude/specs/TM-D1-plan.md
+++ b/.claude/specs/TM-D1-plan.md
@@ -113,10 +113,10 @@ turns out to require a new dep (CLAUDE.md §"Anti-patterns — YAGNI").
 Before opening the PR:
 
 ```bash
-uv run task lint          # ruff + ruff format + mypy strict
-uv run task test          # includes new tests/api/*
-uv run bandit -r src      # HIGH severity only
-make check                # broader; runs dbt-parse + TS lint too
+uv run task lint                                  # ruff + ruff format + mypy strict
+uv run task test                                  # includes new tests/api/*
+uv run bandit -r src --severity-level high        # HIGH severity only
+make check                                        # broader; runs dbt-parse + TS lint too
 ```
 
 All must exit 0. If mypy strict complains about `app.routes` typing,

--- a/.claude/specs/TM-D1-plan.md
+++ b/.claude/specs/TM-D1-plan.md
@@ -143,8 +143,8 @@ PR body (English):
 - [ ] OpenAPI drift test green (both directions).
 - [ ] `src/api/main.py` CORS allow-list contains both local and Vercel
   origins.
-- [ ] `uv run task lint` + `uv run task test` + `uv run bandit -r src`
-  + `make check` all exit 0.
+- [ ] `uv run task lint` + `uv run task test`
+  + `uv run bandit -r src --severity-level high` + `make check` all exit 0.
 - [ ] PR opened with `Closes TM-6` in the body.
 - [ ] `PROGRESS.md` TM-D1 row updated to ✅ with the completion date.
 

--- a/.claude/specs/TM-D1-research.md
+++ b/.claude/specs/TM-D1-research.md
@@ -38,7 +38,13 @@ CORSMiddleware(
 )
 ```
 
-No `"*"` in production origins — matches CLAUDE.md security rule.
+CORS uses an explicit allow-list (no wildcard `*`), which satisfies the
+"no `*` in production" rule from CLAUDE.md §"Security-first". **However,
+the list currently contains only `http://localhost:3000`** and is
+missing the production Vercel origin documented at
+`contracts/openapi.yaml` lines 12–13 (`https://tfl-monitor.vercel.app`).
+That gap would block all production dashboard requests and is treated
+as a deployment blocker in the gap analysis below (G4).
 
 ### Logfire wiring — `src/api/observability.py`
 
@@ -95,14 +101,15 @@ required Logfire surface.
 | G1 | Parametrised test `tests/api/test_stubs.py` asserting every non-`/health` route returns 501 with the documented hint | Locks the spec (cannot accidentally ship a half-wired route before its owning WP) | ~30 lines pytest; adds `tests/api/` folder |
 | G2 | Test asserting every `operationId` in `contracts/openapi.yaml` has a matching FastAPI route (drift detector) | Catches silent route loss | ~40 lines; uses `yaml` + `app.routes` |
 | G3 | Document `/health` shape in a `src/api/README.md` or extend docstring | Portfolio-optics; explain why `dependencies` is `{}` until TM-D2 | docs only |
-| G4 | Extend CORS allow-list to include the Vercel prod origin (`https://tfl-monitor.vercel.app`) | Matches the value quoted in `contracts/openapi.yaml` info | 1 line change |
+| G4 | **Deployment blocker** — extend CORS allow-list to include the Vercel prod origin (`https://tfl-monitor.vercel.app`) so the production dashboard can reach the API | Without this, all prod requests fail CORS preflight; the openapi.yaml info block (lines 12–13) already declares this origin as in-scope | 1 line change |
 | G5 | Ship a `get_health` dependency-check scaffold (empty dict today) | Shape-only; actual DB/Kafka checks land in TM-D2/TM-B3 | `health.py` helper |
 | G6 | Add an `api/config.py` Pydantic `Settings` — not yet required (no env vars consumed outside observability) | YAGNI per CLAUDE.md rule 5 (< 15 vars) | defer |
 | G7 | Ensure `src/api/__init__.py` is valid (empty file today) | Neutral | no action |
 
-G1 and G2 give the WP something concrete to ship. G4 is a real bugfix
-(prod CORS origin is missing). G3 is optional polish. G5/G6/G7 are
-YAGNI.
+G1 and G2 give the WP something concrete to ship. **G4 is reclassified
+as P0/critical — a real production blocker, not optional polish** (the
+openapi.yaml spec already declares the missing origin). G3 is optional
+polish. G5/G6/G7 are YAGNI.
 
 ## Key documents reviewed
 
@@ -115,17 +122,15 @@ YAGNI.
 
 ## Open questions for the planning phase
 
-1. **Headline question.** Spec's declared AC ("skeleton + 501 + Logfire
-   configured") is already satisfied. Should TM-D1:
-   - (a) Ship G1 + G2 + G4 as the concrete deliverable (two new tests
-     + one CORS line). Small PR, real safety net added.
-   - (b) Close as already-delivered — PR only touches `PROGRESS.md`
-     and Linear TM-6, flagging that TM-000 absorbed the work.
-   - (c) Expand to partial TM-D2 groundwork (e.g. a `dependencies.py`
-     placeholder). Risks scope creep and cross-track contamination.
-2. G4 (adding the Vercel prod origin) involves a production security
-   surface — confirm whether it belongs in TM-D1 or in TM-A5 (deploy).
-3. G2 requires adding `pyyaml` (or reading the YAML with the existing
-   `openapi-spec-validator` dev dep). Adding a runtime dep for a test
-   is overkill; prefer `openapi-spec-validator` which is already
-   present.
+1. **Headline question — RESOLVED on 2026-04-23.** The spec's declared
+   AC from `SETUP.md` §7.3 ("skeleton + 501 + Logfire configured") is
+   already satisfied by TM-000, but G4 is a deployment blocker (CORS
+   omits the production Vercel origin). Author chose option **(a)**:
+   ship G1 + G2 + G4 as the concrete deliverable in TM-D1. Option (b)
+   "close as already-delivered" was rejected because deferring G4 to
+   TM-A5 (deploy) would push a known production blocker out of the
+   security/API track that owns it.
+2. G2 implementation — confirmed: use the loader bundled with
+   `openapi-spec-validator` (already a dev dep). No new runtime
+   dependency; if `pyyaml` is needed, add it only to the `dev` group
+   and justify in the PR body.

--- a/.claude/specs/TM-D1-research.md
+++ b/.claude/specs/TM-D1-research.md
@@ -1,0 +1,131 @@
+# TM-D1 — Research (Phase 1)
+
+Read-only exploration. Track: **D-api-agent**. Linear issue: **TM-6** (open).
+
+Objective from `SETUP.md` §7.3: "Stand up FastAPI with all endpoints returning 501 and Logfire configured."
+
+## Scope boundary
+
+Allowed paths: `src/api/`, plus the paired test file(s) under `tests/`.
+Forbidden without ADR: `contracts/openapi.yaml` (any drift → ADR per
+AGENTS.md §2).
+
+## What already exists (delivered by TM-000)
+
+### API skeleton — `src/api/main.py`
+
+| Route | Method | OpenAPI `operationId` | Current body | Target WP |
+|---|---|---|---|---|
+| `/health` | GET | `get_health` | Returns `{"status":"ok","dependencies":{}}` | TM-D1 (this) |
+| `/api/v1/status/live` | GET | `get_status_live` | `501` → `"Not implemented — see TM-D2"` | TM-D2 |
+| `/api/v1/status/history` | GET | `get_status_history` | `501` → `"Not implemented — see TM-D2"` | TM-D2 |
+| `/api/v1/reliability/{line_id}` | GET | `get_line_reliability` | `501` → `"Not implemented — see TM-D2"` | TM-D2 |
+| `/api/v1/disruptions/recent` | GET | `get_recent_disruptions` | `501` → `"Not implemented — see TM-D3"` | TM-D3 |
+| `/api/v1/bus/{stop_id}/punctuality` | GET | `get_bus_punctuality` | `501` → `"Not implemented — see TM-D3"` | TM-D3 |
+| `/api/v1/chat/stream` | POST | `post_chat_stream` | `501` → `"Not implemented — see TM-D5"` | TM-D5 |
+| `/api/v1/chat/{thread_id}/history` | GET | `get_chat_history` | `501` → `"Not implemented — see TM-D5"` | TM-D5 |
+
+All 8 routes declared in `contracts/openapi.yaml` have matching handlers
+with matching `operation_id`s. `501` helper is centralised via
+`_not_implemented(detail)`. CORS is an explicit allow-list:
+
+```python
+CORSMiddleware(
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+No `"*"` in production origins — matches CLAUDE.md security rule.
+
+### Logfire wiring — `src/api/observability.py`
+
+`configure_observability(app)` — one function, called once from `main.py`:
+
+```python
+logfire.configure(
+    service_name="tfl-monitor-api",
+    service_version=os.getenv("APP_VERSION", "0.0.1"),
+    environment=os.getenv("ENVIRONMENT", "local"),
+    send_to_logfire="if-token-present",
+)
+logfire.instrument_fastapi(app)
+logfire.instrument_httpx()
+logfire.instrument_psycopg("psycopg")
+```
+
+Matches CLAUDE.md §"Observability architecture" word-for-word plus the
+additional `instrument_httpx()` (needed when we wire outgoing HTTP from
+the agent in TM-D5). `send_to_logfire="if-token-present"` makes the
+call a no-op in CI / local-without-token — no extra guards required.
+
+`logfire[fastapi,httpx,psycopg]>=3.0` is in `pyproject.toml` deps.
+
+### Dependencies and tests
+
+- `pyproject.toml`: `fastapi>=0.115`, `uvicorn[standard]>=0.32`,
+  `sse-starlette>=2.1`, `httpx>=0.28`, `pydantic>=2.9`,
+  `pydantic-settings>=2.6`, `logfire[fastapi,httpx,psycopg]>=3.0`.
+- Taskipy: `api = "uvicorn api.main:app --reload --app-dir src"`.
+- `tests/test_health.py` — one smoke test: `GET /health` → 200.
+- `tests/test_contracts.py` — covers Pydantic tier-1/tier-2 contracts
+  for Kafka events; does **not** assert anything about API routes.
+
+### CI coverage
+
+`.github/workflows/ci.yml`:
+- Lint job runs `uv run task lint` (mypy strict on `src/` includes
+  `src/api/`) and `uv run bandit -r src contracts scripts`.
+- Test job runs `uv run task test` → Pytest → covers `test_health.py`.
+- Frontend job runs `openapi-typescript contracts/openapi.yaml`
+  diff-gated so the OpenAPI spec cannot drift from the TS types.
+
+## Current state verification
+
+Nothing to run here — `main.py` is already the "501-stubs + health"
+skeleton the spec asks for, and `observability.py` already exposes the
+required Logfire surface.
+
+## Gap analysis — what remains for TM-D1
+
+| # | Item | Value | Cost |
+|---|---|---|---|
+| G1 | Parametrised test `tests/api/test_stubs.py` asserting every non-`/health` route returns 501 with the documented hint | Locks the spec (cannot accidentally ship a half-wired route before its owning WP) | ~30 lines pytest; adds `tests/api/` folder |
+| G2 | Test asserting every `operationId` in `contracts/openapi.yaml` has a matching FastAPI route (drift detector) | Catches silent route loss | ~40 lines; uses `yaml` + `app.routes` |
+| G3 | Document `/health` shape in a `src/api/README.md` or extend docstring | Portfolio-optics; explain why `dependencies` is `{}` until TM-D2 | docs only |
+| G4 | Extend CORS allow-list to include the Vercel prod origin (`https://tfl-monitor.vercel.app`) | Matches the value quoted in `contracts/openapi.yaml` info | 1 line change |
+| G5 | Ship a `get_health` dependency-check scaffold (empty dict today) | Shape-only; actual DB/Kafka checks land in TM-D2/TM-B3 | `health.py` helper |
+| G6 | Add an `api/config.py` Pydantic `Settings` — not yet required (no env vars consumed outside observability) | YAGNI per CLAUDE.md rule 5 (< 15 vars) | defer |
+| G7 | Ensure `src/api/__init__.py` is valid (empty file today) | Neutral | no action |
+
+G1 and G2 give the WP something concrete to ship. G4 is a real bugfix
+(prod CORS origin is missing). G3 is optional polish. G5/G6/G7 are
+YAGNI.
+
+## Key documents reviewed
+
+- `src/api/main.py`, `src/api/observability.py`, `src/api/__init__.py`.
+- `contracts/openapi.yaml` (full read).
+- `tests/test_health.py`, `tests/test_contracts.py`.
+- `pyproject.toml`, `Makefile`, `.github/workflows/ci.yml`.
+- `CLAUDE.md` §"Observability architecture", §"Security-first".
+- `AGENTS.md` §"PR rules — Observability", §"Security (blockers)".
+
+## Open questions for the planning phase
+
+1. **Headline question.** Spec's declared AC ("skeleton + 501 + Logfire
+   configured") is already satisfied. Should TM-D1:
+   - (a) Ship G1 + G2 + G4 as the concrete deliverable (two new tests
+     + one CORS line). Small PR, real safety net added.
+   - (b) Close as already-delivered — PR only touches `PROGRESS.md`
+     and Linear TM-6, flagging that TM-000 absorbed the work.
+   - (c) Expand to partial TM-D2 groundwork (e.g. a `dependencies.py`
+     placeholder). Risks scope creep and cross-track contamination.
+2. G4 (adding the Vercel prod origin) involves a production security
+   surface — confirm whether it belongs in TM-D1 or in TM-A5 (deploy).
+3. G2 requires adding `pyyaml` (or reading the YAML with the existing
+   `openapi-spec-validator` dev dep). Adding a runtime dep for a test
+   is overkill; prefer `openapi-spec-validator` which is already
+   present.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,7 +7,7 @@ Current state of work packages. Update the status column as WPs land.
 | 0 | TM-000 | Contracts and scaffold | — | ✅ 2026-04-22 | Scaffold, contracts, tier-1/tier-2 schemas, fixtures fetched |
 | 1 | TM-A1 | Docker Compose + Postgres + Redpanda + Airflow | A-infra | ✅ 2026-04-23 | Round 3 follow-up applied: pgcrypto + DB-side defaults on raw tables; integration smoke test gated on `DATABASE_URL` |
 | 1 | TM-B1 | Async TfL client + fixtures | B-ingestion | ⬜ | |
-| 2 | TM-C1 | dbt scaffold | C-dbt | ⬜ | |
+| 2 | TM-C1 | dbt scaffold | C-dbt | ✅ 2026-04-23 | Acceptance criteria absorbed by TM-000: `dbt/sources/tfl.yml` mirrors `contracts/dbt_sources.yml` (CI-enforced), `dbt-parse` green, `.gitkeep`s pin empty model dirs. |
 | 2 | TM-D1 | FastAPI skeleton + Logfire wiring | D-api-agent | ⬜ | |
 | 3 | TM-B2 | `line-status` producer | B-ingestion | ⬜ | |
 | 3 | TM-B3 | `line-status` consumer | B-ingestion | ⬜ | |
@@ -27,6 +27,14 @@ Current state of work packages. Update the status column as WPs land.
 | 7 | TM-A5 | Railway deploy (Airflow + API + agent + workers) | A-infra | ⬜ | |
 | 7 | TM-E4 | Vercel deploy | E-frontend | ⬜ | |
 | 7 | TM-F1 | README polish + demo video + live URL | F-polish | ⬜ | |
+
+## TM-C1 notes
+
+- Every functional acceptance criterion declared in `SETUP.md` §7.3 for
+  TM-C1 was already satisfied by the TM-000 scaffold (dbt project,
+  profiles, sources mirror, CI diff gate, `dbt-parse` task). This WP
+  closes as a zero-code PR after verifying the CI diff + parse pass;
+  see `.claude/specs/TM-C1-{research,plan}.md`.
 
 ## TM-000 notes
 


### PR DESCRIPTION
## Summary
  - TM-C1's acceptance criteria from SETUP.md section 7.3 were satisfied by the TM-000 scaffold: dbt project + profiles
  (dev, ci) exist; `dbt/sources/tfl.yml` is a byte-identical mirror of `contracts/dbt_sources.yml` (CI `diff`
  gate); `uv run task dbt-parse` exits 0; `.gitkeep`s pin empty model directories.
  - Closes TM-5 as a zero-code WP. Only PROGRESS.md flips and the coordinator Phase A specs for TM-B1/TM-C1/TM-D1 land
  under `.claude/specs/` so follow-up worktrees have them in `main`.

  ## WP
  TM-C1 — dbt scaffold with sources (track: C-dbt)

  ## Directories touched
  - `PROGRESS.md`
  - `.claude/specs/TM-{B1,C1,D1}-{research,plan}.md` (Phase A outputs, coordination, no code)

  ## Contracts changed?
  - [ ] No

  ## Checklist
  - [x] `diff contracts/dbt_sources.yml dbt/sources/tfl.yml` exits 0
  - [x] `uv run task dbt-parse` exits 0
  - [x] `uv run task lint` passes
  - [x] `uv run task test` unaffected (not re-run; nothing touched in test scope)
  - [x] PROGRESS.md TM-C1 row flipped to complete with 2026-04-23 date
  - [x] Linear TM-5 linked via `Closes TM-5`

  ## Spec deviations
  None. Research flagged that TM-000 already delivered the WP's surface; plan locked a zero-code close.

  ## Out of scope
  - Staging / intermediate / mart models — TM-C2 / TM-C3
  - `dbt debug` in `make check` — would need a running Postgres
  - Pytest-level source YAML parity — CI `diff` already enforces it

  Closes TM-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added planning and research specifications for TM-B1 (async TfL ingestion client, normalization and retry/timing expectations, test fixtures and ingestion test strategy), TM-C1 (dbt infra validation and closure notes), and TM-D1 (API stub/consistency and CORS/acceptance guidance).
  * Updated progress tracking to mark TM-C1 as completed and included PR verification/checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->