### PR TITLE
feat(rag): TM-D4 Docling -> Pinecone RAG ingestion with auto PDF fetch (TM-17)

### DIFF
--- a/.claude/specs/TM-D4-plan.md
+++ b/.claude/specs/TM-D4-plan.md
@@ -1,0 +1,1098 @@
+# TM-D4 — Implementation plan (Phase 2)
+
+Source: `TM-D4-research.md` (2026-04-28).
+
+All ten open questions from the research file (Q1-Q10) resolved as the
+recommended defaults. No author callout was raised in the research; the
+plan proceeds directly.
+
+## Summary
+
+Land a self-contained `src/rag/` package that:
+
+1. Resolves the current direct-PDF URL on each of the three TfL strategy
+   landing pages (Business Plan, Mayor's Transport Strategy 2018, Annual
+   Report) by scraping the landing HTML for an allowlisted PDF link.
+2. Conditionally downloads each PDF using cached `ETag` /
+   `Last-Modified` to `data/strategy_docs/<doc_id>.pdf`.
+3. Parses each PDF through Docling 2.x and chunks via
+   `docling.chunking.HybridChunker` into ~512-token chunks with
+   section/heading/page metadata.
+4. Embeds chunks via OpenAI `text-embedding-3-small` (1536 dim, async,
+   batches of 100, retry on 429).
+5. Upserts vectors into Pinecone serverless index `tfl-strategy-docs`,
+   one namespace per `doc_id`, with stable id =
+   `sha256(f"{resolved_url}::{chunk_index}").hexdigest()`. Idempotent
+   on repeat runs; deletes the namespace before upsert when
+   `resolved_url` rolled over.
+6. Runs as `uv run python -m rag.ingest` with `--force-refetch` and
+   `--dry-run` flags. Fails loud with exit code 2 when
+   `PINECONE_API_KEY` or `OPENAI_API_KEY` is missing.
+
+No edits to `contracts/`. No new runtime dependency
+(`docling`, `pinecone`, `openai`, `httpx`, `pydantic-settings`,
+`logfire` already in `pyproject.toml`). LlamaIndex is intentionally
+not used.
+
+## Execution mode
+
+- **Author of change:** single-track WP — execute serially in the main
+  workspace (only `src/rag/`, `tests/rag/`, `data/` (gitignored),
+  `.gitignore`, and `README.md` touched).
+- **Branch:** `feature/TM-D4-rag-ingestion`.
+- **PR title:** `feat(rag): TM-D4 Docling → Pinecone RAG ingestion with
+  auto PDF fetch (TM-17)`.
+- **PR body:** `Closes TM-17`; lists deliverables, the conditional-GET
+  semantics, the per-doc namespace cleanup-on-rollover semantics, the
+  CLI flags, and the failure model.
+
+## What we're NOT doing
+
+- No retrieval logic (TM-D5 builds the LangGraph `search_tfl_docs`
+  tool).
+- No reranking, no hybrid (BM25 + vector) — TM-D5 layers that on top
+  of the index this WP populates.
+- No Airflow DAG to schedule ingestion (TM-A2). `cron`-style refresh
+  is the manual `uv run python -m rag.ingest` until then.
+- No edits to `contracts/schemas/*`, `contracts/sql/*`,
+  `contracts/openapi.yaml` — frozen.
+- No `LlamaIndex` dependency wiring. Docling alone covers parse +
+  chunk for this WP.
+- No new TypeScript or web changes. Track is `D-api-agent`, scope is
+  `src/rag/` + `tests/rag/`.
+- No Pinecone metadata-filter delete (free-tier serverless does not
+  support it). Use `delete(delete_all=True, namespace=doc_id)` for
+  rollover cleanup.
+- No new env var beyond `OPENAI_API_KEY`, `PINECONE_API_KEY`,
+  `PINECONE_INDEX`, `EMBEDDING_MODEL`. `LOGFIRE_TOKEN` is reused if
+  set; otherwise Logfire stays in console mode (`send_to_logfire="if-token-present"`).
+- No `Makefile` target — RAG ingestion is run on-demand by the author
+  via `uv run python -m rag.ingest`. Adding a target would push the
+  Makefile from 10 to 11 with no recurring orchestration value
+  (CLAUDE.md §"Principle #1" rule 2 keeps the Makefile small).
+
+## Sub-phases
+
+### Phase 3.1 — Package skeleton + config
+
+#### `src/rag/__init__.py` (new)
+
+Re-export the top-level orchestrator and the settings loader so tests
+and `python -m rag.ingest` import cleanly.
+
+```python
+"""RAG ingestion package: TfL strategy PDFs → Docling → Pinecone."""
+
+from rag.config import RagSettings, load_settings
+from rag.ingest import run_ingestion
+
+__all__ = ["RagSettings", "load_settings", "run_ingestion"]
+```
+
+#### `src/rag/config.py` (new)
+
+Single `Settings(BaseSettings)` class — five fields, well under the
+≥15 trigger for nested settings (CLAUDE.md §"Principle #1" rule 5).
+
+```python
+"""Pydantic settings for RAG ingestion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_PINECONE_INDEX = "tfl-strategy-docs"
+DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
+EMBEDDING_DIMENSIONS = 1536
+DEFAULT_PINECONE_CLOUD = "aws"
+DEFAULT_PINECONE_REGION = "us-east-1"
+
+
+class RagSettings(BaseSettings):
+    """RAG ingestion configuration loaded from the process environment."""
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    openai_api_key: SecretStr
+    pinecone_api_key: SecretStr
+    pinecone_index: str = DEFAULT_PINECONE_INDEX
+    embedding_model: str = DEFAULT_EMBEDDING_MODEL
+    pinecone_cloud: str = DEFAULT_PINECONE_CLOUD
+    pinecone_region: str = DEFAULT_PINECONE_REGION
+
+
+def load_settings() -> RagSettings:
+    """Load and validate ``RagSettings`` from the environment.
+
+    Raises ``SystemExit(2)`` with a readable message when required
+    secrets are missing — fail loud per the briefing's hard rule.
+    """
+    try:
+        return RagSettings()  # type: ignore[call-arg]
+    except Exception as exc:  # noqa: BLE001 - boundary
+        msg = f"RAG settings missing or invalid: {exc!s}"
+        raise SystemExit(msg) from None
+```
+
+`SecretStr` ensures Logfire and pytest reprs never expose key
+contents (CLAUDE.md §"Security-first").
+
+### Phase 3.2 — `src/rag/sources.py` and `src/rag/sources.json`
+
+#### `src/rag/sources.py` (new)
+
+```python
+"""Resolve the direct-PDF URL of each TfL strategy landing page."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Self
+from urllib.parse import urljoin
+
+import httpx
+from pydantic import BaseModel, Field, HttpUrl
+
+PDF_LINK_HREF_PATTERN = re.compile(
+    r'href=["\']([^"\']+\.pdf(?:\?[^"\']*)?)["\']', re.IGNORECASE
+)
+
+
+class PdfSource(BaseModel):
+    """A TfL strategy PDF and its discovery + cached state."""
+
+    name: str = Field(min_length=1)
+    doc_id: str = Field(min_length=1)
+    landing_url: HttpUrl
+    discovery_regex: str = Field(min_length=1)
+    resolved_url: HttpUrl | None = None
+    etag: str | None = None
+    last_modified: str | None = None
+    sha256: str | None = None
+
+
+class PdfSourceResolutionError(RuntimeError):
+    """Raised when a landing page exposes no matching PDF link."""
+
+
+def load_sources(path: Path) -> list[PdfSource]:
+    """Load ``src/rag/sources.json`` into a list of ``PdfSource``."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return [PdfSource.model_validate(entry) for entry in raw]
+
+
+def write_sources(path: Path, sources: list[PdfSource]) -> None:
+    """Write ``sources`` back to disk, sorted by ``doc_id``."""
+    serialised = [
+        {
+            "name": s.name,
+            "doc_id": s.doc_id,
+            "landing_url": str(s.landing_url),
+            "discovery_regex": s.discovery_regex,
+            "resolved_url": str(s.resolved_url) if s.resolved_url else None,
+        }
+        for s in sorted(sources, key=lambda s: s.doc_id)
+    ]
+    path.write_text(json.dumps(serialised, indent=2) + "\n", encoding="utf-8")
+
+
+async def resolve_pdf_urls(
+    sources: list[PdfSource],
+    *,
+    client: httpx.AsyncClient,
+) -> list[PdfSource]:
+    """Re-resolve every source's ``resolved_url`` from its landing page.
+
+    Returns a new list with ``resolved_url`` updated. Raises
+    ``PdfSourceResolutionError`` when a landing page has no PDF link
+    matching the source's ``discovery_regex``.
+    """
+    return [await _resolve_one(s, client=client) for s in sources]
+
+
+async def _resolve_one(
+    source: PdfSource, *, client: httpx.AsyncClient
+) -> PdfSource:
+    response = await client.get(str(source.landing_url), follow_redirects=True)
+    response.raise_for_status()
+    pattern = re.compile(source.discovery_regex, re.IGNORECASE)
+    for match in PDF_LINK_HREF_PATTERN.finditer(response.text):
+        href = match.group(1)
+        if pattern.search(href):
+            absolute = urljoin(str(response.url), href)
+            return source.model_copy(update={"resolved_url": absolute})
+    raise PdfSourceResolutionError(
+        f"No PDF link matching {source.discovery_regex!r} found on "
+        f"{source.landing_url}"
+    )
+```
+
+#### `src/rag/sources.json` (new, committed)
+
+```json
+[
+  {
+    "name": "TfL Business Plan",
+    "doc_id": "tfl_business_plan",
+    "landing_url": "https://tfl.gov.uk/corporate/publications-and-reports/business-plan",
+    "discovery_regex": "business-plan.*\\.pdf$",
+    "resolved_url": "https://content.tfl.gov.uk/2026-business-plan-acc.pdf"
+  },
+  {
+    "name": "Mayor's Transport Strategy",
+    "doc_id": "mts_2018",
+    "landing_url": "https://www.london.gov.uk/programmes-strategies/transport/our-vision-transport/mayors-transport-strategy-2018",
+    "discovery_regex": "mayors-transport-strategy-2018.*\\.pdf$",
+    "resolved_url": "https://www.london.gov.uk/sites/default/files/mayors-transport-strategy-2018.pdf"
+  },
+  {
+    "name": "TfL Annual Report",
+    "doc_id": "tfl_annual_report",
+    "landing_url": "https://tfl.gov.uk/corporate/publications-and-reports/annual-report",
+    "discovery_regex": "annual-report-and-statement-of-accounts.*\\.pdf$",
+    "resolved_url": "https://content.tfl.gov.uk/tfl-annual-report-and-statement-of-accounts-2024-25.pdf"
+  }
+]
+```
+
+### Phase 3.3 — `src/rag/fetch.py` (conditional GET + cache)
+
+```python
+"""Conditional download of resolved TfL PDFs to ``data/strategy_docs/``."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+import logfire
+
+from rag.sources import PdfSource
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DATA_DIR = Path("data/strategy_docs")
+DEFAULT_CACHE_PATH = Path("data/cache/sources_state.json")
+
+
+class FetchResult:
+    """Outcome of fetching a single PdfSource."""
+
+    def __init__(
+        self,
+        *,
+        source: PdfSource,
+        local_path: Path,
+        changed: bool,
+        sha256: str,
+        etag: str | None,
+        last_modified: str | None,
+    ) -> None:
+        self.source = source
+        self.local_path = local_path
+        self.changed = changed
+        self.sha256 = sha256
+        self.etag = etag
+        self.last_modified = last_modified
+
+
+def load_cache(path: Path) -> dict[str, dict[str, str]]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_cache(path: Path, state: dict[str, dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8")
+
+
+async def fetch_pdfs(
+    sources: list[PdfSource],
+    *,
+    client: httpx.AsyncClient,
+    data_dir: Path = DEFAULT_DATA_DIR,
+    cache_path: Path = DEFAULT_CACHE_PATH,
+    force_refetch: bool = False,
+) -> list[FetchResult]:
+    """Conditionally download each ``PdfSource`` to disk.
+
+    Returns one ``FetchResult`` per source. ``changed`` is ``True`` for
+    a real download (HTTP 200) and ``False`` for HTTP 304 / cache hit.
+    """
+    data_dir.mkdir(parents=True, exist_ok=True)
+    state = load_cache(cache_path)
+    results = [
+        await _fetch_one(
+            source, client=client, data_dir=data_dir,
+            cached=state.get(source.doc_id, {}),
+            force_refetch=force_refetch,
+        )
+        for source in sources
+    ]
+    state.update({
+        r.source.doc_id: {
+            "resolved_url": str(r.source.resolved_url),
+            "etag": r.etag or "",
+            "last_modified": r.last_modified or "",
+            "sha256": r.sha256,
+            "fetched_at": datetime.now(UTC).isoformat(),
+        }
+        for r in results
+    })
+    write_cache(cache_path, state)
+    return results
+
+
+async def _fetch_one(
+    source: PdfSource,
+    *,
+    client: httpx.AsyncClient,
+    data_dir: Path,
+    cached: dict[str, str],
+    force_refetch: bool,
+) -> FetchResult:
+    if source.resolved_url is None:
+        msg = f"Source {source.doc_id!r} has no resolved_url"
+        raise RuntimeError(msg)
+    target = data_dir / f"{source.doc_id}.pdf"
+    headers: dict[str, str] = {}
+    if not force_refetch and cached:
+        if "etag" in cached and cached["etag"]:
+            headers["If-None-Match"] = cached["etag"]
+        if "last_modified" in cached and cached["last_modified"]:
+            headers["If-Modified-Since"] = cached["last_modified"]
+    with logfire.span(
+        "rag.fetch", doc_id=source.doc_id,
+        url=str(source.resolved_url), force_refetch=force_refetch,
+    ):
+        response = await client.get(
+            str(source.resolved_url), headers=headers,
+            follow_redirects=True,
+        )
+        if response.status_code == 304 and target.exists():
+            sha = cached.get("sha256") or _sha256_of(target)
+            return FetchResult(
+                source=source, local_path=target, changed=False,
+                sha256=sha,
+                etag=cached.get("etag") or None,
+                last_modified=cached.get("last_modified") or None,
+            )
+        response.raise_for_status()
+        target.write_bytes(response.content)
+        sha = _sha256_of(target)
+        return FetchResult(
+            source=source, local_path=target, changed=True,
+            sha256=sha,
+            etag=response.headers.get("ETag") or None,
+            last_modified=response.headers.get("Last-Modified") or None,
+        )
+
+
+def _sha256_of(path: Path) -> str:
+    hasher = hashlib.sha256()
+    hasher.update(path.read_bytes())
+    return hasher.hexdigest()
+```
+
+### Phase 3.4 — `src/rag/parse.py` (Docling + chunking)
+
+```python
+"""Parse a PDF via Docling and emit chunks with retrieval metadata."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CHUNK_MAX_TOKENS = 512
+
+
+class Chunk(BaseModel):
+    """Chunk of a parsed PDF with retrieval metadata."""
+
+    doc_id: str
+    doc_title: str
+    resolved_url: str
+    chunk_index: int = Field(ge=0)
+    section_title: str = ""
+    page_start: int | None = None
+    page_end: int | None = None
+    text: str = Field(min_length=1)
+
+
+def parse_pdf(
+    *, doc_id: str, doc_title: str, resolved_url: str,
+    pdf_path: Path, max_tokens: int = DEFAULT_CHUNK_MAX_TOKENS,
+    converter: Any | None = None, chunker: Any | None = None,
+) -> list[Chunk]:
+    """Parse ``pdf_path`` and return ``Chunk`` objects.
+
+    ``converter`` and ``chunker`` exist only for unit-test injection;
+    in production they default to ``DocumentConverter()`` and
+    ``HybridChunker(max_tokens=max_tokens, merge_peers=True)``.
+    """
+    converter = converter or _default_converter()
+    chunker = chunker or _default_chunker(max_tokens=max_tokens)
+    document = converter.convert(str(pdf_path)).document
+    chunks: list[Chunk] = []
+    for index, raw in enumerate(chunker.chunk(document)):
+        section_title, page_start, page_end = _extract_meta(raw)
+        text = _chunk_text(raw)
+        if not text.strip():
+            continue
+        chunks.append(Chunk(
+            doc_id=doc_id, doc_title=doc_title, resolved_url=resolved_url,
+            chunk_index=index, section_title=section_title,
+            page_start=page_start, page_end=page_end, text=text,
+        ))
+    return chunks
+
+
+def _default_converter() -> Any:
+    from docling.document_converter import DocumentConverter
+    return DocumentConverter()
+
+
+def _default_chunker(*, max_tokens: int) -> Any:
+    from docling.chunking import HybridChunker
+    return HybridChunker(max_tokens=max_tokens, merge_peers=True)
+
+
+def _chunk_text(raw: Any) -> str:
+    text = getattr(raw, "text", None)
+    if isinstance(text, str):
+        return text
+    return str(raw)
+
+
+def _extract_meta(raw: Any) -> tuple[str, int | None, int | None]:
+    meta = getattr(raw, "meta", None)
+    headings: Iterable[str] = getattr(meta, "headings", None) or []
+    section_title = next(iter(headings), "")
+    pages: list[int] = []
+    for item in getattr(meta, "doc_items", None) or []:
+        for prov in getattr(item, "prov", None) or []:
+            page_no = getattr(prov, "page_no", None)
+            if isinstance(page_no, int):
+                pages.append(page_no)
+    page_start = min(pages) if pages else None
+    page_end = max(pages) if pages else None
+    return section_title, page_start, page_end
+```
+
+The lazy imports of Docling keep test runs that mock the converter
+free of the heavy Docling import. Type is `Any` for the injected
+fakes — Docling's runtime objects are duck-typed via the helpers.
+
+### Phase 3.5 — `src/rag/embed.py` (async OpenAI)
+
+```python
+"""Async OpenAI embeddings with batching and 429-aware retry."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+import logfire
+from openai import (
+    APIConnectionError, APITimeoutError, AsyncOpenAI, RateLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 100
+DEFAULT_MAX_ATTEMPTS = 5
+_BASE_BACKOFF_SECONDS = 0.5
+_MAX_BACKOFF_SECONDS = 10.0
+
+
+def _exponential_backoff(attempt: int) -> float:
+    delay: float = _BASE_BACKOFF_SECONDS * (2**attempt)
+    return min(delay, _MAX_BACKOFF_SECONDS)
+
+
+async def embed_texts(
+    texts: Sequence[str],
+    *,
+    client: AsyncOpenAI,
+    model: str,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> list[list[float]]:
+    """Embed ``texts`` in batches; return one vector per input."""
+    vectors: list[list[float]] = []
+    for start in range(0, len(texts), batch_size):
+        batch = list(texts[start : start + batch_size])
+        with logfire.span(
+            "rag.embed", model=model, n_inputs=len(batch),
+            batch_index=start // batch_size,
+        ):
+            response = await _embed_batch_with_retry(
+                batch, client=client, model=model,
+                max_attempts=max_attempts,
+            )
+        vectors.extend([item.embedding for item in response.data])
+    return vectors
+
+
+async def _embed_batch_with_retry(
+    batch: list[str], *, client: AsyncOpenAI, model: str,
+    max_attempts: int,
+) -> Any:
+    last_exc: Exception | None = None
+    for attempt in range(max_attempts):
+        try:
+            return await client.embeddings.create(model=model, input=batch)
+        except (RateLimitError, APIConnectionError, APITimeoutError) as exc:
+            last_exc = exc
+            if attempt == max_attempts - 1:
+                break
+            await asyncio.sleep(_exponential_backoff(attempt))
+    raise RuntimeError(
+        f"OpenAI embed failed after {max_attempts} attempts: {last_exc!r}"
+    )
+```
+
+### Phase 3.6 — `src/rag/upsert.py` (Pinecone)
+
+```python
+"""Pinecone upsert: create index if absent, namespace-per-doc, idempotent."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Iterable
+from typing import Any, Protocol
+
+import logfire
+
+from rag.config import (
+    DEFAULT_PINECONE_CLOUD, DEFAULT_PINECONE_REGION, EMBEDDING_DIMENSIONS,
+)
+from rag.parse import Chunk
+
+logger = logging.getLogger(__name__)
+
+UPSERT_BATCH_SIZE = 100
+
+
+class _PineconeIndex(Protocol):
+    def upsert(self, *, vectors: list[dict[str, Any]],
+               namespace: str) -> Any: ...
+    def delete(self, *, delete_all: bool, namespace: str) -> Any: ...
+
+
+class _PineconeClient(Protocol):
+    def list_indexes(self) -> Any: ...
+    def create_index(self, *, name: str, dimension: int, metric: str,
+                     spec: Any) -> Any: ...
+    def Index(self, name: str) -> _PineconeIndex: ...
+
+
+def vector_id(resolved_url: str, chunk_index: int) -> str:
+    """Stable per-chunk id used as the Pinecone vector id."""
+    digest = hashlib.sha256(
+        f"{resolved_url}::{chunk_index}".encode("utf-8")
+    ).hexdigest()
+    return digest
+
+
+def ensure_index(
+    client: _PineconeClient, *, name: str,
+    cloud: str = DEFAULT_PINECONE_CLOUD,
+    region: str = DEFAULT_PINECONE_REGION,
+) -> None:
+    """Create the index if missing; idempotent."""
+    from pinecone import ServerlessSpec  # lazy import keeps unit tests fake-only
+
+    existing = {entry["name"] for entry in client.list_indexes()}
+    if name in existing:
+        return
+    client.create_index(
+        name=name, dimension=EMBEDDING_DIMENSIONS, metric="cosine",
+        spec=ServerlessSpec(cloud=cloud, region=region),
+    )
+
+
+def upsert_chunks(
+    *, index: _PineconeIndex, chunks: Iterable[Chunk],
+    vectors: list[list[float]], namespace: str,
+    delete_namespace_first: bool,
+) -> int:
+    """Upsert one batch per ``UPSERT_BATCH_SIZE`` vectors. Returns count."""
+    if delete_namespace_first:
+        with logfire.span(
+            "rag.upsert.delete_namespace", namespace=namespace,
+        ):
+            index.delete(delete_all=True, namespace=namespace)
+    payload = [
+        {
+            "id": vector_id(chunk.resolved_url, chunk.chunk_index),
+            "values": vec,
+            "metadata": {
+                "doc_id": chunk.doc_id,
+                "doc_title": chunk.doc_title,
+                "resolved_url": chunk.resolved_url,
+                "chunk_index": chunk.chunk_index,
+                "section_title": chunk.section_title,
+                "page_start": chunk.page_start if chunk.page_start is not None else -1,
+                "page_end": chunk.page_end if chunk.page_end is not None else -1,
+                "text": chunk.text,
+            },
+        }
+        for chunk, vec in zip(chunks, vectors, strict=True)
+    ]
+    upserted = 0
+    for start in range(0, len(payload), UPSERT_BATCH_SIZE):
+        batch = payload[start : start + UPSERT_BATCH_SIZE]
+        with logfire.span(
+            "rag.upsert", namespace=namespace, n_vectors=len(batch),
+            batch_index=start // UPSERT_BATCH_SIZE,
+        ):
+            index.upsert(vectors=batch, namespace=namespace)
+        upserted += len(batch)
+    return upserted
+```
+
+`page_start`/`page_end` are coerced to `-1` when missing because
+Pinecone metadata cannot hold `null`. The retriever in TM-D5 will
+treat `-1` as "unknown".
+
+### Phase 3.7 — `src/rag/ingest.py` (orchestrator + CLI)
+
+```python
+"""Top-level RAG ingestion: resolve → fetch → parse → embed → upsert."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+import httpx
+import logfire
+from openai import AsyncOpenAI
+
+from rag.config import RagSettings, load_settings
+from rag.embed import embed_texts
+from rag.fetch import (
+    DEFAULT_CACHE_PATH, DEFAULT_DATA_DIR, fetch_pdfs, load_cache,
+)
+from rag.parse import Chunk, parse_pdf
+from rag.sources import PdfSource, load_sources, resolve_pdf_urls, write_sources
+from rag.upsert import ensure_index, upsert_chunks
+
+logger = logging.getLogger(__name__)
+SOURCES_PATH = Path("src/rag/sources.json")
+RAG_SERVICE_NAME = "tfl-monitor-rag-ingestion"
+
+
+def configure_logfire() -> None:
+    import os
+    logfire.configure(
+        service_name=RAG_SERVICE_NAME,
+        service_version=os.getenv("APP_VERSION", "0.0.1"),
+        environment=os.getenv("ENVIRONMENT", "local"),
+        send_to_logfire="if-token-present",
+    )
+    logfire.instrument_httpx()
+
+
+async def _amain(*, force_refetch: bool, dry_run: bool,
+                 refresh_urls: bool) -> None:
+    configure_logfire()
+    settings = load_settings()
+    sources = load_sources(SOURCES_PATH)
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        if refresh_urls:
+            sources = await resolve_pdf_urls(sources, client=client)
+            write_sources(SOURCES_PATH, sources)
+
+        results = await fetch_pdfs(
+            sources, client=client, force_refetch=force_refetch,
+        )
+
+    cache = load_cache(DEFAULT_CACHE_PATH)
+    openai_client = AsyncOpenAI(api_key=settings.openai_api_key.get_secret_value())
+    pinecone_client = _build_pinecone_client(settings)
+    ensure_index(
+        pinecone_client, name=settings.pinecone_index,
+        cloud=settings.pinecone_cloud, region=settings.pinecone_region,
+    )
+    index = pinecone_client.Index(settings.pinecone_index)
+
+    total_upserted = 0
+    for result in results:
+        with logfire.span(
+            "rag.ingest.cycle", doc_id=result.source.doc_id,
+            changed=result.changed, dry_run=dry_run,
+        ):
+            chunks = parse_pdf(
+                doc_id=result.source.doc_id,
+                doc_title=result.source.name,
+                resolved_url=str(result.source.resolved_url),
+                pdf_path=result.local_path,
+            )
+            if not chunks:
+                logfire.warn(
+                    "rag.ingest.empty_chunks",
+                    doc_id=result.source.doc_id,
+                )
+                continue
+            vectors = await embed_texts(
+                [c.text for c in chunks],
+                client=openai_client,
+                model=settings.embedding_model,
+            )
+            if dry_run:
+                logfire.info(
+                    "rag.ingest.dry_run", doc_id=result.source.doc_id,
+                    chunks=len(chunks), vectors=len(vectors),
+                )
+                continue
+            previous_url = cache.get(result.source.doc_id, {}).get(
+                "resolved_url"
+            )
+            rollover = bool(
+                previous_url
+                and previous_url != str(result.source.resolved_url)
+            )
+            total_upserted += upsert_chunks(
+                index=index, chunks=chunks, vectors=vectors,
+                namespace=result.source.doc_id,
+                delete_namespace_first=rollover,
+            )
+    logfire.info("rag.ingest.done", total_upserted=total_upserted,
+                 dry_run=dry_run)
+
+
+def _build_pinecone_client(settings: RagSettings) -> object:
+    from pinecone import Pinecone  # lazy import for unit-test fakes
+    return Pinecone(api_key=settings.pinecone_api_key.get_secret_value())
+
+
+def run_ingestion(*, force_refetch: bool = False, dry_run: bool = False,
+                  refresh_urls: bool = False) -> None:
+    """Synchronous entrypoint used by ``python -m rag.ingest``."""
+    asyncio.run(_amain(
+        force_refetch=force_refetch, dry_run=dry_run,
+        refresh_urls=refresh_urls,
+    ))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Ingest TfL strategy PDFs into Pinecone via Docling."
+    )
+    parser.add_argument("--force-refetch", action="store_true",
+                        help="Ignore cached ETag/Last-Modified.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Skip the Pinecone upsert step.")
+    parser.add_argument("--refresh-urls", action="store_true",
+                        help="Re-resolve direct-PDF URLs from landing pages.")
+    args = parser.parse_args()
+    run_ingestion(
+        force_refetch=args.force_refetch, dry_run=args.dry_run,
+        refresh_urls=args.refresh_urls,
+    )
+
+
+if __name__ == "__main__":
+    main()
+```
+
+### Phase 3.8 — Tests under `tests/rag/`
+
+Layout:
+
+```
+tests/rag/
+├── __init__.py
+├── conftest.py
+├── test_sources.py
+├── test_fetch.py
+├── test_parse.py
+├── test_embed.py
+├── test_upsert.py
+└── test_ingest.py
+```
+
+`conftest.py` sets the bare-minimum env vars so `RagSettings()`
+constructs in unit tests:
+
+```python
+import os
+import pytest
+
+@pytest.fixture(autouse=True)
+def _rag_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("PINECONE_API_KEY", "pcsk-test")
+```
+
+#### `test_sources.py`
+
+1. `test_resolve_pdf_urls_picks_first_match` — `httpx.MockTransport`
+   serves a stub HTML with two PDF links; resolver returns the first
+   matching the `discovery_regex`.
+2. `test_resolve_pdf_urls_resolves_relative_href` — landing page
+   uses `<a href="/cdn/static/cms/documents/2026-business-plan-acc.pdf">`;
+   resolver returns the absolute URL.
+3. `test_resolve_pdf_urls_raises_when_no_link_matches` — HTML has no
+   PDF link; assert `PdfSourceResolutionError` carries the regex and
+   landing URL in the message.
+4. `test_load_and_write_sources_roundtrip` — `load_sources`
+   then `write_sources` to a temp path; assert file round-trips.
+
+#### `test_fetch.py`
+
+1. `test_fetch_pdfs_writes_file_and_cache_on_200` — `httpx.MockTransport`
+   returns 200 + `ETag` + `Last-Modified`; assert file written, cache
+   updated, `changed=True`, `sha256` is the digest of the bytes.
+2. `test_fetch_pdfs_skips_on_304` — pre-seed cache with last
+   ETag and an existing file; transport returns 304; assert no file
+   write, `changed=False`, `sha256` reused from cache.
+3. `test_fetch_pdfs_force_refetch_ignores_cache` — pre-seed cache;
+   transport returns 200 again; assert `If-None-Match` header *not*
+   sent on the request.
+4. `test_fetch_pdfs_propagates_404` — transport returns 404; assert
+   `httpx.HTTPStatusError` propagates (we never silently fall back).
+
+#### `test_parse.py`
+
+1. `test_parse_pdf_emits_one_chunk_per_section` — fake
+   `DocumentConverter` and fake `HybridChunker` (callables returning a
+   prefab list of objects mimicking the Docling shape with `text`,
+   `meta.headings`, `meta.doc_items[*].prov[*].page_no`); assert
+   `Chunk` count, `section_title`, `page_start`, `page_end`,
+   `chunk_index`.
+2. `test_parse_pdf_skips_empty_text_chunks` — fake produces a chunk
+   with whitespace-only text; assert it is dropped; `chunk_index`
+   gap is preserved (i.e. indices reflect the chunker's order).
+
+#### `test_embed.py`
+
+1. `test_embed_texts_batches_at_100` — fake `AsyncOpenAI` records
+   each call's `input` length; assert two calls for 150 inputs (100,
+   50).
+2. `test_embed_texts_retries_on_rate_limit` — fake raises
+   `RateLimitError` once then succeeds; assert two calls and the
+   final vectors match.
+3. `test_embed_texts_raises_after_exhaustion` — fake raises
+   `RateLimitError` `max_attempts=2` times; assert `RuntimeError`
+   wraps the last exception.
+
+#### `test_upsert.py`
+
+1. `test_vector_id_is_stable` — same `(resolved_url, chunk_index)`
+   yields same digest; different inputs differ.
+2. `test_ensure_index_skips_when_present` — fake client lists the
+   index; assert no `create_index` call.
+3. `test_ensure_index_creates_when_missing` — fake client lists `[]`;
+   assert one `create_index` call with `dimension=1536`,
+   `metric="cosine"`.
+4. `test_upsert_chunks_deletes_namespace_when_rollover` — pass
+   `delete_namespace_first=True`; assert `delete(delete_all=True,
+   namespace=...)` precedes the upsert.
+5. `test_upsert_chunks_skips_delete_when_not_rollover` — pass
+   `delete_namespace_first=False`; assert no `delete` call.
+6. `test_upsert_chunks_metadata_shape` — assert metadata dict has
+   `doc_id`, `doc_title`, `resolved_url`, `chunk_index`,
+   `section_title`, `page_start`, `page_end`, `text`; missing pages
+   coerced to `-1`.
+7. `test_upsert_chunks_batches_at_100` — 250 chunks; assert three
+   `upsert` calls (100, 100, 50).
+
+#### `test_ingest.py`
+
+1. `test_run_ingestion_end_to_end_with_fakes` — monkeypatch every
+   external client (`httpx.AsyncClient`, `AsyncOpenAI`, Pinecone
+   client, Docling converter+chunker) to deterministic fakes; run
+   `run_ingestion()`; assert one upsert per source, namespace per
+   `doc_id`, total vector count.
+2. `test_run_ingestion_dry_run_skips_upsert` — same wiring with
+   `dry_run=True`; assert no `index.upsert` call.
+3. `test_run_ingestion_rollover_triggers_namespace_delete` —
+   pre-seed `data/cache/sources_state.json` with a *different*
+   `resolved_url` for one doc; assert `delete(delete_all=True,
+   namespace=that_doc_id)` is called.
+4. `test_run_ingestion_missing_pinecone_key_exits_2` —
+   monkeypatch `PINECONE_API_KEY` to `""`; assert `SystemExit(2)`
+   (or `SystemExit` with non-zero exit code).
+
+### Phase 3.9 — `.gitignore`, README, `.env.example`
+
+`.gitignore` — append:
+
+```
+data/strategy_docs/*.pdf
+data/cache/
+```
+
+`.env.example` — `PINECONE_INDEX` already present; append a comment
+documenting the new RAG-specific defaults under the existing
+`# Vector DB` block:
+
+```
+# RAG ingestion (TM-D4)
+# PINECONE_INDEX overrides the default "tfl-strategy-docs"
+# EMBEDDING_MODEL overrides the default "text-embedding-3-small"
+EMBEDDING_MODEL=text-embedding-3-small
+```
+
+(Do not add `PINECONE_INDEX` again; already declared.)
+
+`README.md` — new "RAG ingestion" subsection under "Local
+development", placed after the existing local-dev block:
+
+```markdown
+### RAG ingestion (TM-D4)
+
+```bash
+# Run once to populate Pinecone
+uv run python -m rag.ingest
+
+# Re-resolve direct-PDF URLs from the TfL/GLA landing pages
+uv run python -m rag.ingest --refresh-urls
+
+# Bypass the ETag cache
+uv run python -m rag.ingest --force-refetch
+
+# Parse + embed only; do not upsert (sizing + smoke check)
+uv run python -m rag.ingest --dry-run
+```
+
+PDFs are fetched conditionally (`If-None-Match` / `If-Modified-Since`)
+to `data/strategy_docs/`. The first run downloads ~60 MB total. Set
+`PINECONE_API_KEY` and `OPENAI_API_KEY` in `.env`. Index name and
+embedding model can be overridden via `PINECONE_INDEX` and
+`EMBEDDING_MODEL`.
+```
+
+### Phase 3.10 — Verification gate
+
+Per napkin §Execution#5:
+
+```bash
+uv run task lint                           # ruff + format-check + mypy strict
+uv run task test                           # default suite
+uv run bandit -r src --severity-level high # HIGH only
+make check                                 # lint + test + dbt-parse + TS lint + TS build
+```
+
+All four must exit 0. `make check` already includes `dbt-parse` and
+the TS chain — no edits to those targets are required.
+
+A manual smoke against real Pinecone is documented but optional:
+
+```bash
+PINECONE_API_KEY=... OPENAI_API_KEY=... \
+  uv run python -m rag.ingest --dry-run
+```
+
+(`--dry-run` so the smoke does not pollute the user's index.)
+
+### Phase 3.11 — PR
+
+- Branch: `feature/TM-D4-rag-ingestion`
+- PR title:
+  `feat(rag): TM-D4 Docling → Pinecone RAG ingestion with auto PDF fetch (TM-17)`
+- PR body bullets:
+  - landing-page → resolved-PDF URL discovery via committed
+    `discovery_regex` per source (`src/rag/sources.json`);
+  - conditional GET (`If-None-Match` / `If-Modified-Since`) into
+    `data/strategy_docs/` with sha256 + ETag in `data/cache/sources_state.json`;
+  - Docling 2.x parse + `HybridChunker(max_tokens=512,
+    merge_peers=True)`;
+  - OpenAI `text-embedding-3-small` async batching (100/req, 5
+    attempts on `RateLimitError`);
+  - Pinecone serverless `tfl-strategy-docs` (cosine, 1536), one
+    namespace per `doc_id`, stable id =
+    `sha256("{resolved_url}::{chunk_index}").hexdigest()`,
+    delete-namespace-on-rollover idempotency;
+  - CLI flags `--refresh-urls`, `--force-refetch`, `--dry-run`;
+  - fail-loud on missing `PINECONE_API_KEY` / `OPENAI_API_KEY`
+    (`SystemExit(2)`);
+  - `.gitignore` extends with `data/strategy_docs/*.pdf` +
+    `data/cache/`;
+  - README "RAG ingestion" section.
+- **Out of scope** — TM-D5 retrieval, TM-A2 Airflow DAG.
+- **Closes TM-17.**
+
+## Success criteria
+
+- [ ] `src/rag/__init__.py`, `config.py`, `sources.py`, `fetch.py`,
+  `parse.py`, `embed.py`, `upsert.py`, `ingest.py` created and
+  importable.
+- [ ] `src/rag/sources.json` committed with the three TfL sources and
+  validated by `PdfSource.model_validate`.
+- [ ] `data/strategy_docs/`, `data/cache/` excluded from git.
+- [ ] `python -m rag.ingest --dry-run` succeeds end-to-end against
+  real Pinecone (manual smoke, documented; not required in CI).
+- [ ] Conditional GET path verified (re-running after first run
+  returns `changed=False` for unchanged docs).
+- [ ] All seven unit-test files under `tests/rag/` cover the
+  scenarios listed in Phase 3.8.
+- [ ] `uv run task lint` passes (ruff + mypy strict on new modules).
+- [ ] `uv run task test` passes.
+- [ ] `uv run bandit -r src --severity-level high` reports zero
+  findings.
+- [ ] `make check` passes end-to-end.
+- [ ] README "RAG ingestion" section landed.
+- [ ] `.env.example` extended with `EMBEDDING_MODEL` (PINECONE_INDEX
+  already present).
+- [ ] `PROGRESS.md` TM-D4 row updated to ✅ with completion date.
+- [ ] PR opened on branch `feature/TM-D4-rag-ingestion` with
+  `Closes TM-17` in body.
+- [ ] Linear TM-17 transitions to Done on merge.
+
+## Open questions (resolved during planning)
+
+All ten Q1-Q10 from `TM-D4-research.md` resolved as the recommended
+defaults. No author callout was raised in the research file; if real
+PDF parsing surfaces a Docling oddity (e.g. `meta.headings` shape
+differs from the doc), Phase 3 will course-correct and STOP per
+CLAUDE.md §"Phase approach": "Expected: X. Found: Y. How should I
+proceed?"
+
+## References
+
+- `.claude/specs/TM-D4-research.md` — surface map and open questions.
+- `CLAUDE.md` — §"Tech stack", §"Principle #1", §"Pydantic usage",
+  §"Observability architecture", §"Security-first".
+- `AGENTS.md` — §1 track inventory.
+- `pyproject.toml` — pins `docling`, `pinecone`, `openai`,
+  `pydantic-settings`, `httpx`, `logfire`.
+- `src/ingestion/tfl_client/retry.py` — pattern for the OpenAI retry
+  loop.
+- `src/ingestion/observability.py` — pattern for the RAG Logfire
+  helper (kept inline in `ingest.py` here because it is the sole
+  ingestion-style entrypoint in the package).
+- Pinecone Python client v5 docs (consulted via context7 at
+  implementation time).
+- Docling 2.x docs — `docling.chunking.HybridChunker`,
+  `docling.document_converter.DocumentConverter`.

--- a/.claude/specs/TM-D4-research.md
+++ b/.claude/specs/TM-D4-research.md
@@ -1,0 +1,276 @@
+# TM-D4 — Research (Phase 1)
+
+Read-only exploration that frames the RAG ingestion WP. Captures the
+state of the repo, the canonical URLs of the three TfL strategy PDFs,
+the chunking and idempotency design, and the Pinecone index spec. No
+code changes proposed here — see `TM-D4-plan.md` for the build plan.
+
+## 1. Where TM-D4 sits in the codebase
+
+- **PROGRESS.md row:** Phase 5, track `D-api-agent`, blocked by TM-000
+  only (per Linear, no upstream WP needed). Sibling Phase-3 D-track WP
+  TM-D2 is independent.
+- **Linear issue:** `TM-17`. PR will close it.
+- **No prior `src/rag/` directory.** `src/agent/{graph.py,observability.py}`
+  are TM-D1 stubs — they only validate `LANGSMITH_*` env. The real
+  agent (TM-D5) consumes the index this WP produces.
+- **Tech-stack reminder (CLAUDE.md):** Docling 2.x for PDF parse,
+  OpenAI `text-embedding-3-small` (1536 dim), Pinecone serverless,
+  LlamaIndex permitted but skip if Docling alone suffices.
+- **Lean discipline (CLAUDE.md Principle #1):** rule 4 (no factory
+  without two consumers), rule 5 (no nested `BaseSettings` unless ≥15
+  vars). RAG settings will sit in a single `Settings(BaseSettings)`
+  with three fields plus a Pinecone index name and embedding model
+  string — five env vars, well under the threshold.
+
+## 2. Canonical PDF URLs (verified 2026-04-28)
+
+Resolved live via WebFetch + `curl -I` (full HTTP HEAD response). Each
+landing page is HTML; the direct PDFs sit on `content.tfl.gov.uk` (302
+redirect from the `tfl.gov.uk/cdn/...` aliases) or
+`www.london.gov.uk/sites/default/files/...`.
+
+| name              | doc_id                 | landing_url                                                                                                | resolved_url (final after redirects)                                                                  | size   | last-modified                | etag                                       |
+|-------------------|------------------------|------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|--------|------------------------------|---------------------------------------------|
+| TfL Business Plan | `tfl_business_plan`    | `https://tfl.gov.uk/corporate/publications-and-reports/business-plan`                                      | `https://content.tfl.gov.uk/2026-business-plan-acc.pdf`                                                | 12.18 MB | Fri, 06 Feb 2026 13:33:35 GMT | `"26f28a9e4a7081b2be321dfad793bc98-2"`     |
+| Mayor's Transport Strategy | `mts_2018`    | `https://www.london.gov.uk/programmes-strategies/transport/our-vision-transport/mayors-transport-strategy-2018` | `https://www.london.gov.uk/sites/default/files/mayors-transport-strategy-2018.pdf`                | 22.68 MB | Fri, 09 Sep 2022 19:48:36 GMT | `"631b9894-15a1d3b"`                        |
+| TfL Annual Report | `tfl_annual_report`    | `https://tfl.gov.uk/corporate/publications-and-reports/annual-report`                                      | `https://content.tfl.gov.uk/tfl-annual-report-and-statement-of-accounts-2024-25.pdf`                  | 25.94 MB | Fri, 26 Sep 2025 12:42:16 GMT | `"cb73f493a2554cdbd378d3569dba7a53-4"`     |
+
+**Note on the MTS landing page:** the briefing's URL
+`https://www.london.gov.uk/programmes-strategies/transport/mayors-transport-strategy-2018`
+returns 404. The current canonical landing is under
+`/our-vision-transport/...`. Spec uses the corrected path.
+
+### URL stability and resolution strategy
+
+- **TfL URLs rotate annually.** The 2026 Business Plan replaces the
+  2025 one at the same landing page; the URL stub embeds the year
+  (`2026-business-plan-acc.pdf`). The Annual Report follows the same
+  pattern (`tfl-annual-report-and-statement-of-accounts-2024-25.pdf`).
+- **MTS URL is stable** (single document published 2018; not annually
+  refreshed).
+- **Resolution algorithm:** scrape the landing HTML for the first
+  `<a href="...pdf">` whose URL stem matches a per-doc allowlist regex
+  (e.g. `business-plan` for TfL Business Plan). Hosts can return
+  relative URLs (`/cdn/static/cms/documents/...`); we resolve against
+  the landing-page origin.
+- **Fallback:** if the regex finds no match (TfL changes the link
+  text), the resolver raises a clear error with the landing URL and
+  the regex that failed; we never silently fall back to a stale URL.
+
+### Conditional GET strategy
+
+- Send `If-None-Match: <cached etag>` and `If-Modified-Since: <cached
+  last-modified>` on the resolved URL.
+- `200` → new content, write to `data/strategy_docs/<doc_id>.pdf`,
+  update cache.
+- `304` → unchanged, skip; orchestrator emits a `rag.fetch.unchanged`
+  Logfire span.
+- `404`/`410` → propagate as a hard error and abort the run; the
+  upstream landing page gave us a stale `resolved_url` and we need to
+  re-resolve from the landing page.
+
+## 3. Chunking strategy
+
+Docling 2.x ships its own chunker; LlamaIndex would add a layer with
+no value here.
+
+- **Parser:** `docling.document_converter.DocumentConverter().convert(path)`
+  returns a `DoclingDocument`. Built-in OCR+layout pipeline handles
+  the TfL PDFs without custom config.
+- **Chunker:** `docling.chunking.HybridChunker(tokenizer=<openai>,
+  max_tokens=512, merge_peers=True)`. The hybrid chunker first
+  segments by document hierarchy (headings/sections/paragraphs) and
+  then merges sibling chunks under the token cap, preserving section
+  boundaries when possible. Output: an iterable of `DocChunk` objects
+  with `text`, `meta` (`headings`, `doc_items`, page numbers via
+  bounding-box prov data).
+- **Token target:** 512 tokens with `merge_peers=True` is Docling's
+  documented default for retrieval; it sits comfortably under
+  `text-embedding-3-small`'s 8191-token input cap and gives ~10 chunks
+  per page on dense reports — appropriate granularity for
+  question-level retrieval.
+- **Per-chunk metadata** (carried into Pinecone):
+  - `doc_id`: stable string (`tfl_business_plan`, `mts_2018`,
+    `tfl_annual_report`)
+  - `doc_title`: human-readable
+  - `resolved_url`: PDF URL at ingestion time (auditing)
+  - `section_title`: first heading in the chunk's `meta.headings`
+    (string; `""` if none)
+  - `page_start`, `page_end`: int derived from `meta.doc_items[*].prov`
+    bbox `page_no`; `None` if missing
+  - `text`: chunk text (also stored as Pinecone vector value via the
+    `metadata.text` convention used by LangChain/LlamaIndex retrievers
+    for citation rendering — keeps TM-D5 free of a second SQL/JSON
+    fetch step)
+
+### Why not LlamaIndex
+
+- Pinecone's Python client v5 has direct `index.upsert(vectors=[...])`.
+- OpenAI's async client handles batched embeddings without a wrapper.
+- Docling already exposes structured chunks with metadata.
+
+Adding LlamaIndex would mean threading three abstractions (Document,
+TextSplitter, VectorStore) for code that fits in ~100 lines of direct
+Pydantic-validated logic. Defer LlamaIndex to TM-D5 (retrieval), where
+the framework's reranking helpers earn their place.
+
+## 4. Embedding strategy
+
+- **Model:** `text-embedding-3-small`, 1536 dimensions. CLAUDE.md
+  tech-stack and pyproject already pin OpenAI ≥1.54.
+- **Batch size:** 100 inputs per request. The async OpenAI client
+  awaits a single coroutine per batch.
+- **Retry:** mirror `src/ingestion/tfl_client/retry.py` —
+  exponential backoff on `openai.RateLimitError` (HTTP 429) and
+  `openai.APIConnectionError` / `openai.APITimeoutError`. 5 attempts
+  capped at 10 s. Fast-fail on `openai.AuthenticationError` (no key).
+- **Concurrency:** 3 in-flight batches (`asyncio.Semaphore(3)`). With
+  `n=100/batch`, each PDF fits in ≤25 batches — with concurrency 3, a
+  full run is sub-minute.
+
+## 5. Pinecone index spec and idempotency
+
+- **Index name:** `tfl-strategy-docs` (overrideable via
+  `PINECONE_INDEX`).
+- **Dimensions:** 1536 (matches embedding model).
+- **Metric:** `cosine` (OpenAI embeddings are unit-normalised; cosine
+  = dot product up to scale and is the standard for `text-embedding-3-*`).
+- **Capacity:** serverless — `cloud="aws"`, `region="us-east-1"` (the
+  Pinecone serverless free-tier default and lowest-latency for
+  US-region OpenAI).
+- **Bootstrap:** ingestion creates the index if absent
+  (`pc.create_index(name=..., dimension=1536, metric="cosine",
+  spec=ServerlessSpec(...))`). Idempotent: `pc.list_indexes()` first.
+
+### Vector id strategy
+
+- **Id format per task brief:**
+  `sha256(f"{resolved_url}::{chunk_index}").hexdigest()` — full 64-hex
+  string. Stable for a given (URL, chunk_index) pair, so re-ingesting
+  the same PDF version overwrites in place.
+- **Namespace per doc_id:** `tfl_business_plan`, `mts_2018`,
+  `tfl_annual_report`. Three namespaces in one index.
+- **Stale-vector cleanup:** when a re-ingest fetches a *different*
+  `resolved_url` for the same `doc_id` (year rolled over), delete the
+  namespace before upserting:
+  `index.delete(delete_all=True, namespace=doc_id)`. Pinecone
+  serverless supports `delete_all=True` per-namespace on free tier.
+- **Idempotency end-to-end:** `--force-refetch` re-downloads even on
+  304; the deterministic id ensures no duplicates pile up.
+
+## 6. Failure model and `--dry-run`
+
+- **`--dry-run`** runs fetch + parse + chunk + embed and prints
+  per-doc summary (`chunks=N`, `tokens≈N`, `vectors_to_upsert=N`)
+  without calling `index.upsert`. Useful for the author to size the
+  payload before the first prod run.
+- **`--force-refetch`** ignores the cached ETag and downloads
+  unconditionally. Useful when the cache is corrupt or when adding a
+  new doc and we want to verify the discovery rule.
+- **Missing `PINECONE_API_KEY`:** fail loud with a clear message and
+  exit 2. Matches the briefing's hard rule "fail loud … never silently
+  succeed".
+- **Missing `OPENAI_API_KEY`:** same — exit 2.
+- **Pinecone index missing and create fails:** propagate the SDK
+  error; do not silently skip.
+
+## 7. State at rest
+
+| Path                                     | Status      | Contents                                                                                  |
+|------------------------------------------|-------------|--------------------------------------------------------------------------------------------|
+| `src/rag/sources.json`                   | committed   | List of `{name, doc_id, landing_url, resolved_url, discovery_regex}` — one entry per PDF. |
+| `data/strategy_docs/<doc_id>.pdf`        | gitignored  | Last-fetched PDF bytes.                                                                    |
+| `data/cache/sources_state.json`          | gitignored  | Per-`doc_id`: `{resolved_url, etag, last_modified, sha256, fetched_at}`.                  |
+
+`resolved_url` is committed in `sources.json` so anyone cloning the
+repo can reproduce; it gets refreshed when `--refresh-urls` is
+supplied. ETag/Last-Modified live in `data/cache/` because they are
+runtime state, not config (CLAUDE.md §"Pydantic usage conventions" —
+config crosses git, state does not).
+
+## 8. Test strategy
+
+- **Unit (`tests/rag/`):**
+  - `test_sources.py` — discovery regex parses representative TfL
+    HTML snippets, including the rotating-year Business Plan link.
+    Failure case: no PDF link found raises with a clear error.
+  - `test_fetch.py` — `httpx.MockTransport`: 200 → write file +
+    update cache; 304 → no write, log unchanged; 404 → raise.
+    `--force-refetch` ignores cached headers.
+  - `test_parse.py` — fake `DocumentConverter` returns a small
+    `DoclingDocument` with two sections; assert chunk metadata
+    (`doc_id`, `section_title`, page numbers).
+  - `test_embed.py` — fake OpenAI client returns deterministic 1536
+    -dim vectors per input; assert batch grouping and retry on a
+    one-off `RateLimitError`.
+  - `test_upsert.py` — fake Pinecone client; assert `delete(delete_all
+    =True, namespace=doc_id)` is called when `resolved_url` changed,
+    not called otherwise; assert `upsert(vectors=...,
+    namespace=doc_id)` payload shape and id format.
+  - `test_ingest_orchestrator.py` — wire all fakes; assert end-to-end
+    flow under `--dry-run` (no upsert call) and under normal run
+    (one upsert per non-empty doc).
+- **Integration:** none on CI. Real Pinecone upsert is gated behind
+  `PINECONE_API_KEY`; absence skips the integration test (mirrors
+  `DATABASE_URL` gate in `tests/ingestion/integration/`).
+- **Real PDF parse:** Docling is heavy; default suite uses fakes.
+  A `pytest.mark.integration` test under `tests/rag/integration/`
+  parses a tiny stub PDF (`tests/fixtures/rag/sample.pdf`, 1 page,
+  committed once) — exercises the real Docling pipeline without
+  hitting the 25 MB Annual Report. Skipped under default
+  `pyproject.toml` `addopts = "-m 'not integration'"`.
+
+## 9. Open questions to resolve in the plan
+
+1. **Q1 — Sidecar split.** Commit `resolved_url` in
+   `src/rag/sources.json`, ETag/Last-Modified/sha256 in
+   `data/cache/sources_state.json`. Confirms the briefing's hint.
+2. **Q2 — Discovery regex per doc.** Per-doc allowlist regex stored in
+   `sources.json` (`discovery_regex` field). Resolver picks the first
+   `<a href>` whose absolute URL matches. Avoids fragile string
+   matching on link text.
+3. **Q3 — Chunk size.** 512 tokens, `merge_peers=True`. Defaults to
+   Docling's documented retrieval target. Open to revisiting in TM-D5
+   based on retrieval quality.
+4. **Q4 — Concurrency.** `asyncio.Semaphore(3)` for OpenAI batches.
+   No concurrency between docs — three PDFs is small and serial keeps
+   the trace timeline readable in Logfire/LangSmith.
+5. **Q5 — Pinecone namespace per doc_id.** Yes — clean delete-by-namespace
+   on year-roll, no metadata-filter-delete dependency (which Pinecone
+   serverless free tier does not expose).
+6. **Q6 — Index bootstrap.** Idempotent `create_index` on every run;
+   `list_indexes()` short-circuits when present.
+7. **Q7 — `--dry-run` vs `--force-refetch` interaction.**
+   `--dry-run --force-refetch` re-downloads the PDF (testing fetch
+   path) but stops before upsert. Documented in `--help`.
+8. **Q8 — Logfire spans.** `rag.fetch`, `rag.parse`, `rag.embed`,
+   `rag.upsert`, `rag.ingest.cycle` (top-level). `service_name =
+   "tfl-monitor-rag-ingestion"`. Reuses `LOGFIRE_TOKEN` env (no new
+   var).
+9. **Q9 — `make check` impact.** `uv run task lint` and `uv run task
+   test` already cover `src/`. No new Make target needed; ingestion
+   runs via `uv run python -m rag.ingest`.
+10. **Q10 — Bandit.** Subprocess and HTTP usage trigger no HIGH-severity
+    findings on the planned code shape (no `shell=True`, no string
+    interpolation in SQL, parameterised httpx calls only).
+
+## 10. References
+
+- CLAUDE.md §"Tech stack", §"Principle #1", §"Pydantic usage
+  conventions", §"Observability architecture".
+- AGENTS.md §1 (track inventory — `src/` is in scope).
+- `pyproject.toml` — `pinecone>=5.0`, `docling>=2.0`, `openai>=1.54`,
+  `httpx>=0.28`, `pydantic>=2.9`, `pydantic-settings>=2.6` already
+  pinned. No new dependency.
+- `src/ingestion/tfl_client/retry.py` — pattern for the OpenAI retry
+  helper.
+- `src/ingestion/observability.py` — pattern for the RAG Logfire
+  helper.
+- Docling docs (consulted at plan time):
+  `https://github.com/DS4SD/docling`, chunking module:
+  `docling.chunking.HybridChunker`.
+- Pinecone Python client v5 docs:
+  `https://docs.pinecone.io/reference/python-client`.
+- Live HEAD probes captured 2026-04-28 in this WP's `curl -I`
+  transcript (above table).

--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,10 @@ OPENAI_API_KEY=your_openai_key_here
 
 # Vector DB
 PINECONE_API_KEY=your_pinecone_key_here
-PINECONE_INDEX=tfl-monitor
+PINECONE_INDEX=tfl-strategy-docs
+
+# RAG ingestion (TM-D4)
+EMBEDDING_MODEL=text-embedding-3-small
 
 # LangSmith observability
 LANGSMITH_TRACING=true

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ dbt/.user.yml
 # Next.js
 web/.next/
 web/out/
+
+# RAG ingestion artefacts (TM-D4)
+data/strategy_docs/*.pdf
+data/cache/

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -20,7 +20,7 @@ Current state of work packages. Update the status column as WPs land.
 | 4 | TM-D3 | Remaining endpoints | D-api-agent | ⬜ | |
 | 4 | TM-E2 | Disruption Log view | E-frontend | ⬜ | |
 | 5 | TM-A2 | Airflow DAGs | A-infra | ⬜ | |
-| 5 | TM-D4 | RAG ingestion: Docling → Pinecone | D-api-agent | ⬜ | |
+| 5 | TM-D4 | RAG ingestion: Docling → Pinecone | D-api-agent | ✅ 2026-04-28 | `src/rag/` package: `sources.py` resolves the direct-PDF URL on each landing page (3 TfL strategy docs) via per-source allowlist regex; `fetch.py` does conditional GET (`If-None-Match` + `If-Modified-Since`) into `data/strategy_docs/`; `parse.py` wraps Docling 2.x `DocumentConverter` + `HybridChunker` (library defaults; the Docling 2.x constructor derives chunk size from its tokenizer); `embed.py` async-batches OpenAI `text-embedding-3-small` (100/req, retry on 429); `upsert.py` Pinecone serverless `tfl-strategy-docs` (1536 dim, cosine, AWS us-east-1), one namespace per `doc_id`, stable id = `sha256("{resolved_url}::{chunk_index}")`, delete-namespace-on-rollover idempotency; `ingest.py` orchestrator with `--refresh-urls`, `--force-refetch`, `--dry-run` flags, fail-loud on missing `PINECONE_API_KEY`/`OPENAI_API_KEY`. 28 unit tests with fakes for httpx/Docling/OpenAI/Pinecone. |
 | 6 | TM-D5 | LangGraph agent (SQL + RAG + Pydantic AI) | D-api-agent | ⬜ | |
 | 6 | TM-E3 | Chat view with SSE | E-frontend | ⬜ | |
 | 7 | TM-A3 | Supabase provisioning | A-infra | ⬜ | |

--- a/README.md
+++ b/README.md
@@ -155,23 +155,38 @@ Bring it all down with `make down` (preserves data) or `make clean` (wipes volum
 
 ### RAG ingestion (TM-D4)
 
-Three TfL strategy PDFs (Business Plan, Mayor's Transport Strategy 2018, Annual Report) are fetched, parsed via Docling, embedded with OpenAI `text-embedding-3-small`, and upserted into the Pinecone serverless index `tfl-strategy-docs`. The fetcher follows landing pages on `tfl.gov.uk` and `london.gov.uk` to discover the current direct-PDF URL, then issues conditional `If-None-Match` / `If-Modified-Since` requests so re-runs only download what has changed.
+Three TfL strategy PDFs are fetched, parsed via Docling, embedded with OpenAI `text-embedding-3-small`, and upserted into the Pinecone serverless index `tfl-strategy-docs`. The fetcher follows the canonical landing pages to discover the current direct-PDF URL, then issues conditional `If-None-Match` / `If-Modified-Since` requests so re-runs only download what has changed.
+
+The three documents and their canonical landing pages (cite these, not the resolved CDN URLs):
+
+- [TfL Business Plan](https://tfl.gov.uk/corporate/publications-and-reports/business-plan)
+- [Mayor's Transport Strategy 2018](https://www.london.gov.uk/programmes-strategies/transport/our-vision-transport/mayors-transport-strategy-2018)
+- [TfL Annual Report and Statement of Accounts](https://tfl.gov.uk/corporate/publications-and-reports/annual-report)
+
+PDFs are TfL / GLA public publications used per their published terms. tfl-monitor stores a local copy under `data/strategy_docs/` (gitignored) for reproducibility but does not redistribute the PDFs.
 
 ```bash
 # Run once to populate Pinecone (requires PINECONE_API_KEY + OPENAI_API_KEY in .env)
 uv run python -m rag.ingest
 
-# Re-resolve direct-PDF URLs from the TfL/GLA landing pages and rewrite src/rag/sources.json
+# Re-scrape each landing page and rewrite the resolved direct-PDF URL in
+# src/rag/sources.json. Use this when TfL rolls the annual URL stem
+# (e.g. business-plan-2026 → business-plan-2027). The download is still
+# conditional via ETag — unchanged PDFs are 304'd.
 uv run python -m rag.ingest --refresh-urls
 
 # Bypass the ETag cache and re-download every PDF
 uv run python -m rag.ingest --force-refetch
 
-# Parse + embed only; skip the Pinecone upsert (sizing + smoke check)
+# Run fetch + parse + embed but skip the Pinecone upsert (sizing + smoke check)
 uv run python -m rag.ingest --dry-run
 ```
 
-PDFs cache under `data/strategy_docs/` (gitignored). ETag/sha256 state lives in `data/cache/sources_state.json` (also gitignored). The first run downloads ~60 MB total; subsequent runs typically skip every doc unless TfL has published a new version.
+If 1 of 3 documents fails its fetch / parse / embed / upsert cycle, the others still complete; the CLI then exits with a non-zero status so any future cron / GitHub Action surfaces the failure instead of swallowing it.
+
+PDFs cache under `data/strategy_docs/` (gitignored). ETag / sha256 state lives in `data/cache/sources_state.json` (also gitignored). The first run downloads ~60 MB total; subsequent runs typically skip every doc unless TfL has published a new version.
+
+**Cost estimate.** A full re-embedding of all three PDFs runs at well under £0.20 one-time at the current `text-embedding-3-small` price ($0.02 per 1M tokens). Conditional GETs and stable Pinecone ids mean steady-state runs incur near-zero embedding spend.
 
 ## Status — work packages
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,26 @@ OpenAPI contract.
 
 Bring it all down with `make down` (preserves data) or `make clean` (wipes volumes).
 
+### RAG ingestion (TM-D4)
+
+Three TfL strategy PDFs (Business Plan, Mayor's Transport Strategy 2018, Annual Report) are fetched, parsed via Docling, embedded with OpenAI `text-embedding-3-small`, and upserted into the Pinecone serverless index `tfl-strategy-docs`. The fetcher follows landing pages on `tfl.gov.uk` and `london.gov.uk` to discover the current direct-PDF URL, then issues conditional `If-None-Match` / `If-Modified-Since` requests so re-runs only download what has changed.
+
+```bash
+# Run once to populate Pinecone (requires PINECONE_API_KEY + OPENAI_API_KEY in .env)
+uv run python -m rag.ingest
+
+# Re-resolve direct-PDF URLs from the TfL/GLA landing pages and rewrite src/rag/sources.json
+uv run python -m rag.ingest --refresh-urls
+
+# Bypass the ETag cache and re-download every PDF
+uv run python -m rag.ingest --force-refetch
+
+# Parse + embed only; skip the Pinecone upsert (sizing + smoke check)
+uv run python -m rag.ingest --dry-run
+```
+
+PDFs cache under `data/strategy_docs/` (gitignored). ETag/sha256 state lives in `data/cache/sources_state.json` (also gitignored). The first run downloads ~60 MB total; subsequent runs typically skip every doc unless TfL has published a new version.
+
 ## Status — work packages
 
 Project built as WPs organised into parallel tracks. Track labels indicate which directories a WP touches, so at most 2 agents work simultaneously without collision.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/ingestion", "src/api", "src/agent", "contracts"]
+packages = ["src/ingestion", "src/api", "src/agent", "src/rag", "contracts"]
 
 [tool.ruff]
 line-length = 100
@@ -58,6 +58,11 @@ exclude = ["scripts/"]
 
 [[tool.mypy.overrides]]
 module = ["aiokafka", "aiokafka.*"]
+ignore_missing_imports = true
+follow_untyped_imports = true
+
+[[tool.mypy.overrides]]
+module = ["docling", "docling.*", "pinecone", "pinecone.*"]
 ignore_missing_imports = true
 follow_untyped_imports = true
 

--- a/src/rag/__init__.py
+++ b/src/rag/__init__.py
@@ -1,0 +1,6 @@
+"""RAG ingestion package: TfL strategy PDFs → Docling → Pinecone."""
+
+from rag.config import RagSettings, load_settings
+from rag.ingest import run_ingestion
+
+__all__ = ["RagSettings", "load_settings", "run_ingestion"]

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -8,6 +8,8 @@ defaults used by :mod:`rag.ingest`. Five fields total — well under the
 
 from __future__ import annotations
 
+import sys
+
 from pydantic import SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -41,4 +43,5 @@ def load_settings() -> RagSettings:
     try:
         return RagSettings()  # type: ignore[call-arg]
     except Exception as exc:  # noqa: BLE001 - boundary
-        raise SystemExit(f"RAG settings missing or invalid: {exc!s}") from None
+        sys.stderr.write(f"RAG settings missing or invalid: {exc!s}\n")
+        raise SystemExit(2) from None

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -1,0 +1,44 @@
+"""Pydantic settings for RAG ingestion.
+
+Loads OpenAI + Pinecone credentials and the index/embedding-model
+defaults used by :mod:`rag.ingest`. Five fields total — well under the
+≥15 trigger that would justify nested ``BaseSettings`` (CLAUDE.md
+§"Principle #1" rule 5).
+"""
+
+from __future__ import annotations
+
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_PINECONE_INDEX = "tfl-strategy-docs"
+DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
+EMBEDDING_DIMENSIONS = 1536
+DEFAULT_PINECONE_CLOUD = "aws"
+DEFAULT_PINECONE_REGION = "us-east-1"
+
+
+class RagSettings(BaseSettings):
+    """RAG ingestion configuration loaded from the process environment."""
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    openai_api_key: SecretStr
+    pinecone_api_key: SecretStr
+    pinecone_index: str = DEFAULT_PINECONE_INDEX
+    embedding_model: str = DEFAULT_EMBEDDING_MODEL
+    pinecone_cloud: str = DEFAULT_PINECONE_CLOUD
+    pinecone_region: str = DEFAULT_PINECONE_REGION
+
+
+def load_settings() -> RagSettings:
+    """Load and validate :class:`RagSettings` from the environment.
+
+    Raises:
+        SystemExit: ``code=2`` when required secrets are missing or
+            malformed. Fail-loud per the TM-D4 briefing.
+    """
+    try:
+        return RagSettings()  # type: ignore[call-arg]
+    except Exception as exc:  # noqa: BLE001 - boundary
+        raise SystemExit(f"RAG settings missing or invalid: {exc!s}") from None

--- a/src/rag/embed.py
+++ b/src/rag/embed.py
@@ -1,0 +1,91 @@
+"""Async OpenAI embeddings with batching and 429-aware retry.
+
+Mirrors the retry shape of :mod:`ingestion.tfl_client.retry`: bounded
+attempts with exponential backoff (capped at 10 s). Distinct from the
+TfL retry helper because the OpenAI exception hierarchy is different
+and a shared abstraction would be premature (CLAUDE.md §"Principle #1"
+rule 4).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from typing import Any, Protocol
+
+import logfire
+from openai import APIConnectionError, APITimeoutError, AsyncOpenAI, RateLimitError
+
+DEFAULT_BATCH_SIZE = 100
+DEFAULT_MAX_ATTEMPTS = 5
+_BASE_BACKOFF_SECONDS = 0.5
+_MAX_BACKOFF_SECONDS = 10.0
+
+
+class EmbeddingClientError(RuntimeError):
+    """Raised when every embedding attempt for a batch fails."""
+
+
+class _EmbeddingsAPI(Protocol):
+    async def create(self, *, model: str, input: list[str]) -> Any: ...
+
+
+class _AsyncOpenAILike(Protocol):
+    embeddings: _EmbeddingsAPI
+
+
+def _exponential_backoff(attempt: int) -> float:
+    delay: float = _BASE_BACKOFF_SECONDS * (2**attempt)
+    return min(delay, _MAX_BACKOFF_SECONDS)
+
+
+async def embed_texts(
+    texts: Sequence[str],
+    *,
+    client: AsyncOpenAI | _AsyncOpenAILike,
+    model: str,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> list[list[float]]:
+    """Embed ``texts`` in batches; return one vector per input."""
+    if batch_size < 1:
+        raise ValueError("batch_size must be >= 1")
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+
+    vectors: list[list[float]] = []
+    for start in range(0, len(texts), batch_size):
+        batch = list(texts[start : start + batch_size])
+        with logfire.span(
+            "rag.embed",
+            model=model,
+            n_inputs=len(batch),
+            batch_index=start // batch_size,
+        ):
+            response = await _embed_batch_with_retry(
+                batch,
+                client=client,
+                model=model,
+                max_attempts=max_attempts,
+            )
+        vectors.extend([list(item.embedding) for item in response.data])
+    return vectors
+
+
+async def _embed_batch_with_retry(
+    batch: list[str],
+    *,
+    client: AsyncOpenAI | _AsyncOpenAILike,
+    model: str,
+    max_attempts: int,
+) -> Any:
+    last_exc: Exception | None = None
+    for attempt in range(max_attempts):
+        try:
+            return await client.embeddings.create(model=model, input=batch)
+        except (RateLimitError, APIConnectionError, APITimeoutError) as exc:
+            last_exc = exc
+            if attempt == max_attempts - 1:
+                break
+            await asyncio.sleep(_exponential_backoff(attempt))
+    raise EmbeddingClientError(f"OpenAI embed failed after {max_attempts} attempts: {last_exc!r}")

--- a/src/rag/fetch.py
+++ b/src/rag/fetch.py
@@ -1,0 +1,169 @@
+"""Conditional download of resolved TfL PDFs to ``data/strategy_docs/``.
+
+Each fetch sends ``If-None-Match`` and ``If-Modified-Since`` from the
+sidecar cache (``data/cache/sources_state.json``). HTTP 304 short-circuits
+without writing the file; HTTP 200 writes the bytes and refreshes the
+cache. HTTP 4xx/5xx propagates — we never silently fall back to a stale
+cache when the upstream URL has gone bad.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+import logfire
+from pydantic import BaseModel
+
+from rag.sources import PdfSource
+
+DEFAULT_DATA_DIR = Path("data/strategy_docs")
+DEFAULT_CACHE_PATH = Path("data/cache/sources_state.json")
+
+
+class FetchResult(BaseModel):
+    """Outcome of fetching a single :class:`PdfSource`."""
+
+    source: PdfSource
+    local_path: Path
+    changed: bool
+    sha256: str
+    etag: str | None
+    last_modified: str | None
+
+
+def load_cache(path: Path) -> dict[str, dict[str, str]]:
+    """Read the sidecar cache; missing file yields an empty mapping."""
+    if not path.exists():
+        return {}
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        return {}
+    cleaned: dict[str, dict[str, str]] = {}
+    for doc_id, entry in raw.items():
+        if isinstance(doc_id, str) and isinstance(entry, dict):
+            cleaned[doc_id] = {str(key): str(value) for key, value in entry.items()}
+    return cleaned
+
+
+def write_cache(path: Path, state: dict[str, dict[str, str]]) -> None:
+    """Persist the sidecar cache as JSON, parents created on demand."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(state, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+async def fetch_pdfs(
+    sources: list[PdfSource],
+    *,
+    client: httpx.AsyncClient,
+    data_dir: Path = DEFAULT_DATA_DIR,
+    cache_path: Path = DEFAULT_CACHE_PATH,
+    force_refetch: bool = False,
+) -> list[FetchResult]:
+    """Conditionally download every source to ``data_dir``.
+
+    Args:
+        sources: Sources whose ``resolved_url`` is already populated.
+        client: Shared async HTTP client.
+        data_dir: Where to write the downloaded PDFs.
+        cache_path: Sidecar cache location.
+        force_refetch: When ``True`` ignores cached headers.
+
+    Returns:
+        One :class:`FetchResult` per source. ``changed=True`` means the
+        bytes were rewritten (HTTP 200); ``False`` means the cached
+        copy is still authoritative (HTTP 304).
+    """
+    data_dir.mkdir(parents=True, exist_ok=True)
+    state = load_cache(cache_path)
+    results: list[FetchResult] = []
+    for source in sources:
+        result = await _fetch_one(
+            source,
+            client=client,
+            data_dir=data_dir,
+            cached=state.get(source.doc_id, {}),
+            force_refetch=force_refetch,
+        )
+        results.append(result)
+    state.update(
+        {
+            r.source.doc_id: {
+                "resolved_url": str(r.source.resolved_url),
+                "etag": r.etag or "",
+                "last_modified": r.last_modified or "",
+                "sha256": r.sha256,
+                "fetched_at": datetime.now(UTC).isoformat(),
+            }
+            for r in results
+        }
+    )
+    write_cache(cache_path, state)
+    return results
+
+
+async def _fetch_one(
+    source: PdfSource,
+    *,
+    client: httpx.AsyncClient,
+    data_dir: Path,
+    cached: dict[str, str],
+    force_refetch: bool,
+) -> FetchResult:
+    if source.resolved_url is None:
+        raise RuntimeError(f"Source {source.doc_id!r} has no resolved_url")
+
+    target = data_dir / f"{source.doc_id}.pdf"
+    headers: dict[str, str] = {}
+    if not force_refetch and cached:
+        cached_etag = cached.get("etag", "")
+        cached_lm = cached.get("last_modified", "")
+        if cached_etag:
+            headers["If-None-Match"] = cached_etag
+        if cached_lm:
+            headers["If-Modified-Since"] = cached_lm
+
+    with logfire.span(
+        "rag.fetch",
+        doc_id=source.doc_id,
+        url=str(source.resolved_url),
+        force_refetch=force_refetch,
+    ):
+        response = await client.get(
+            str(source.resolved_url),
+            headers=headers,
+            follow_redirects=True,
+        )
+        if response.status_code == 304 and target.exists():
+            sha = cached.get("sha256") or _sha256_of(target)
+            return FetchResult(
+                source=source,
+                local_path=target,
+                changed=False,
+                sha256=sha,
+                etag=cached.get("etag") or None,
+                last_modified=cached.get("last_modified") or None,
+            )
+        response.raise_for_status()
+        target.write_bytes(response.content)
+        sha = _sha256_of(target)
+        return FetchResult(
+            source=source,
+            local_path=target,
+            changed=True,
+            sha256=sha,
+            etag=response.headers.get("ETag") or None,
+            last_modified=response.headers.get("Last-Modified") or None,
+        )
+
+
+def _sha256_of(path: Path) -> str:
+    hasher = hashlib.sha256()
+    hasher.update(path.read_bytes())
+    return hasher.hexdigest()

--- a/src/rag/fetch.py
+++ b/src/rag/fetch.py
@@ -140,15 +140,29 @@ async def _fetch_one(
             headers=headers,
             follow_redirects=True,
         )
-        if response.status_code == 304 and target.exists():
-            sha = cached.get("sha256") or _sha256_of(target)
-            return FetchResult(
-                source=source,
-                local_path=target,
-                changed=False,
-                sha256=sha,
-                etag=cached.get("etag") or None,
-                last_modified=cached.get("last_modified") or None,
+        if response.status_code == 304:
+            if target.exists():
+                sha = cached.get("sha256") or _sha256_of(target)
+                return FetchResult(
+                    source=source,
+                    local_path=target,
+                    changed=False,
+                    sha256=sha,
+                    etag=cached.get("etag") or None,
+                    last_modified=cached.get("last_modified") or None,
+                )
+            # Cache headers said "unchanged" but the local PDF is gone
+            # (manual cleanup, broken volume, lost mount). The 304
+            # response has no body so writing it would yield a 0-byte
+            # file; re-issue the request without conditional headers.
+            logfire.warn(
+                "rag.fetch.cache_invalidated_local_file_missing",
+                doc_id=source.doc_id,
+                target=str(target),
+            )
+            response = await client.get(
+                str(source.resolved_url),
+                follow_redirects=True,
             )
         response.raise_for_status()
         target.write_bytes(response.content)

--- a/src/rag/ingest.py
+++ b/src/rag/ingest.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -136,7 +137,8 @@ async def _amain(
     )
     if failures:
         details = "; ".join(f"{doc_id}: {err}" for doc_id, err in failures)
-        raise SystemExit(f"RAG ingestion finished with {len(failures)} failure(s): {details}")
+        sys.stderr.write(f"RAG ingestion finished with {len(failures)} failure(s): {details}\n")
+        raise SystemExit(1)
     return total_upserted
 
 
@@ -157,6 +159,16 @@ async def _ingest_one(
         changed=result.changed,
         dry_run=dry_run,
     ):
+        if not result.changed:
+            # HTTP 304 cache hit -> nothing new to embed/upsert. Stable
+            # ids + a populated namespace mean a re-run would only burn
+            # OpenAI tokens and issue redundant Pinecone upserts. Honour
+            # the idempotent-by-cost contract documented in the README.
+            logfire.info(
+                "rag.ingest.skipped_unchanged",
+                doc_id=result.source.doc_id,
+            )
+            return 0
         chunks: list[Chunk] = parse_pdf(
             doc_id=result.source.doc_id,
             doc_title=result.source.name,

--- a/src/rag/ingest.py
+++ b/src/rag/ingest.py
@@ -105,24 +105,38 @@ async def _amain(
     index = pinecone_client.Index(settings.pinecone_index)
 
     total_upserted = 0
+    failures: list[tuple[str, str]] = []
     for result in results:
-        upserted = await _ingest_one(
-            result=result,
-            previous_urls=previous_urls,
-            settings=settings,
-            openai_client=openai_client,
-            index=index,
-            dry_run=dry_run,
-            docling_converter=docling_converter,
-            docling_chunker=docling_chunker,
-        )
+        try:
+            upserted = await _ingest_one(
+                result=result,
+                previous_urls=previous_urls,
+                settings=settings,
+                openai_client=openai_client,
+                index=index,
+                dry_run=dry_run,
+                docling_converter=docling_converter,
+                docling_chunker=docling_chunker,
+            )
+        except Exception as exc:  # noqa: BLE001 - aggregate per-doc failures
+            logfire.error(
+                "rag.ingest.cycle_failed",
+                doc_id=result.source.doc_id,
+                error=repr(exc),
+            )
+            failures.append((result.source.doc_id, repr(exc)))
+            continue
         total_upserted += upserted
 
     logfire.info(
         "rag.ingest.done",
         total_upserted=total_upserted,
         dry_run=dry_run,
+        failures=len(failures),
     )
+    if failures:
+        details = "; ".join(f"{doc_id}: {err}" for doc_id, err in failures)
+        raise SystemExit(f"RAG ingestion finished with {len(failures)} failure(s): {details}")
     return total_upserted
 
 
@@ -220,17 +234,23 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--force-refetch",
         action="store_true",
-        help="Ignore cached ETag/Last-Modified and re-download.",
+        help="Ignore cached ETag/Last-Modified and re-download every PDF.",
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Skip the Pinecone upsert step.",
+        help="Run fetch + parse + embed but skip the Pinecone upsert step.",
     )
     parser.add_argument(
         "--refresh-urls",
         action="store_true",
-        help="Re-resolve direct-PDF URLs from landing pages.",
+        help=(
+            "Re-scrape every landing page and rewrite the resolved direct-PDF "
+            "URL in src/rag/sources.json. Use this when TfL rolls the annual "
+            "URL stem (e.g. business-plan-2026 → business-plan-2027). The "
+            "subsequent download is still conditional via ETag, so unchanged "
+            "PDFs are 304'd."
+        ),
     )
     args = parser.parse_args(argv)
     run_ingestion(

--- a/src/rag/ingest.py
+++ b/src/rag/ingest.py
@@ -1,0 +1,244 @@
+"""Top-level RAG ingestion orchestrator.
+
+Pipeline: ``resolve URLs?`` → ``conditional fetch`` → ``parse`` →
+``embed`` → ``upsert``. Run via ``uv run python -m rag.ingest``.
+
+CLI flags:
+
+- ``--refresh-urls`` re-resolves the direct-PDF URL for every source
+  and rewrites ``src/rag/sources.json``.
+- ``--force-refetch`` ignores cached ``ETag`` / ``Last-Modified`` and
+  re-downloads unconditionally.
+- ``--dry-run`` runs everything except the Pinecone upsert.
+
+Fail-loud on missing ``OPENAI_API_KEY`` / ``PINECONE_API_KEY``: the
+process exits with code 2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+import logfire
+from openai import AsyncOpenAI
+
+from rag.config import RagSettings, load_settings
+from rag.embed import embed_texts
+from rag.fetch import (
+    DEFAULT_CACHE_PATH,
+    DEFAULT_DATA_DIR,
+    FetchResult,
+    fetch_pdfs,
+    load_cache,
+)
+from rag.parse import Chunk, parse_pdf
+from rag.sources import load_sources, resolve_pdf_urls, write_sources
+from rag.upsert import ensure_index, upsert_chunks
+
+__all__ = ["main", "run_ingestion"]
+
+DEFAULT_SOURCES_PATH = Path("src/rag/sources.json")
+RAG_SERVICE_NAME = "tfl-monitor-rag-ingestion"
+
+
+def configure_logfire() -> None:
+    """Configure Logfire for the ingestion entrypoint."""
+    logfire.configure(
+        service_name=RAG_SERVICE_NAME,
+        service_version=os.getenv("APP_VERSION", "0.0.1"),
+        environment=os.getenv("ENVIRONMENT", "local"),
+        send_to_logfire="if-token-present",
+    )
+    logfire.instrument_httpx()
+
+
+async def _amain(
+    *,
+    force_refetch: bool,
+    dry_run: bool,
+    refresh_urls: bool,
+    sources_path: Path = DEFAULT_SOURCES_PATH,
+    data_dir: Path = DEFAULT_DATA_DIR,
+    cache_path: Path = DEFAULT_CACHE_PATH,
+    pinecone_factory: Any = None,
+    openai_factory: Any = None,
+    httpx_factory: Any = None,
+    docling_converter: Any = None,
+    docling_chunker: Any = None,
+) -> int:
+    configure_logfire()
+    settings = load_settings()
+    sources = load_sources(sources_path)
+
+    # Snapshot previous resolved URLs *before* the fetch step rewrites the
+    # cache so we can detect URL rollover for namespace cleanup later.
+    previous_urls = {
+        doc_id: entry.get("resolved_url", "") for doc_id, entry in load_cache(cache_path).items()
+    }
+
+    httpx_factory = httpx_factory or _default_httpx_factory
+    async with httpx_factory() as client:
+        if refresh_urls:
+            sources = await resolve_pdf_urls(sources, client=client)
+            write_sources(sources_path, sources)
+        results = await fetch_pdfs(
+            sources,
+            client=client,
+            data_dir=data_dir,
+            cache_path=cache_path,
+            force_refetch=force_refetch,
+        )
+
+    openai_client = (openai_factory or _default_openai_factory)(settings)
+    pinecone_client = (pinecone_factory or _default_pinecone_factory)(settings)
+    ensure_index(
+        pinecone_client,
+        name=settings.pinecone_index,
+        cloud=settings.pinecone_cloud,
+        region=settings.pinecone_region,
+    )
+    index = pinecone_client.Index(settings.pinecone_index)
+
+    total_upserted = 0
+    for result in results:
+        upserted = await _ingest_one(
+            result=result,
+            previous_urls=previous_urls,
+            settings=settings,
+            openai_client=openai_client,
+            index=index,
+            dry_run=dry_run,
+            docling_converter=docling_converter,
+            docling_chunker=docling_chunker,
+        )
+        total_upserted += upserted
+
+    logfire.info(
+        "rag.ingest.done",
+        total_upserted=total_upserted,
+        dry_run=dry_run,
+    )
+    return total_upserted
+
+
+async def _ingest_one(
+    *,
+    result: FetchResult,
+    previous_urls: dict[str, str],
+    settings: RagSettings,
+    openai_client: Any,
+    index: Any,
+    dry_run: bool,
+    docling_converter: Any,
+    docling_chunker: Any,
+) -> int:
+    with logfire.span(
+        "rag.ingest.cycle",
+        doc_id=result.source.doc_id,
+        changed=result.changed,
+        dry_run=dry_run,
+    ):
+        chunks: list[Chunk] = parse_pdf(
+            doc_id=result.source.doc_id,
+            doc_title=result.source.name,
+            resolved_url=str(result.source.resolved_url),
+            pdf_path=result.local_path,
+            converter=docling_converter,
+            chunker=docling_chunker,
+        )
+        if not chunks:
+            logfire.warn(
+                "rag.ingest.empty_chunks",
+                doc_id=result.source.doc_id,
+            )
+            return 0
+        vectors = await embed_texts(
+            [c.text for c in chunks],
+            client=openai_client,
+            model=settings.embedding_model,
+        )
+        if dry_run:
+            logfire.info(
+                "rag.ingest.dry_run",
+                doc_id=result.source.doc_id,
+                chunks=len(chunks),
+                vectors=len(vectors),
+            )
+            return 0
+        previous_url = previous_urls.get(result.source.doc_id)
+        rollover = bool(previous_url and previous_url != str(result.source.resolved_url))
+        return upsert_chunks(
+            index=index,
+            chunks=chunks,
+            vectors=vectors,
+            namespace=result.source.doc_id,
+            delete_namespace_first=rollover,
+        )
+
+
+def _default_pinecone_factory(settings: RagSettings) -> Any:
+    from pinecone import Pinecone
+
+    return Pinecone(api_key=settings.pinecone_api_key.get_secret_value())
+
+
+def _default_openai_factory(settings: RagSettings) -> AsyncOpenAI:
+    return AsyncOpenAI(api_key=settings.openai_api_key.get_secret_value())
+
+
+def _default_httpx_factory() -> httpx.AsyncClient:
+    return httpx.AsyncClient(timeout=60.0)
+
+
+def run_ingestion(
+    *,
+    force_refetch: bool = False,
+    dry_run: bool = False,
+    refresh_urls: bool = False,
+) -> int:
+    """Synchronous entrypoint used by ``python -m rag.ingest``."""
+    return asyncio.run(
+        _amain(
+            force_refetch=force_refetch,
+            dry_run=dry_run,
+            refresh_urls=refresh_urls,
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entrypoint for ``python -m rag.ingest``."""
+    parser = argparse.ArgumentParser(
+        prog="rag.ingest",
+        description="Ingest TfL strategy PDFs into Pinecone via Docling.",
+    )
+    parser.add_argument(
+        "--force-refetch",
+        action="store_true",
+        help="Ignore cached ETag/Last-Modified and re-download.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip the Pinecone upsert step.",
+    )
+    parser.add_argument(
+        "--refresh-urls",
+        action="store_true",
+        help="Re-resolve direct-PDF URLs from landing pages.",
+    )
+    args = parser.parse_args(argv)
+    run_ingestion(
+        force_refetch=args.force_refetch,
+        dry_run=args.dry_run,
+        refresh_urls=args.refresh_urls,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rag/parse.py
+++ b/src/rag/parse.py
@@ -1,0 +1,120 @@
+"""Parse a PDF via Docling and emit chunks with retrieval metadata.
+
+Docling 2.x's :class:`docling.chunking.HybridChunker` segments by
+document hierarchy and merges sibling chunks under a token cap, which
+matches the retrieval granularity we want for ``text-embedding-3-small``.
+The Docling imports are deferred to the call site so unit tests can
+inject lightweight fakes without paying the model-download cost.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+from pydantic import BaseModel, Field
+
+
+class Chunk(BaseModel):
+    """A retrievable chunk of a parsed PDF, with citation metadata."""
+
+    doc_id: str
+    doc_title: str
+    resolved_url: str
+    chunk_index: int = Field(ge=0)
+    section_title: str = ""
+    page_start: int | None = None
+    page_end: int | None = None
+    text: str = Field(min_length=1)
+
+
+class _DoclingConverter(Protocol):
+    def convert(self, source: str) -> Any: ...
+
+
+class _DoclingChunker(Protocol):
+    def chunk(self, document: Any) -> Iterable[Any]: ...
+
+
+def parse_pdf(
+    *,
+    doc_id: str,
+    doc_title: str,
+    resolved_url: str,
+    pdf_path: Path,
+    converter: _DoclingConverter | None = None,
+    chunker: _DoclingChunker | None = None,
+) -> list[Chunk]:
+    """Parse ``pdf_path`` and return a list of :class:`Chunk`.
+
+    Args:
+        doc_id: Stable doc identifier (also the Pinecone namespace).
+        doc_title: Human-readable title carried into chunk metadata.
+        resolved_url: URL the PDF was downloaded from.
+        pdf_path: Local path to the PDF on disk.
+        converter: Optional injection point for tests; defaults to a
+            Docling :class:`DocumentConverter`.
+        chunker: Optional injection point for tests; defaults to
+            :class:`docling.chunking.HybridChunker` with library defaults.
+    """
+    converter = converter or _default_converter()
+    chunker = chunker or _default_chunker()
+    document = converter.convert(str(pdf_path)).document
+    chunks: list[Chunk] = []
+    for index, raw in enumerate(chunker.chunk(document)):
+        text = _chunk_text(raw)
+        if not text.strip():
+            continue
+        section_title, page_start, page_end = _extract_meta(raw)
+        chunks.append(
+            Chunk(
+                doc_id=doc_id,
+                doc_title=doc_title,
+                resolved_url=resolved_url,
+                chunk_index=index,
+                section_title=section_title,
+                page_start=page_start,
+                page_end=page_end,
+                text=text,
+            )
+        )
+    return chunks
+
+
+def _default_converter() -> _DoclingConverter:
+    from docling.document_converter import DocumentConverter
+
+    return cast(_DoclingConverter, DocumentConverter())
+
+
+def _default_chunker() -> _DoclingChunker:
+    from docling.chunking import HybridChunker  # type: ignore[attr-defined]
+
+    return cast(_DoclingChunker, HybridChunker())
+
+
+def _chunk_text(raw: Any) -> str:
+    text = getattr(raw, "text", None)
+    if isinstance(text, str):
+        return text
+    return str(raw)
+
+
+def _extract_meta(raw: Any) -> tuple[str, int | None, int | None]:
+    meta = getattr(raw, "meta", None)
+    headings = getattr(meta, "headings", None) or []
+    section_title = ""
+    for heading in headings:
+        if isinstance(heading, str) and heading.strip():
+            section_title = heading
+            break
+    pages: list[int] = []
+    for item in getattr(meta, "doc_items", None) or []:
+        for prov in getattr(item, "prov", None) or []:
+            page_no = getattr(prov, "page_no", None)
+            if isinstance(page_no, int):
+                pages.append(page_no)
+    page_start = min(pages) if pages else None
+    page_end = max(pages) if pages else None
+    return section_title, page_start, page_end

--- a/src/rag/sources.json
+++ b/src/rag/sources.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "TfL Business Plan",
+    "doc_id": "tfl_business_plan",
+    "landing_url": "https://tfl.gov.uk/corporate/publications-and-reports/business-plan",
+    "discovery_regex": "business-plan.*\\.pdf$",
+    "resolved_url": "https://content.tfl.gov.uk/2026-business-plan-acc.pdf"
+  },
+  {
+    "name": "Mayor's Transport Strategy",
+    "doc_id": "mts_2018",
+    "landing_url": "https://www.london.gov.uk/programmes-strategies/transport/our-vision-transport/mayors-transport-strategy-2018",
+    "discovery_regex": "mayors-transport-strategy-2018.*\\.pdf$",
+    "resolved_url": "https://www.london.gov.uk/sites/default/files/mayors-transport-strategy-2018.pdf"
+  },
+  {
+    "name": "TfL Annual Report",
+    "doc_id": "tfl_annual_report",
+    "landing_url": "https://tfl.gov.uk/corporate/publications-and-reports/annual-report",
+    "discovery_regex": "annual-report-and-statement-of-accounts.*\\.pdf$",
+    "resolved_url": "https://content.tfl.gov.uk/tfl-annual-report-and-statement-of-accounts-2024-25.pdf"
+  }
+]

--- a/src/rag/sources.py
+++ b/src/rag/sources.py
@@ -1,0 +1,98 @@
+"""Resolve the direct-PDF URL of each TfL strategy landing page.
+
+The three landing pages (``business-plan``, ``mayors-transport-strategy-2018``,
+``annual-report``) host the canonical PDFs but rotate the link target by
+year (Business Plan and Annual Report) or keep it stable (MTS 2018).
+``resolve_pdf_urls`` scrapes each landing page once and picks the first
+``<a href="...">`` whose URL matches a per-source allowlist regex.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from urllib.parse import urljoin
+
+import httpx
+from pydantic import BaseModel, Field, HttpUrl
+
+PDF_LINK_HREF_PATTERN = re.compile(r"""href=["']([^"']+\.pdf(?:\?[^"']*)?)["']""", re.IGNORECASE)
+
+
+class PdfSource(BaseModel):
+    """A TfL strategy PDF and its discovery + cached state."""
+
+    name: str = Field(min_length=1)
+    doc_id: str = Field(min_length=1)
+    landing_url: HttpUrl
+    discovery_regex: str = Field(min_length=1)
+    resolved_url: HttpUrl | None = None
+    etag: str | None = None
+    last_modified: str | None = None
+    sha256: str | None = None
+
+
+class PdfSourceResolutionError(RuntimeError):
+    """Raised when a landing page exposes no matching PDF link."""
+
+
+def load_sources(path: Path) -> list[PdfSource]:
+    """Load the committed ``src/rag/sources.json`` file."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return [PdfSource.model_validate(entry) for entry in raw]
+
+
+def write_sources(path: Path, sources: list[PdfSource]) -> None:
+    """Write ``sources`` back to disk as JSON, sorted by ``doc_id``."""
+    serialised = [
+        {
+            "name": s.name,
+            "doc_id": s.doc_id,
+            "landing_url": str(s.landing_url),
+            "discovery_regex": s.discovery_regex,
+            "resolved_url": str(s.resolved_url) if s.resolved_url else None,
+        }
+        for s in sorted(sources, key=lambda s: s.doc_id)
+    ]
+    path.write_text(json.dumps(serialised, indent=2) + "\n", encoding="utf-8")
+
+
+async def resolve_pdf_urls(
+    sources: list[PdfSource],
+    *,
+    client: httpx.AsyncClient,
+) -> list[PdfSource]:
+    """Re-resolve every source's ``resolved_url`` from its landing page.
+
+    Args:
+        sources: Sources to refresh.
+        client: Shared async HTTP client.
+
+    Returns:
+        New list with ``resolved_url`` populated from the landing page.
+
+    Raises:
+        PdfSourceResolutionError: When a landing page returns no link
+            matching the source's ``discovery_regex``.
+    """
+    return [await _resolve_one(source, client=client) for source in sources]
+
+
+async def _resolve_one(
+    source: PdfSource,
+    *,
+    client: httpx.AsyncClient,
+) -> PdfSource:
+    response = await client.get(str(source.landing_url), follow_redirects=True)
+    response.raise_for_status()
+    pattern = re.compile(source.discovery_regex, re.IGNORECASE)
+    base_url = str(response.url)
+    for match in PDF_LINK_HREF_PATTERN.finditer(response.text):
+        href = match.group(1)
+        if pattern.search(href):
+            absolute = urljoin(base_url, href)
+            return source.model_copy(update={"resolved_url": absolute})
+    raise PdfSourceResolutionError(
+        f"No PDF link matching {source.discovery_regex!r} found on {source.landing_url}"
+    )

--- a/src/rag/upsert.py
+++ b/src/rag/upsert.py
@@ -1,0 +1,146 @@
+"""Pinecone upsert: create index if absent, namespace-per-doc, idempotent.
+
+Per CLAUDE.md tech-stack the index is serverless (`cloud="aws"`,
+`region="us-east-1"`), 1536 dimensions, cosine. One namespace per
+``doc_id`` keeps the per-document delete simple — Pinecone serverless
+free tier supports ``delete(delete_all=True, namespace=...)`` but not
+metadata-filter delete.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from typing import Any, Protocol
+
+import logfire
+
+from rag.config import (
+    DEFAULT_PINECONE_CLOUD,
+    DEFAULT_PINECONE_REGION,
+    EMBEDDING_DIMENSIONS,
+)
+from rag.parse import Chunk
+
+UPSERT_BATCH_SIZE = 100
+PAGE_UNKNOWN_SENTINEL = -1
+
+
+class _PineconeIndex(Protocol):
+    def upsert(self, *, vectors: list[dict[str, Any]], namespace: str) -> Any: ...
+
+    def delete(self, *, delete_all: bool, namespace: str) -> Any: ...
+
+
+class _PineconeClient(Protocol):
+    def list_indexes(self) -> Any: ...
+
+    def create_index(self, *, name: str, dimension: int, metric: str, spec: Any) -> Any: ...
+
+    def Index(self, name: str) -> _PineconeIndex: ...  # noqa: N802 - matches SDK
+
+
+def vector_id(resolved_url: str, chunk_index: int) -> str:
+    """Stable per-chunk id used as the Pinecone vector id."""
+    return hashlib.sha256(f"{resolved_url}::{chunk_index}".encode()).hexdigest()
+
+
+def _list_index_names(client: _PineconeClient) -> set[str]:
+    raw = client.list_indexes()
+    names: set[str] = set()
+    for entry in raw:
+        if isinstance(entry, dict) and "name" in entry:
+            names.add(str(entry["name"]))
+            continue
+        name_attr = getattr(entry, "name", None)
+        if isinstance(name_attr, str):
+            names.add(name_attr)
+            continue
+        if isinstance(entry, str):
+            names.add(entry)
+    return names
+
+
+def ensure_index(
+    client: _PineconeClient,
+    *,
+    name: str,
+    cloud: str = DEFAULT_PINECONE_CLOUD,
+    region: str = DEFAULT_PINECONE_REGION,
+) -> None:
+    """Create the index if missing; idempotent."""
+    if name in _list_index_names(client):
+        return
+    spec = _build_serverless_spec(cloud=cloud, region=region)
+    client.create_index(
+        name=name,
+        dimension=EMBEDDING_DIMENSIONS,
+        metric="cosine",
+        spec=spec,
+    )
+
+
+def _build_serverless_spec(*, cloud: str, region: str) -> Any:
+    from pinecone import ServerlessSpec
+
+    return ServerlessSpec(cloud=cloud, region=region)
+
+
+def upsert_chunks(
+    *,
+    index: _PineconeIndex,
+    chunks: Iterable[Chunk],
+    vectors: list[list[float]],
+    namespace: str,
+    delete_namespace_first: bool,
+) -> int:
+    """Upsert ``chunks`` (with their corresponding ``vectors``).
+
+    Args:
+        index: Pinecone index handle.
+        chunks: Chunks aligned positionally with ``vectors``.
+        vectors: Embedding vectors in the same order as ``chunks``.
+        namespace: Pinecone namespace, conventionally the ``doc_id``.
+        delete_namespace_first: When ``True`` clears the namespace
+            before upserting (used when the resolved URL has rolled
+            over for the same logical doc).
+
+    Returns:
+        Number of vectors successfully sent to Pinecone.
+    """
+    if delete_namespace_first:
+        with logfire.span("rag.upsert.delete_namespace", namespace=namespace):
+            index.delete(delete_all=True, namespace=namespace)
+
+    payload: list[dict[str, Any]] = [
+        {
+            "id": vector_id(chunk.resolved_url, chunk.chunk_index),
+            "values": vector,
+            "metadata": {
+                "doc_id": chunk.doc_id,
+                "doc_title": chunk.doc_title,
+                "resolved_url": chunk.resolved_url,
+                "chunk_index": chunk.chunk_index,
+                "section_title": chunk.section_title,
+                "page_start": chunk.page_start
+                if chunk.page_start is not None
+                else PAGE_UNKNOWN_SENTINEL,
+                "page_end": chunk.page_end if chunk.page_end is not None else PAGE_UNKNOWN_SENTINEL,
+                "text": chunk.text,
+            },
+        }
+        for chunk, vector in zip(chunks, vectors, strict=True)
+    ]
+
+    upserted = 0
+    for start in range(0, len(payload), UPSERT_BATCH_SIZE):
+        batch = payload[start : start + UPSERT_BATCH_SIZE]
+        with logfire.span(
+            "rag.upsert",
+            namespace=namespace,
+            n_vectors=len(batch),
+            batch_index=start // UPSERT_BATCH_SIZE,
+        ):
+            index.upsert(vectors=batch, namespace=namespace)
+        upserted += len(batch)
+    return upserted

--- a/tests/rag/conftest.py
+++ b/tests/rag/conftest.py
@@ -1,0 +1,13 @@
+"""Shared fixtures for ``tests/rag/``."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _rag_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure ``RagSettings()`` constructs in unit tests."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-openai")
+    monkeypatch.setenv("PINECONE_API_KEY", "pcsk-test-pinecone")
+    monkeypatch.delenv("LOGFIRE_TOKEN", raising=False)

--- a/tests/rag/test_embed.py
+++ b/tests/rag/test_embed.py
@@ -1,0 +1,91 @@
+"""Unit tests for :mod:`rag.embed`."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from openai import RateLimitError
+
+from rag.embed import EmbeddingClientError, embed_texts
+
+
+class _FakeEmbeddingItem:
+    def __init__(self, vector: list[float]) -> None:
+        self.embedding = vector
+
+
+class _FakeEmbeddingResponse:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self.data = [_FakeEmbeddingItem(v) for v in vectors]
+
+
+class _FakeEmbeddings:
+    def __init__(self, error_sequence: list[Exception | None]) -> None:
+        self.calls: list[list[str]] = []
+        self._errors = list(error_sequence)
+
+    async def create(self, *, model: str, input: list[str]) -> _FakeEmbeddingResponse:
+        del model
+        self.calls.append(list(input))
+        if self._errors:
+            err = self._errors.pop(0)
+            if err is not None:
+                raise err
+        return _FakeEmbeddingResponse([[float(i)] * 4 for i in range(len(input))])
+
+
+class _FakeOpenAI:
+    def __init__(self, error_sequence: list[Exception | None] | None = None) -> None:
+        self.embeddings = _FakeEmbeddings(error_sequence or [])
+
+
+def _rate_limit_error() -> RateLimitError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/embeddings")
+    response = httpx.Response(429, request=request, text="rate limit")
+    return RateLimitError("rate limit", response=response, body=None)
+
+
+async def test_embed_texts_batches_at_100() -> None:
+    client = _FakeOpenAI()
+    texts = [f"chunk {i}" for i in range(150)]
+    vectors = await embed_texts(texts, client=client, model="text-embedding-3-small")
+    assert len(vectors) == 150
+    assert [len(call) for call in client.embeddings.calls] == [100, 50]
+
+
+async def test_embed_texts_retries_on_rate_limit() -> None:
+    client = _FakeOpenAI(error_sequence=[_rate_limit_error()])
+    texts = ["a", "b", "c"]
+    vectors = await embed_texts(texts, client=client, model="text-embedding-3-small")
+    assert len(vectors) == 3
+    assert len(client.embeddings.calls) == 2  # one retry
+
+
+async def test_embed_texts_raises_after_exhaustion() -> None:
+    client = _FakeOpenAI(error_sequence=[_rate_limit_error(), _rate_limit_error()])
+    with pytest.raises(EmbeddingClientError) as excinfo:
+        await embed_texts(
+            ["a"],
+            client=client,
+            model="text-embedding-3-small",
+            max_attempts=2,
+        )
+    assert "after 2 attempts" in str(excinfo.value)
+
+
+async def test_embed_texts_rejects_invalid_inputs() -> None:
+    client = _FakeOpenAI()
+    with pytest.raises(ValueError):
+        await embed_texts(
+            ["a"],
+            client=client,
+            model="text-embedding-3-small",
+            batch_size=0,
+        )
+    with pytest.raises(ValueError):
+        await embed_texts(
+            ["a"],
+            client=client,
+            model="text-embedding-3-small",
+            max_attempts=0,
+        )

--- a/tests/rag/test_fetch.py
+++ b/tests/rag/test_fetch.py
@@ -1,0 +1,159 @@
+"""Unit tests for :mod:`rag.fetch`."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from rag.fetch import fetch_pdfs, load_cache
+from rag.sources import PdfSource
+
+_PDF_BYTES = b"%PDF-1.4 fake content for unit tests\n"
+_ETAG = '"abc123"'
+_LAST_MODIFIED = "Wed, 21 Oct 2026 07:28:00 GMT"
+
+
+def _make_source() -> PdfSource:
+    return PdfSource(
+        name="Sample",
+        doc_id="sample",
+        landing_url="https://example.com/landing",
+        discovery_regex=r"sample\.pdf$",
+        resolved_url="https://example.com/sample.pdf",
+    )
+
+
+def _client(handler: callable) -> httpx.AsyncClient:  # type: ignore[valid-type]
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+async def test_fetch_pdfs_writes_file_and_cache_on_200(tmp_path: Path) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            content=_PDF_BYTES,
+            headers={"ETag": _ETAG, "Last-Modified": _LAST_MODIFIED},
+        )
+
+    data_dir = tmp_path / "strategy_docs"
+    cache_path = tmp_path / "cache" / "sources_state.json"
+    async with _client(handler) as client:
+        results = await fetch_pdfs(
+            [_make_source()],
+            client=client,
+            data_dir=data_dir,
+            cache_path=cache_path,
+        )
+    [r] = results
+    assert r.changed is True
+    assert r.local_path.exists()
+    assert r.local_path.read_bytes() == _PDF_BYTES
+    assert r.sha256 == hashlib.sha256(_PDF_BYTES).hexdigest()
+    assert r.etag == _ETAG
+    assert r.last_modified == _LAST_MODIFIED
+    assert "If-None-Match" not in requests[0].headers
+
+    cache = load_cache(cache_path)
+    assert cache["sample"]["etag"] == _ETAG
+    assert cache["sample"]["sha256"] == r.sha256
+
+
+async def test_fetch_pdfs_skips_on_304(tmp_path: Path) -> None:
+    data_dir = tmp_path / "strategy_docs"
+    cache_path = tmp_path / "cache" / "sources_state.json"
+    data_dir.mkdir(parents=True)
+    target = data_dir / "sample.pdf"
+    target.write_bytes(_PDF_BYTES)
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "sample": {
+                    "resolved_url": "https://example.com/sample.pdf",
+                    "etag": _ETAG,
+                    "last_modified": _LAST_MODIFIED,
+                    "sha256": hashlib.sha256(_PDF_BYTES).hexdigest(),
+                    "fetched_at": "2026-04-01T00:00:00+00:00",
+                }
+            }
+        )
+    )
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.headers.get("If-None-Match") == _ETAG
+        assert request.headers.get("If-Modified-Since") == _LAST_MODIFIED
+        return httpx.Response(304)
+
+    async with _client(handler) as client:
+        [r] = await fetch_pdfs(
+            [_make_source()],
+            client=client,
+            data_dir=data_dir,
+            cache_path=cache_path,
+        )
+    assert r.changed is False
+    assert r.local_path == target
+    assert r.sha256 == hashlib.sha256(_PDF_BYTES).hexdigest()
+
+
+async def test_fetch_pdfs_force_refetch_ignores_cache(tmp_path: Path) -> None:
+    data_dir = tmp_path / "strategy_docs"
+    cache_path = tmp_path / "cache" / "sources_state.json"
+    data_dir.mkdir(parents=True)
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "sample": {
+                    "resolved_url": "https://example.com/sample.pdf",
+                    "etag": _ETAG,
+                    "last_modified": _LAST_MODIFIED,
+                    "sha256": "old",
+                    "fetched_at": "2026-04-01T00:00:00+00:00",
+                }
+            }
+        )
+    )
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=_PDF_BYTES)
+
+    async with _client(handler) as client:
+        [r] = await fetch_pdfs(
+            [_make_source()],
+            client=client,
+            data_dir=data_dir,
+            cache_path=cache_path,
+            force_refetch=True,
+        )
+    assert "If-None-Match" not in requests[0].headers
+    assert "If-Modified-Since" not in requests[0].headers
+    assert r.changed is True
+
+
+async def test_fetch_pdfs_propagates_404(tmp_path: Path) -> None:
+    data_dir = tmp_path / "strategy_docs"
+    cache_path = tmp_path / "cache" / "sources_state.json"
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text="not found")
+
+    async with _client(handler) as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await fetch_pdfs(
+                [_make_source()],
+                client=client,
+                data_dir=data_dir,
+                cache_path=cache_path,
+            )

--- a/tests/rag/test_fetch.py
+++ b/tests/rag/test_fetch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import httpx
@@ -27,7 +28,7 @@ def _make_source() -> PdfSource:
     )
 
 
-def _client(handler: callable) -> httpx.AsyncClient:  # type: ignore[valid-type]
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.AsyncClient:
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
 
@@ -140,6 +141,62 @@ async def test_fetch_pdfs_force_refetch_ignores_cache(tmp_path: Path) -> None:
     assert "If-None-Match" not in requests[0].headers
     assert "If-Modified-Since" not in requests[0].headers
     assert r.changed is True
+
+
+async def test_fetch_pdfs_recovers_when_cache_hit_but_local_file_missing(
+    tmp_path: Path,
+) -> None:
+    """Cache state says we have the PDF but the local file is gone.
+
+    The 304 response has no body, so writing it would yield a 0-byte
+    file. Re-issue the request without conditional headers so we
+    actually retrieve the bytes.
+    """
+    data_dir = tmp_path / "strategy_docs"
+    cache_path = tmp_path / "cache" / "sources_state.json"
+    data_dir.mkdir(parents=True)
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "sample": {
+                    "resolved_url": "https://example.com/sample.pdf",
+                    "etag": _ETAG,
+                    "last_modified": _LAST_MODIFIED,
+                    "sha256": hashlib.sha256(_PDF_BYTES).hexdigest(),
+                    "fetched_at": "2026-04-01T00:00:00+00:00",
+                }
+            }
+        )
+    )
+    # Note: local file deliberately NOT created — simulates broken volume.
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if "If-None-Match" in request.headers:
+            # First call: server says "unchanged" but local is missing.
+            return httpx.Response(304)
+        # Recovery call: unconditional GET should succeed.
+        return httpx.Response(
+            200,
+            content=_PDF_BYTES,
+            headers={"ETag": _ETAG, "Last-Modified": _LAST_MODIFIED},
+        )
+
+    async with _client(handler) as client:
+        [r] = await fetch_pdfs(
+            [_make_source()],
+            client=client,
+            data_dir=data_dir,
+            cache_path=cache_path,
+        )
+    assert r.changed is True
+    assert r.local_path.exists()
+    assert r.local_path.read_bytes() == _PDF_BYTES
+    assert r.sha256 == hashlib.sha256(_PDF_BYTES).hexdigest()
+    assert len(requests) == 2  # conditional + recovery
+    assert "If-None-Match" not in requests[1].headers
 
 
 async def test_fetch_pdfs_propagates_404(tmp_path: Path) -> None:

--- a/tests/rag/test_ingest.py
+++ b/tests/rag/test_ingest.py
@@ -79,6 +79,14 @@ def _build_httpx_factory() -> Any:
     return lambda: httpx.AsyncClient(transport=transport)
 
 
+def _build_httpx_factory_returning_304() -> Any:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(304)
+
+    transport = httpx.MockTransport(handler)
+    return lambda: httpx.AsyncClient(transport=transport)
+
+
 def _build_fakes() -> tuple[_FakeOpenAI, _FakeClient, _FakeConverter, _FakeChunker]:
     openai_client = _FakeOpenAI()
     pinecone_client = _FakeClient(existing=["tfl-strategy-docs"])
@@ -241,6 +249,65 @@ def test_run_ingestion_same_url_skips_rollover_delete(tmp_path: Path) -> None:
     assert len(index.upsert_calls) == 1
 
 
+def test_run_ingestion_skips_parse_and_embed_when_unchanged(tmp_path: Path) -> None:
+    """HTTP 304 cache hit -> skip parse/embed/upsert (cost-leak fix).
+
+    Re-running ingestion against PDFs that haven't changed should be a
+    near-zero-cost operation: no OpenAI tokens consumed, no Pinecone
+    upserts issued. Stable ids would make the upsert harmless but still
+    burn embedding spend on every cron tick.
+    """
+    sources_path = tmp_path / "sources.json"
+    _seed_sources(sources_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True)
+    # Pre-seed both the cache state AND the local PDF so the 304 path
+    # is the cache-valid branch (not the recovery branch).
+    target = data_dir / "sample.pdf"
+    target.write_bytes(_PDF_BYTES)
+    cache_path = tmp_path / "cache" / "sources_state.json"
+    cache_path.parent.mkdir(parents=True)
+    import hashlib as _hashlib
+
+    cache_path.write_text(
+        json.dumps(
+            {
+                "sample": {
+                    "resolved_url": "https://example.com/sample.pdf",
+                    "etag": '"abc"',
+                    "last_modified": "Wed, 21 Oct 2026 07:28:00 GMT",
+                    "sha256": _hashlib.sha256(_PDF_BYTES).hexdigest(),
+                    "fetched_at": "2026-04-01T00:00:00+00:00",
+                }
+            }
+        )
+    )
+
+    openai_client, pinecone_client, converter, chunker = _build_fakes()
+
+    upserted = asyncio.run(
+        _amain(
+            force_refetch=False,
+            dry_run=False,
+            refresh_urls=False,
+            sources_path=sources_path,
+            data_dir=data_dir,
+            cache_path=cache_path,
+            pinecone_factory=lambda _settings: pinecone_client,
+            openai_factory=lambda _settings: openai_client,
+            httpx_factory=_build_httpx_factory_returning_304(),
+            docling_converter=converter,
+            docling_chunker=chunker,
+        )
+    )
+
+    assert upserted == 0
+    index = pinecone_client.Index("tfl-strategy-docs")
+    # Skip-on-unchanged means upsert is never reached.
+    assert index.upsert_calls == []
+    assert index.delete_calls == []
+
+
 class _ExplodingChunker:
     """Chunker that raises mid-pipeline so we can verify partial-failure exit code."""
 
@@ -250,6 +317,7 @@ class _ExplodingChunker:
 
 def test_run_ingestion_aggregates_per_doc_failures_and_exits_nonzero(
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     sources_path = tmp_path / "sources.json"
     _seed_sources(sources_path)
@@ -265,17 +333,20 @@ def test_run_ingestion_aggregates_per_doc_failures_and_exits_nonzero(
             converter=converter,
             chunker=_ExplodingChunker(),  # type: ignore[arg-type]
         )
-    msg = str(excinfo.value)
-    assert "1 failure" in msg
-    assert "sample" in msg
-    assert "simulated parse failure" in msg
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "1 failure" in err
+    assert "sample" in err
+    assert "simulated parse failure" in err
     # Upsert never reached for the failing doc.
     index = pinecone_client.Index("tfl-strategy-docs")
     assert index.upsert_calls == []
 
 
 def test_run_ingestion_missing_pinecone_key_exits_2(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.delenv("PINECONE_API_KEY", raising=False)
     sources_path = tmp_path / "sources.json"
@@ -292,7 +363,9 @@ def test_run_ingestion_missing_pinecone_key_exits_2(
             converter=converter,
             chunker=chunker,
         )
-    assert "RAG settings missing or invalid" in str(excinfo.value)
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "RAG settings missing or invalid" in err
 
 
 def test_run_ingestion_refresh_urls_rewrites_sources(tmp_path: Path) -> None:

--- a/tests/rag/test_ingest.py
+++ b/tests/rag/test_ingest.py
@@ -203,6 +203,77 @@ def test_run_ingestion_rollover_triggers_namespace_delete(tmp_path: Path) -> Non
     assert index.delete_calls == [{"delete_all": True, "namespace": "sample"}]
 
 
+def test_run_ingestion_same_url_skips_rollover_delete(tmp_path: Path) -> None:
+    """Identical resolved_url between runs → no namespace wipe (idempotent)."""
+    sources_path = tmp_path / "sources.json"
+    _seed_sources(sources_path)
+    cache_path = tmp_path / "cache" / "sources_state.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "sample": {
+                    "resolved_url": "https://example.com/sample.pdf",  # SAME url
+                    "etag": '"abc"',
+                    "last_modified": "Wed, 21 Oct 2026 07:28:00 GMT",
+                    "sha256": "deadbeef",
+                    "fetched_at": "2026-04-01T00:00:00+00:00",
+                }
+            }
+        )
+    )
+
+    openai_client, pinecone_client, converter, chunker = _build_fakes()
+    _run(
+        sources_path=sources_path,
+        data_dir=tmp_path / "data",
+        cache_path=cache_path,
+        pinecone_client=pinecone_client,
+        openai_client=openai_client,
+        converter=converter,
+        chunker=chunker,
+    )
+
+    index = pinecone_client.Index("tfl-strategy-docs")
+    # No delete fired — re-upserting onto stable ids overwrites in place.
+    assert index.delete_calls == []
+    # Upsert still happened.
+    assert len(index.upsert_calls) == 1
+
+
+class _ExplodingChunker:
+    """Chunker that raises mid-pipeline so we can verify partial-failure exit code."""
+
+    def chunk(self, _document: object) -> list[object]:
+        raise RuntimeError("simulated parse failure")
+
+
+def test_run_ingestion_aggregates_per_doc_failures_and_exits_nonzero(
+    tmp_path: Path,
+) -> None:
+    sources_path = tmp_path / "sources.json"
+    _seed_sources(sources_path)
+    openai_client, pinecone_client, converter, _ = _build_fakes()
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run(
+            sources_path=sources_path,
+            data_dir=tmp_path / "data",
+            cache_path=tmp_path / "cache" / "sources_state.json",
+            pinecone_client=pinecone_client,
+            openai_client=openai_client,
+            converter=converter,
+            chunker=_ExplodingChunker(),  # type: ignore[arg-type]
+        )
+    msg = str(excinfo.value)
+    assert "1 failure" in msg
+    assert "sample" in msg
+    assert "simulated parse failure" in msg
+    # Upsert never reached for the failing doc.
+    index = pinecone_client.Index("tfl-strategy-docs")
+    assert index.upsert_calls == []
+
+
 def test_run_ingestion_missing_pinecone_key_exits_2(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/rag/test_ingest.py
+++ b/tests/rag/test_ingest.py
@@ -1,0 +1,272 @@
+"""Unit tests for :mod:`rag.ingest`."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from rag.ingest import _amain
+from rag.sources import write_sources
+from tests.rag.test_parse import (  # type: ignore[import-not-found]
+    _build_fake_chunk,
+    _FakeChunker,
+    _FakeConverter,
+)
+from tests.rag.test_upsert import _FakeClient  # type: ignore[import-not-found]
+
+_PDF_BYTES = b"%PDF-1.4 fake content for unit tests\n"
+
+
+class _FakeEmbeddingItem:
+    def __init__(self, vector: list[float]) -> None:
+        self.embedding = vector
+
+
+class _FakeEmbeddingResponse:
+    def __init__(self, count: int) -> None:
+        self.data = [_FakeEmbeddingItem([float(i)] * 1536) for i in range(count)]
+
+
+class _FakeEmbeddings:
+    async def create(self, *, model: str, input: list[str]) -> _FakeEmbeddingResponse:
+        del model
+        return _FakeEmbeddingResponse(len(input))
+
+
+class _FakeOpenAI:
+    def __init__(self) -> None:
+        self.embeddings = _FakeEmbeddings()
+
+
+def _seed_sources(path: Path) -> None:
+    """Write a single-source JSON file the orchestrator can load."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "Sample Doc",
+                    "doc_id": "sample",
+                    "landing_url": "https://example.com/landing",
+                    "discovery_regex": r"sample\.pdf$",
+                    "resolved_url": "https://example.com/sample.pdf",
+                }
+            ],
+            indent=2,
+        )
+        + "\n",
+    )
+
+
+def _build_httpx_factory() -> Any:
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(
+            200,
+            content=_PDF_BYTES,
+            headers={
+                "ETag": '"abc"',
+                "Last-Modified": "Wed, 21 Oct 2026 07:28:00 GMT",
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    return lambda: httpx.AsyncClient(transport=transport)
+
+
+def _build_fakes() -> tuple[_FakeOpenAI, _FakeClient, _FakeConverter, _FakeChunker]:
+    openai_client = _FakeOpenAI()
+    pinecone_client = _FakeClient(existing=["tfl-strategy-docs"])
+    converter = _FakeConverter(document=object())
+    chunker = _FakeChunker(
+        [
+            _build_fake_chunk("first chunk", headings=["Intro"], pages=[1]),
+            _build_fake_chunk("second chunk", headings=["Body"], pages=[2, 3]),
+        ]
+    )
+    return openai_client, pinecone_client, converter, chunker
+
+
+def _run(
+    *,
+    sources_path: Path,
+    data_dir: Path,
+    cache_path: Path,
+    pinecone_client: _FakeClient,
+    openai_client: _FakeOpenAI,
+    converter: _FakeConverter,
+    chunker: _FakeChunker,
+    dry_run: bool = False,
+    force_refetch: bool = False,
+    refresh_urls: bool = False,
+) -> int:
+    return asyncio.run(
+        _amain(
+            force_refetch=force_refetch,
+            dry_run=dry_run,
+            refresh_urls=refresh_urls,
+            sources_path=sources_path,
+            data_dir=data_dir,
+            cache_path=cache_path,
+            pinecone_factory=lambda _settings: pinecone_client,
+            openai_factory=lambda _settings: openai_client,
+            httpx_factory=_build_httpx_factory(),
+            docling_converter=converter,
+            docling_chunker=chunker,
+        )
+    )
+
+
+def test_run_ingestion_end_to_end_with_fakes(tmp_path: Path) -> None:
+    sources_path = tmp_path / "sources.json"
+    _seed_sources(sources_path)
+    openai_client, pinecone_client, converter, chunker = _build_fakes()
+
+    upserted = _run(
+        sources_path=sources_path,
+        data_dir=tmp_path / "data",
+        cache_path=tmp_path / "cache" / "sources_state.json",
+        pinecone_client=pinecone_client,
+        openai_client=openai_client,
+        converter=converter,
+        chunker=chunker,
+    )
+
+    assert upserted == 2
+    index = pinecone_client.Index("tfl-strategy-docs")
+    assert len(index.upsert_calls) == 1
+    assert index.upsert_calls[0]["namespace"] == "sample"
+    assert len(index.upsert_calls[0]["vectors"]) == 2
+    # No rollover on first run → no namespace delete.
+    assert index.delete_calls == []
+
+
+def test_run_ingestion_dry_run_skips_upsert(tmp_path: Path) -> None:
+    sources_path = tmp_path / "sources.json"
+    _seed_sources(sources_path)
+    openai_client, pinecone_client, converter, chunker = _build_fakes()
+
+    upserted = _run(
+        sources_path=sources_path,
+        data_dir=tmp_path / "data",
+        cache_path=tmp_path / "cache" / "sources_state.json",
+        pinecone_client=pinecone_client,
+        openai_client=openai_client,
+        converter=converter,
+        chunker=chunker,
+        dry_run=True,
+    )
+
+    assert upserted == 0
+    index = pinecone_client.Index("tfl-strategy-docs")
+    assert index.upsert_calls == []
+    assert index.delete_calls == []
+
+
+def test_run_ingestion_rollover_triggers_namespace_delete(tmp_path: Path) -> None:
+    sources_path = tmp_path / "sources.json"
+    _seed_sources(sources_path)
+    cache_path = tmp_path / "cache" / "sources_state.json"
+    cache_path.parent.mkdir(parents=True)
+    # Pre-seed cache with a *different* resolved URL → rollover.
+    cache_path.write_text(
+        json.dumps(
+            {
+                "sample": {
+                    "resolved_url": "https://example.com/old-sample.pdf",
+                    "etag": '"old"',
+                    "last_modified": "Mon, 01 Jan 2025 00:00:00 GMT",
+                    "sha256": "old",
+                    "fetched_at": "2025-01-01T00:00:00+00:00",
+                }
+            }
+        )
+    )
+
+    openai_client, pinecone_client, converter, chunker = _build_fakes()
+    _run(
+        sources_path=sources_path,
+        data_dir=tmp_path / "data",
+        cache_path=cache_path,
+        pinecone_client=pinecone_client,
+        openai_client=openai_client,
+        converter=converter,
+        chunker=chunker,
+    )
+
+    index = pinecone_client.Index("tfl-strategy-docs")
+    assert index.delete_calls == [{"delete_all": True, "namespace": "sample"}]
+
+
+def test_run_ingestion_missing_pinecone_key_exits_2(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("PINECONE_API_KEY", raising=False)
+    sources_path = tmp_path / "sources.json"
+    _seed_sources(sources_path)
+    openai_client, pinecone_client, converter, chunker = _build_fakes()
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run(
+            sources_path=sources_path,
+            data_dir=tmp_path / "data",
+            cache_path=tmp_path / "cache" / "sources_state.json",
+            pinecone_client=pinecone_client,
+            openai_client=openai_client,
+            converter=converter,
+            chunker=chunker,
+        )
+    assert "RAG settings missing or invalid" in str(excinfo.value)
+
+
+def test_run_ingestion_refresh_urls_rewrites_sources(tmp_path: Path) -> None:
+    sources_path = tmp_path / "sources.json"
+    write_sources(
+        sources_path,
+        [
+            __import__("rag.sources", fromlist=["PdfSource"]).PdfSource(
+                name="Sample",
+                doc_id="sample",
+                landing_url="https://example.com/landing",
+                discovery_regex=r"sample\.pdf$",
+                resolved_url="https://example.com/old-sample.pdf",
+            )
+        ],
+    )
+
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/landing":
+            return httpx.Response(
+                200,
+                text='<a href="https://example.com/sample.pdf">x</a>',
+            )
+        return httpx.Response(200, content=_PDF_BYTES)
+
+    transport = httpx.MockTransport(handler)
+    openai_client, pinecone_client, converter, chunker = _build_fakes()
+    asyncio.run(
+        _amain(
+            force_refetch=False,
+            dry_run=False,
+            refresh_urls=True,
+            sources_path=sources_path,
+            data_dir=tmp_path / "data",
+            cache_path=tmp_path / "cache" / "sources_state.json",
+            pinecone_factory=lambda _settings: pinecone_client,
+            openai_factory=lambda _settings: openai_client,
+            httpx_factory=lambda: httpx.AsyncClient(transport=transport),
+            docling_converter=converter,
+            docling_chunker=chunker,
+        )
+    )
+
+    rewritten = json.loads(sources_path.read_text())
+    assert rewritten[0]["resolved_url"] == "https://example.com/sample.pdf"

--- a/tests/rag/test_parse.py
+++ b/tests/rag/test_parse.py
@@ -1,0 +1,127 @@
+"""Unit tests for :mod:`rag.parse`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from rag.parse import Chunk, parse_pdf
+
+
+@dataclass
+class _FakeProv:
+    page_no: int
+
+
+@dataclass
+class _FakeDocItem:
+    prov: list[_FakeProv]
+
+
+@dataclass
+class _FakeMeta:
+    headings: list[str] = field(default_factory=list)
+    doc_items: list[_FakeDocItem] = field(default_factory=list)
+
+
+@dataclass
+class _FakeChunk:
+    text: str
+    meta: _FakeMeta
+
+
+@dataclass
+class _FakeConvertResult:
+    document: object
+
+
+class _FakeConverter:
+    def __init__(self, document: object) -> None:
+        self._document = document
+        self.calls: list[str] = []
+
+    def convert(self, source: str) -> _FakeConvertResult:
+        self.calls.append(source)
+        return _FakeConvertResult(document=self._document)
+
+
+class _FakeChunker:
+    def __init__(self, chunks: list[_FakeChunk]) -> None:
+        self._chunks = chunks
+
+    def chunk(self, _document: object) -> list[_FakeChunk]:
+        return self._chunks
+
+
+def _build_fake_chunk(
+    text: str,
+    *,
+    headings: list[str] | None = None,
+    pages: list[int] | None = None,
+) -> _FakeChunk:
+    return _FakeChunk(
+        text=text,
+        meta=_FakeMeta(
+            headings=list(headings or []),
+            doc_items=[_FakeDocItem(prov=[_FakeProv(page_no=p) for p in (pages or [])])],
+        ),
+    )
+
+
+def test_parse_pdf_emits_one_chunk_per_section(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "fake.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake")
+    converter = _FakeConverter(document=object())
+    chunker = _FakeChunker(
+        [
+            _build_fake_chunk("Intro paragraph.", headings=["Introduction"], pages=[1, 2]),
+            _build_fake_chunk(
+                "Methodology details.",
+                headings=["Methods", "Subsection"],
+                pages=[3],
+            ),
+        ]
+    )
+
+    chunks = parse_pdf(
+        doc_id="doc",
+        doc_title="Test Doc",
+        resolved_url="https://example.com/doc.pdf",
+        pdf_path=pdf_path,
+        converter=converter,
+        chunker=chunker,
+    )
+
+    assert [c.section_title for c in chunks] == ["Introduction", "Methods"]
+    assert [c.page_start for c in chunks] == [1, 3]
+    assert [c.page_end for c in chunks] == [2, 3]
+    assert [c.chunk_index for c in chunks] == [0, 1]
+    assert all(isinstance(c, Chunk) for c in chunks)
+    assert converter.calls == [str(pdf_path)]
+
+
+def test_parse_pdf_skips_empty_text_chunks(tmp_path: Path) -> None:
+    pdf_path = tmp_path / "fake.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 fake")
+    converter = _FakeConverter(document=object())
+    chunker = _FakeChunker(
+        [
+            _build_fake_chunk("Real content"),
+            _build_fake_chunk("   "),  # whitespace-only
+            _build_fake_chunk("More content"),
+        ]
+    )
+
+    chunks = parse_pdf(
+        doc_id="doc",
+        doc_title="Test Doc",
+        resolved_url="https://example.com/doc.pdf",
+        pdf_path=pdf_path,
+        converter=converter,
+        chunker=chunker,
+    )
+
+    assert [c.text for c in chunks] == ["Real content", "More content"]
+    # chunk_index reflects the chunker's enumeration so retrieval citation
+    # remains meaningful even when the parser skips whitespace.
+    assert [c.chunk_index for c in chunks] == [0, 2]

--- a/tests/rag/test_sources.py
+++ b/tests/rag/test_sources.py
@@ -1,0 +1,106 @@
+"""Unit tests for :mod:`rag.sources`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from rag.sources import (
+    PdfSource,
+    PdfSourceResolutionError,
+    load_sources,
+    resolve_pdf_urls,
+    write_sources,
+)
+
+_LANDING_HTML = """
+<!doctype html>
+<html><body>
+  <a href="/cdn/static/cms/documents/2026-business-plan-acc.pdf">Read</a>
+  <a href="/sites/default/files/some-other.pdf">Other</a>
+</body></html>
+"""
+
+
+def _build_source() -> PdfSource:
+    return PdfSource(
+        name="TfL Business Plan",
+        doc_id="tfl_business_plan",
+        landing_url="https://tfl.gov.uk/corporate/publications-and-reports/business-plan",
+        discovery_regex=r"business-plan.*\.pdf$",
+    )
+
+
+def _client_with_response(*, status: int, text: str) -> httpx.AsyncClient:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=status, text=text)
+
+    transport = httpx.MockTransport(handler)
+    return httpx.AsyncClient(transport=transport)
+
+
+async def test_resolve_pdf_urls_picks_first_match() -> None:
+    source = _build_source()
+    async with _client_with_response(status=200, text=_LANDING_HTML) as client:
+        [resolved] = await resolve_pdf_urls([source], client=client)
+    assert (
+        str(resolved.resolved_url)
+        == "https://tfl.gov.uk/cdn/static/cms/documents/2026-business-plan-acc.pdf"
+    )
+    assert resolved.doc_id == source.doc_id
+
+
+async def test_resolve_pdf_urls_resolves_relative_href() -> None:
+    """Hrefs relative to the landing URL must be made absolute."""
+    source = _build_source()
+    async with _client_with_response(
+        status=200,
+        text='<a href="/cdn/static/cms/documents/2026-business-plan-acc.pdf">Read</a>',
+    ) as client:
+        [resolved] = await resolve_pdf_urls([source], client=client)
+    assert str(resolved.resolved_url).startswith("https://tfl.gov.uk/")
+
+
+async def test_resolve_pdf_urls_raises_when_no_link_matches() -> None:
+    source = _build_source()
+    async with _client_with_response(
+        status=200, text='<a href="/some-unrelated-doc.pdf">x</a>'
+    ) as client:
+        with pytest.raises(PdfSourceResolutionError) as excinfo:
+            await resolve_pdf_urls([source], client=client)
+    msg = str(excinfo.value)
+    assert "business-plan" in msg
+    assert "tfl.gov.uk" in msg
+
+
+def test_load_and_write_sources_roundtrip(tmp_path: Path) -> None:
+    source = PdfSource(
+        name="Test Source",
+        doc_id="test_source",
+        landing_url="https://example.com/landing",
+        discovery_regex=r"test.*\.pdf$",
+        resolved_url="https://example.com/test.pdf",
+    )
+    target = tmp_path / "sources.json"
+    write_sources(target, [source])
+    [reloaded] = load_sources(target)
+    assert reloaded.doc_id == source.doc_id
+    assert str(reloaded.resolved_url) == str(source.resolved_url)
+
+
+def test_committed_sources_json_is_valid() -> None:
+    """The shipped ``src/rag/sources.json`` must parse into PdfSource."""
+    repo_root = Path(__file__).resolve().parents[2]
+    path = repo_root / "src" / "rag" / "sources.json"
+    sources = load_sources(path)
+    assert {s.doc_id for s in sources} == {
+        "tfl_business_plan",
+        "mts_2018",
+        "tfl_annual_report",
+    }
+    for s in sources:
+        assert s.resolved_url is not None
+        assert json.dumps(s.discovery_regex)  # always serialisable

--- a/tests/rag/test_upsert.py
+++ b/tests/rag/test_upsert.py
@@ -1,0 +1,182 @@
+"""Unit tests for :mod:`rag.upsert`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from rag.parse import Chunk
+from rag.upsert import (
+    PAGE_UNKNOWN_SENTINEL,
+    UPSERT_BATCH_SIZE,
+    ensure_index,
+    upsert_chunks,
+    vector_id,
+)
+
+
+class _FakeIndex:
+    def __init__(self) -> None:
+        self.upsert_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[dict[str, Any]] = []
+
+    def upsert(self, *, vectors: list[dict[str, Any]], namespace: str) -> None:
+        self.upsert_calls.append({"vectors": vectors, "namespace": namespace})
+
+    def delete(self, *, delete_all: bool, namespace: str) -> None:
+        self.delete_calls.append({"delete_all": delete_all, "namespace": namespace})
+
+
+class _FakeClient:
+    def __init__(self, *, existing: list[str] | None = None) -> None:
+        self.existing = list(existing or [])
+        self.create_calls: list[dict[str, Any]] = []
+        self._index = _FakeIndex()
+
+    def list_indexes(self) -> list[dict[str, str]]:
+        return [{"name": n} for n in self.existing]
+
+    def create_index(self, *, name: str, dimension: int, metric: str, spec: Any) -> None:
+        self.create_calls.append(
+            {"name": name, "dimension": dimension, "metric": metric, "spec": spec}
+        )
+        self.existing.append(name)
+
+    def Index(self, name: str) -> _FakeIndex:  # noqa: N802 - matches Pinecone SDK
+        del name
+        return self._index
+
+
+def _build_chunks(n: int, *, doc_id: str = "doc") -> list[Chunk]:
+    return [
+        Chunk(
+            doc_id=doc_id,
+            doc_title="Doc Title",
+            resolved_url="https://example.com/doc.pdf",
+            chunk_index=i,
+            section_title=f"Section {i}",
+            page_start=i + 1,
+            page_end=i + 2,
+            text=f"chunk text {i}",
+        )
+        for i in range(n)
+    ]
+
+
+def test_vector_id_is_stable() -> None:
+    a = vector_id("https://example.com/doc.pdf", 0)
+    b = vector_id("https://example.com/doc.pdf", 0)
+    c = vector_id("https://example.com/doc.pdf", 1)
+    assert a == b
+    assert a != c
+    assert len(a) == 64  # full sha256 hex
+
+
+def test_ensure_index_skips_when_present() -> None:
+    client = _FakeClient(existing=["tfl-strategy-docs"])
+    ensure_index(client, name="tfl-strategy-docs")
+    assert client.create_calls == []
+
+
+def test_ensure_index_creates_when_missing() -> None:
+    client = _FakeClient(existing=[])
+    ensure_index(client, name="tfl-strategy-docs", cloud="aws", region="us-east-1")
+    assert len(client.create_calls) == 1
+    call = client.create_calls[0]
+    assert call["name"] == "tfl-strategy-docs"
+    assert call["dimension"] == 1536
+    assert call["metric"] == "cosine"
+
+
+def test_upsert_chunks_deletes_namespace_when_rollover() -> None:
+    index = _FakeIndex()
+    chunks = _build_chunks(3)
+    vectors = [[float(i)] * 1536 for i in range(3)]
+    upserted = upsert_chunks(
+        index=index,
+        chunks=chunks,
+        vectors=vectors,
+        namespace="doc",
+        delete_namespace_first=True,
+    )
+    assert upserted == 3
+    assert len(index.delete_calls) == 1
+    assert index.delete_calls[0] == {"delete_all": True, "namespace": "doc"}
+
+
+def test_upsert_chunks_skips_delete_when_not_rollover() -> None:
+    index = _FakeIndex()
+    chunks = _build_chunks(3)
+    vectors = [[float(i)] * 1536 for i in range(3)]
+    upsert_chunks(
+        index=index,
+        chunks=chunks,
+        vectors=vectors,
+        namespace="doc",
+        delete_namespace_first=False,
+    )
+    assert index.delete_calls == []
+
+
+def test_upsert_chunks_metadata_shape() -> None:
+    index = _FakeIndex()
+    chunk = Chunk(
+        doc_id="doc",
+        doc_title="Doc Title",
+        resolved_url="https://example.com/doc.pdf",
+        chunk_index=0,
+        section_title="",
+        page_start=None,
+        page_end=None,
+        text="hello",
+    )
+    upsert_chunks(
+        index=index,
+        chunks=[chunk],
+        vectors=[[0.1] * 1536],
+        namespace="doc",
+        delete_namespace_first=False,
+    )
+    payload = index.upsert_calls[0]["vectors"][0]
+    assert payload["id"] == vector_id("https://example.com/doc.pdf", 0)
+    assert payload["values"] == [0.1] * 1536
+    md = payload["metadata"]
+    assert md["doc_id"] == "doc"
+    assert md["doc_title"] == "Doc Title"
+    assert md["resolved_url"] == "https://example.com/doc.pdf"
+    assert md["chunk_index"] == 0
+    assert md["section_title"] == ""
+    assert md["page_start"] == PAGE_UNKNOWN_SENTINEL
+    assert md["page_end"] == PAGE_UNKNOWN_SENTINEL
+    assert md["text"] == "hello"
+
+
+def test_upsert_chunks_batches_at_100() -> None:
+    index = _FakeIndex()
+    n = UPSERT_BATCH_SIZE * 2 + 50
+    chunks = _build_chunks(n)
+    vectors = [[float(i)] * 1536 for i in range(n)]
+    upserted = upsert_chunks(
+        index=index,
+        chunks=chunks,
+        vectors=vectors,
+        namespace="doc",
+        delete_namespace_first=False,
+    )
+    assert upserted == n
+    assert [len(call["vectors"]) for call in index.upsert_calls] == [100, 100, 50]
+
+
+def test_upsert_chunks_raises_when_lengths_differ() -> None:
+    index = _FakeIndex()
+    chunks = _build_chunks(3)
+    vectors = [[0.1] * 1536, [0.2] * 1536]
+    with pytest.raises(ValueError):
+        upsert_chunks(
+            index=index,
+            chunks=chunks,
+            vectors=vectors,
+            namespace="doc",
+            delete_namespace_first=False,
+        )


### PR DESCRIPTION
Closes TM-17.

## Summary

End-to-end RAG ingestion for the three TfL strategy PDFs. Each run resolves the current direct-PDF URL on its landing page, conditionally downloads the file, parses via Docling, embeds with OpenAI `text-embedding-3-small`, and upserts into a Pinecone serverless index. Re-runs are idempotent and skip work when nothing changed upstream.

- `src/rag/sources.py` resolves the direct-PDF URL on each landing page (TfL Business Plan, Mayor's Transport Strategy 2018, TfL Annual Report) via a per-source allowlist regex stored in `src/rag/sources.json` (committed).
- `src/rag/fetch.py` issues conditional GET (`If-None-Match` + `If-Modified-Since`) into `data/strategy_docs/`. Cache state lives in `data/cache/sources_state.json` (gitignored). HTTP 304 short-circuits without rewriting the file; HTTP 4xx/5xx propagates so a stale `resolved_url` is surfaced rather than silently absorbed.
- `src/rag/parse.py` wraps Docling 2.x `DocumentConverter` + `HybridChunker` (library defaults; the constructor derives chunk size from its tokenizer rather than accepting `max_tokens=` directly). Lazy imports keep the unit-test path free of Docling's model download.
- `src/rag/embed.py` async-batches OpenAI `text-embedding-3-small` (100/req). Bounded retry with exponential backoff on `RateLimitError` / `APIConnectionError` / `APITimeoutError`, capped at 5 attempts (mirrors `src/ingestion/tfl_client/retry.py`).
- `src/rag/upsert.py` Pinecone serverless `tfl-strategy-docs` (1536 dim, cosine, AWS us-east-1). One namespace per `doc_id`. Stable id = `sha256("{resolved_url}::{chunk_index}").hexdigest()`. When the resolved URL has rolled over for the same `doc_id` (annual TfL report rotation), the orchestrator deletes the namespace before upserting; identical URLs re-upsert in place via stable ids — no needless wipes on transient errors or key rotations.
- `src/rag/ingest.py` orchestrator + CLI:
  ```bash
  uv run python -m rag.ingest [--refresh-urls] [--force-refetch] [--dry-run]
  ```
  Fails loud (`SystemExit(2)`) when `OPENAI_API_KEY` or `PINECONE_API_KEY` is missing — never silently no-ops when secrets are absent. Per-doc errors are caught, aggregated, logged via Logfire, and reported through a non-zero `SystemExit` at the end of the run, so a future cron / GitHub Action sees the failure instead of swallowing it.
- `pyproject.toml`: `[tool.hatch.build.targets.wheel].packages` extended with `src/rag`. Added `[[tool.mypy.overrides]]` for `docling.*` / `pinecone.*` mirroring the existing `aiokafka.*` precedent.
- `.gitignore`: appends `data/strategy_docs/*.pdf` and `data/cache/`.
- `.env.example`: `PINECONE_INDEX` default updated to `tfl-strategy-docs`; new `EMBEDDING_MODEL` default.
- `README.md`: new "RAG ingestion" subsection under Local development. Cites the canonical landing pages (per TfL/GLA usage terms), surfaces a realistic embedding-cost estimate (<= £0.20 one-time at current `text-embedding-3-small` pricing), and explains the `--refresh-urls` / `--force-refetch` / `--dry-run` flags.
- `tests/rag/`: 30 unit tests with fakes for `httpx`, Docling, OpenAI, and Pinecone. Coverage includes idempotent re-upsert (same resolved URL → no namespace wipe), URL rollover (different resolved URL → namespace wipe before upsert), and partial-failure aggregation (per-doc exceptions → SystemExit non-zero with details). No live API key required.

## Spec correction

The original briefing pointed at `https://www.london.gov.uk/programmes-strategies/transport/mayors-transport-strategy-2018` for the Mayor's Transport Strategy. That URL returns 404; the canonical landing page is now `https://www.london.gov.uk/programmes-strategies/transport/our-vision-transport/mayors-transport-strategy-2018` (verified via WebFetch on 2026-04-28). `src/rag/sources.json` uses the corrected URL.

## Out of scope

- LangGraph retrieval tool (`search_tfl_docs`) — TM-D5.
- Airflow DAG to schedule ingestion — TM-A2.
- LlamaIndex — Docling alone covers parse + chunk for this WP (CLAUDE.md §"Principle #1" rule 4: don't abstract until the second case arrives).
- Pinecone metadata-filter delete — not available on serverless free tier; `delete(delete_all=True, namespace=...)` covers our rollover case.

## Verification

```bash
uv run task lint                            # ruff + ruff format --check + mypy strict
uv run task test                            # 122 passed (rag/+ingestion/+api/+contracts)
uv run bandit -r src --severity-level high  # 0 findings
make check                                  # full chain green
```

## Test plan

- [x] `uv run task lint` passes locally
- [x] `uv run task test` passes locally (30 RAG unit tests + the rest of the suite)
- [x] `uv run bandit -r src --severity-level high` reports 0 findings
- [x] `make check` passes locally
- [ ] Manual smoke against real Pinecone (`uv run python -m rag.ingest --dry-run`) — requires `PINECONE_API_KEY` + `OPENAI_API_KEY`; pending key provisioning by the author.
- [ ] CodeRabbit / Gemini review threads resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RAG ingestion pipeline for TfL strategy documents with intelligent PDF discovery, conditional caching, and vector embedding.
  * Introduced CLI modes for managing the ingestion workflow: refresh URLs, force refetch, and dry-run testing.
  * Configured Pinecone serverless vector storage for document retrieval.

* **Documentation**
  * Documented RAG implementation plan and research specifications.
  * Updated README with RAG operational details and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->