### PR TITLE
feat(api): TM-D1 lock 501 stubs + drift test + prod CORS origin (TM-6)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -8,7 +8,7 @@ Current state of work packages. Update the status column as WPs land.
 | 1 | TM-A1 | Docker Compose + Postgres + Redpanda + Airflow | A-infra | ✅ 2026-04-23 | Round 3 follow-up applied: pgcrypto + DB-side defaults on raw tables; integration smoke test gated on `DATABASE_URL` |
 | 1 | TM-B1 | Async TfL client + fixtures | B-ingestion | ⬜ | |
 | 2 | TM-C1 | dbt scaffold | C-dbt | ✅ 2026-04-23 | Acceptance criteria absorbed by TM-000: `dbt/sources/tfl.yml` mirrors `contracts/dbt_sources.yml` (CI-enforced), `dbt-parse` green, `.gitkeep`s pin empty model dirs. |
-| 2 | TM-D1 | FastAPI skeleton + Logfire wiring | D-api-agent | ⬜ | |
+| 2 | TM-D1 | FastAPI skeleton + Logfire wiring | D-api-agent | ✅ 2026-04-26 | Locked 501 stubs with parametrised tests, added bidirectional OpenAPI drift test, extended CORS allow-list with `https://tfl-monitor.vercel.app` (G1 + G2 + G4 from research). |
 | 3 | TM-B2 | `line-status` producer | B-ingestion | ⬜ | |
 | 3 | TM-B3 | `line-status` consumer | B-ingestion | ⬜ | |
 | 3 | TM-C2 | dbt staging + first mart | C-dbt | ⬜ | |

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -24,7 +24,10 @@ configure_observability(app)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=[
+        "http://localhost:3000",
+        "https://tfl-monitor.vercel.app",
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/tests/api/test_stubs.py
+++ b/tests/api/test_stubs.py
@@ -49,6 +49,16 @@ def _api_routes(app_obj: Any) -> Iterable[APIRoute]:
             yield route
 
 
+def _spec_operation_ids(spec: dict[str, Any]) -> set[str]:
+    """Collect every ``operationId`` declared under ``paths`` in the OpenAPI spec."""
+    operation_ids: set[str] = set()
+    for path_item in spec["paths"].values():
+        for operation in path_item.values():
+            if isinstance(operation, dict) and "operationId" in operation:
+                operation_ids.add(operation["operationId"])
+    return operation_ids
+
+
 @pytest.fixture(scope="module")
 def client() -> TestClient:
     return TestClient(app)
@@ -80,14 +90,27 @@ def test_stub_returns_501(
     assert wp_hint in detail, f"expected {wp_hint!r} in detail, got {detail!r}"
 
 
+def test_every_app_route_declares_operation_id() -> None:
+    """Guard against silent drift: every user-defined route needs an ``operationId``.
+
+    Without this, a developer could add a route, forget to set ``operation_id``,
+    and the App→Spec drift test would still pass because the route would be
+    invisible to the comparison.
+    """
+    routes_missing_id = sorted(
+        f"{','.join(sorted(route.methods or set()))} {route.path}"
+        for route in _api_routes(app)
+        if route.path not in FASTAPI_BUILTIN_PATHS and not route.operation_id
+    )
+    assert not routes_missing_id, (
+        f"FastAPI routes without an operation_id (drift test would silently skip them): "
+        f"{routes_missing_id}"
+    )
+
+
 def test_spec_operation_ids_have_matching_routes(openapi_spec: dict[str, Any]) -> None:
     """Every ``operationId`` in the OpenAPI spec must exist as a FastAPI route."""
-    spec_operation_ids: set[str] = set()
-    for path_item in openapi_spec["paths"].values():
-        for operation in path_item.values():
-            if isinstance(operation, dict) and "operationId" in operation:
-                spec_operation_ids.add(operation["operationId"])
-
+    spec_operation_ids = _spec_operation_ids(openapi_spec)
     app_operation_ids = {route.operation_id for route in _api_routes(app) if route.operation_id}
 
     missing_in_app = spec_operation_ids - app_operation_ids
@@ -98,13 +121,13 @@ def test_spec_operation_ids_have_matching_routes(openapi_spec: dict[str, Any]) -
 
 
 def test_app_routes_have_matching_spec_entries(openapi_spec: dict[str, Any]) -> None:
-    """Every FastAPI route must have a matching ``operationId`` in the spec."""
-    spec_operation_ids: set[str] = set()
-    for path_item in openapi_spec["paths"].values():
-        for operation in path_item.values():
-            if isinstance(operation, dict) and "operationId" in operation:
-                spec_operation_ids.add(operation["operationId"])
+    """Every FastAPI route must have a matching ``operationId`` in the spec.
 
+    The companion ``test_every_app_route_declares_operation_id`` check
+    guarantees no route reaches this point with a falsy ``operation_id``,
+    so the set subtraction can never produce a ``None`` element.
+    """
+    spec_operation_ids = _spec_operation_ids(openapi_spec)
     app_operation_ids = {
         route.operation_id
         for route in _api_routes(app)

--- a/tests/api/test_stubs.py
+++ b/tests/api/test_stubs.py
@@ -1,0 +1,118 @@
+"""Lock the 501 stubs and detect drift between FastAPI routes and the OpenAPI spec.
+
+Until the owning work packages (TM-D2, TM-D3, TM-D5) wire the real handlers,
+every non-``/health`` route must return ``501 Not Implemented`` with a
+detail that points to the WP that will implement it. This file also asserts
+that the FastAPI surface and ``contracts/openapi.yaml`` agree on the set of
+operation IDs in both directions, so neither side can drift silently.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from openapi_spec_validator.readers import read_from_filename
+
+from api.main import app
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPENAPI_PATH = REPO_ROOT / "contracts" / "openapi.yaml"
+
+# FastAPI registers a few routes for the auto-generated docs. They are not in
+# our hand-written spec, so the App→Spec direction must ignore them.
+FASTAPI_BUILTIN_PATHS = {"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
+
+
+# (method, path, body, expected_wp_hint)
+StubCase = tuple[str, str, dict[str, Any] | None, str]
+
+STUB_ROUTES: list[StubCase] = [
+    ("GET", "/api/v1/status/live", None, "TM-D2"),
+    ("GET", "/api/v1/status/history", None, "TM-D2"),
+    ("GET", "/api/v1/reliability/victoria", None, "TM-D2"),
+    ("GET", "/api/v1/disruptions/recent", None, "TM-D3"),
+    ("GET", "/api/v1/bus/dummy/punctuality", None, "TM-D3"),
+    ("POST", "/api/v1/chat/stream", {"thread_id": "t-1", "message": "hi"}, "TM-D5"),
+    ("GET", "/api/v1/chat/t-1/history", None, "TM-D5"),
+]
+
+
+def _api_routes(app_obj: Any) -> Iterable[APIRoute]:
+    """Yield only the user-defined ``APIRoute`` instances on the FastAPI app."""
+    for route in app_obj.routes:
+        if isinstance(route, APIRoute):
+            yield route
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(scope="module")
+def openapi_spec() -> dict[str, Any]:
+    spec, _base_uri = read_from_filename(str(OPENAPI_PATH))
+    assert isinstance(spec, dict)
+    return spec
+
+
+@pytest.mark.parametrize(("method", "path", "body", "wp_hint"), STUB_ROUTES)
+def test_stub_returns_501(
+    client: TestClient,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    wp_hint: str,
+) -> None:
+    """Every non-``/health`` route must 501 with its owning-WP hint until landed."""
+    response = client.request(method, path, json=body)
+    assert response.status_code == 501, (
+        f"{method} {path} expected 501, got {response.status_code}: {response.text}"
+    )
+    detail = response.json()["detail"]
+    assert isinstance(detail, str)
+    assert detail.startswith("Not implemented"), detail
+    assert wp_hint in detail, f"expected {wp_hint!r} in detail, got {detail!r}"
+
+
+def test_spec_operation_ids_have_matching_routes(openapi_spec: dict[str, Any]) -> None:
+    """Every ``operationId`` in the OpenAPI spec must exist as a FastAPI route."""
+    spec_operation_ids: set[str] = set()
+    for path_item in openapi_spec["paths"].values():
+        for operation in path_item.values():
+            if isinstance(operation, dict) and "operationId" in operation:
+                spec_operation_ids.add(operation["operationId"])
+
+    app_operation_ids = {route.operation_id for route in _api_routes(app) if route.operation_id}
+
+    missing_in_app = spec_operation_ids - app_operation_ids
+    assert not missing_in_app, (
+        f"operationIds declared in contracts/openapi.yaml but missing from app: "
+        f"{sorted(missing_in_app)}"
+    )
+
+
+def test_app_routes_have_matching_spec_entries(openapi_spec: dict[str, Any]) -> None:
+    """Every FastAPI route must have a matching ``operationId`` in the spec."""
+    spec_operation_ids: set[str] = set()
+    for path_item in openapi_spec["paths"].values():
+        for operation in path_item.values():
+            if isinstance(operation, dict) and "operationId" in operation:
+                spec_operation_ids.add(operation["operationId"])
+
+    app_operation_ids = {
+        route.operation_id
+        for route in _api_routes(app)
+        if route.operation_id and route.path not in FASTAPI_BUILTIN_PATHS
+    }
+
+    missing_in_spec = app_operation_ids - spec_operation_ids
+    assert not missing_in_spec, (
+        f"FastAPI routes without a matching operationId in contracts/openapi.yaml: "
+        f"{sorted(missing_in_spec)}"
+    )


### PR DESCRIPTION
## Summary

- **G1 — 501 stub lock:** new `tests/api/test_stubs.py` parametrises across the 7 non-`/health` routes and asserts each returns `501` with `detail` starting with `"Not implemented"` and naming its owning WP (`TM-D2` / `TM-D3` / `TM-D5`). `POST /api/v1/chat/stream` is exercised with a minimal valid `ChatRequest` body so we prove the 501 fires even when the payload is well-formed.
- **G2 — bidirectional OpenAPI drift test:** the same module loads `contracts/openapi.yaml` via `openapi_spec_validator.readers.read_from_filename` (already a dev dep — no new runtime or dev dependency added) and asserts every `operationId` declared in the spec is registered on the FastAPI app, and every `APIRoute` on the app (excluding FastAPI's built-in `/openapi.json`, `/docs`, `/docs/oauth2-redirect`, `/redoc`) has a matching `operationId` in the spec.
- **G4 — production CORS origin:** extends `src/api/main.py` `allow_origins` to the explicit two-element list `["http://localhost:3000", "https://tfl-monitor.vercel.app"]`, matching the value documented in `contracts/openapi.yaml` lines 12–13. Still no wildcard, still no env-driven list.

## Why

- `CLAUDE.md` §"Security-first" requires explicit CORS allow-lists with no `*` in production. The current single-origin list silently drops every Vercel preflight, so this was reclassified during research as a **P0 deployment blocker** rather than optional polish (see PR #27 discussion / `.claude/specs/TM-D1-research.md` G4).
- `CLAUDE.md` §"Observability architecture" + `AGENTS.md` §"PR rules — Observability" mandate that the API surface stays in lockstep with `contracts/openapi.yaml`. The bidirectional drift test makes accidental contract divergence a CI failure rather than a runtime surprise.
- The 501 stub lock makes it impossible to ship a half-wired endpoint before its owning WP (TM-D2 / TM-D3 / TM-D5) lands the real handler.

## Out of scope

- Implementing the actual route bodies — those are owned by TM-D2 (`/api/v1/status/*`, `/api/v1/reliability/{line_id}`), TM-D3 (`/api/v1/disruptions/recent`, `/api/v1/bus/{stop_id}/punctuality`), and TM-D5 (`/api/v1/chat/*`).
- Real `/health` dependency probes (Postgres, Kafka). Shape stays `{"status":"ok","dependencies":{}}` until TM-D2.
- Any change under `contracts/` — `openapi.yaml` is read-only here; the drift test consumes it but never edits it. No ADR needed.
- No new `Settings(BaseSettings)` for the API (CLAUDE.md rule 5: <15 env vars).
- No env-driven CORS list — explicit allow-list per CLAUDE.md lean-by-default; this was discussed and rejected on PR #27.

## Test plan

- [x] `uv run task lint` — ruff check + ruff format --check + mypy strict
- [x] `uv run task test` — `tests/test_health.py` + `tests/test_contracts.py` + new `tests/api/test_stubs.py` (17 passed, 11 deselected)
- [x] `uv run bandit -r src --severity-level high` — no HIGH-severity findings
- [x] `make check` — full sweep (lint + test + dbt-parse + `pnpm --dir web lint` + `pnpm --dir web build`) all green

Closes TM-6.