### PR TITLE
docs: add mkdocs site + cross-module README links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v3
+      - name: Restore .cache for material social-cards
+        uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ hashFiles('mkdocs.yml') }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - name: Install docs deps
+        run: uv sync --group docs --frozen
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Build and deploy to gh-pages
+        run: uv run mkdocs gh-deploy --config-file mkdocs.yml --force --clean --verbose

--- a/README.md
+++ b/README.md
@@ -1,79 +1,104 @@
 # tfl-monitor
 
-> A real-time data platform for Transport for London's network — streaming pipeline, dbt-modelled warehouse, and a RAG agent that answers questions about live operations and TfL strategy.
+> A real-time data + AI engineering portfolio: streaming Transport for London
+> feeds into a dbt-modelled warehouse, with a LangGraph agent that routes
+> between SQL over the warehouse and RAG over TfL strategy documents.
 
-🚧 **Under active development.** Live demo link coming with deployment (Phase 7).
+[![CI](https://github.com/hcslomeu/tfl-monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/hcslomeu/tfl-monitor/actions/workflows/ci.yml)
+[![docs](https://github.com/hcslomeu/tfl-monitor/actions/workflows/docs.yml/badge.svg)](https://hcslomeu.github.io/tfl-monitor/)
+[![python](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
+[![licence](https://img.shields.io/badge/licence-MIT-green.svg)](./LICENSE)
 
-- **Live demo**: 🚧 via TM-A5 + TM-E4
-- **Demo video**: 🚧 via TM-F1
-- **Architecture**: [`ARCHITECTURE.md`](./ARCHITECTURE.md)
-- **Setup**: [`SETUP.md`](./SETUP.md)
+🚧 **Under active deployment** — the codebase is feature-complete; TM-A5
+ships the AWS Bedrock + EC2 deploy.
+
+- 📚 **Documentation**: <https://hcslomeu.github.io/tfl-monitor/>
+- 🏛️ **Architecture**: [`ARCHITECTURE.md`](./ARCHITECTURE.md) ·
+  [docs/architecture](https://hcslomeu.github.io/tfl-monitor/architecture/)
+- 🧱 **Setup**: [`SETUP.md`](./SETUP.md)
+- ✅ **WP ledger**: [`PROGRESS.md`](./PROGRESS.md)
+- 🚀 **Live demo**: shipping with TM-A5 + TM-E4
+- 🎬 **Demo video**: shipping with TM-F1
 
 ---
 
 ## What this project is
 
-tfl-monitor ingests live feeds from the Transport for London Unified API — line status, arrivals, and disruptions across Tube, Elizabeth Line, Overground, and DLR — into a Kafka-backed streaming pipeline, transforms them into a dbt-modelled Postgres warehouse, and exposes a Next.js dashboard plus a conversational agent that can answer two different kinds of question:
+tfl-monitor ingests live feeds from the Transport for London Unified API —
+line status, arrivals, and disruptions across Tube, Elizabeth Line,
+Overground, and DLR — into a Kafka-backed streaming pipeline, transforms them
+into a dbt-modelled Postgres warehouse, and exposes a Next.js dashboard plus
+a conversational agent that can answer two different kinds of question:
 
-- **"Which Tube line had the worst reliability last week?"** — answered by an agent that writes SQL against the warehouse.
-- **"What's TfL's strategy for Piccadilly Line upgrades?"** — answered by RAG retrieval over TfL's Business Plan, the Mayor's Transport Strategy, and TfL's Annual Report.
+- **"Which Tube line had the worst reliability last week?"** — answered by an
+  agent that runs a typed query against the warehouse.
+- **"What's TfL's strategy for Piccadilly Line upgrades?"** — answered by RAG
+  retrieval over TfL's Business Plan, the Mayor's Transport Strategy, and
+  TfL's Annual Report.
 
-The agent routes between these two modes automatically.
+The agent routes between these two modes automatically and cites either the
+SQL rows or the exact document chunks it used.
 
 ## Why this project exists
 
-Portfolio project demonstrating **end-to-end data + AI engineering** on a realistic public dataset:
+A portfolio that demonstrates the **full data + AI engineering loop** on a
+realistic public dataset, not a CRUD demo or a notebook prototype:
 
 - Streaming ingestion that earns its Kafka broker (not a cron job in disguise)
 - A warehouse modelled properly in dbt with tests, documentation, and lineage
-- An AI agent that doesn't hallucinate because it's wired to real data and real documents
-- Everything deployed, observable, reproducible
+- An AI agent that doesn't hallucinate because it's wired to real data and
+  real documents
+- Production deployment for ~$6/month total, observable end-to-end
 
 ## Architecture at a glance
 
-```
+```text
 TfL Unified API ──polling──▶ Redpanda (Kafka) ──▶ Postgres (raw) ──▶ dbt ──▶ marts
-                                                                                │
-TfL strategy PDFs ──Docling──▶ embeddings ──▶ Pinecone                          │
-                                               │                                │
-                                               └───────┬────────────────────────┘
-                                                       ▼
-                                            LangGraph agent (SQL ↔ RAG)
-                                                       │
+                                                                               │
+TfL strategy PDFs ──Docling──▶ embeddings ──▶ Pinecone                         │
+                                              │                                │
+                                              └──────┬─────────────────────────┘
+                                                     ▼
+                                          LangGraph agent (SQL ↔ RAG)
+                                                     │
                                    FastAPI (SSE streaming) ◀┘
-                                             │
-                                             ▼
-                                    Next.js dashboard
+                                              │
+                                              ▼
+                                     Next.js dashboard
 
  Observability layered across the whole stack:
  • LangSmith   → LLM + agent traces (routing decisions, retrieval, tokens)
  • Logfire     → app + infra traces (FastAPI spans, Postgres queries, HTTP calls)
 ```
 
-Full diagram and component table in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+Full diagram with mermaid + per-pipeline walkthroughs in
+[the docs site](https://hcslomeu.github.io/tfl-monitor/architecture/).
 
 ## Tech stack
 
 | Layer | Choice | Reason |
-|---|---|---|
-| Streaming broker | Redpanda (Kafka-compatible) | Kafka API, single binary, same code local and in Redpanda Cloud |
-| Warehouse | PostgreSQL 16 | Simple, Supabase-compatible, fits the dataset |
-| Transformations | dbt-core + dbt-postgres | Tests, docs, lineage — the modern warehouse standard |
-| Batch orchestration | Apache Airflow 2.10+ | DAGs for static data ingest and nightly dbt rebuilds |
-| Ingestion | Python 3.12 + `httpx` + `aiokafka` | Async producers with retry, Pydantic-validated messages |
-| API | FastAPI + `sse-starlette` | Async, typed, great OpenAPI story |
-| Agent | LangGraph 1.x | Stateful graph with SQL tool and RAG tool |
-| Structured LLM calls | Pydantic AI | Type-safe extraction inside tools (not the main agent) |
-| RAG | LlamaIndex + Pinecone + Docling | Hybrid retrieval over TfL PDFs |
-| Validation | Pydantic v2 | Every data boundary in the system |
-| LLM observability | LangSmith | Traces every agent decision, tool call, retrieval |
-| App observability | Logfire | FastAPI, Postgres, HTTP — OpenTelemetry-native |
-| Frontend | Next.js 16 + shadcn/ui + claude.design | Server components, typed API client from OpenAPI |
-| Deploy | Railway + Vercel + Supabase + Redpanda Cloud + Pinecone | Free tiers where possible; ~£5/mo for Airflow on Railway |
+|-------|--------|--------|
+| Streaming broker | Redpanda (Kafka API) | Single binary, identical local ↔ prod |
+| Warehouse | PostgreSQL 16 / Supabase | JSONB-native, mature dbt adapter |
+| Transformations | dbt-core + dbt-postgres | Tests, docs, lineage as code |
+| Orchestration | Apache Airflow 2.10+ | LocalExecutor; portfolio-relevant skill |
+| Ingestion | `httpx` + `aiokafka` + Pydantic v2 | Async retry, typed events end-to-end |
+| API | FastAPI + `sse-starlette` | Async, typed, OpenAPI 3.1 auto-emitted |
+| Agent | LangGraph 1.x | Stateful graph with five typed tools |
+| Structured extraction | Pydantic AI | Tool-level typed LLM calls (Haiku normaliser) |
+| RAG | LlamaIndex + Pinecone + Docling | Conditional GET, namespace per document |
+| LLMs | Claude Sonnet 3.5 + Haiku 3.5 | Top-of-class tool calling |
+| LLM observability | LangSmith | Auto-instruments every node and tool call |
+| App observability | Logfire | OpenTelemetry-native FastAPI / Postgres / HTTP |
+| Frontend | Next.js 16 + shadcn/ui | Server components, Tailwind v4, Radix Nova |
+| Lint / format | Ruff (Python), Biome (TS) | Single tool per ecosystem |
+
+Full table — including the rejection rationale per choice — is in
+[`docs/stack`](https://hcslomeu.github.io/tfl-monitor/stack/).
 
 ## Engineering highlights
 
-### Contracts-first, enabling parallel agent work
+### Contracts-first parallelism
 
 Every cross-track interface lives in [`contracts/`](./contracts):
 
@@ -82,147 +107,176 @@ Every cross-track interface lives in [`contracts/`](./contracts):
 - Postgres DDL for every raw table
 - dbt `sources.yml` derived from the DDL
 
-The frontend generates TypeScript types from the OpenAPI spec. The ingestion layer serialises Pydantic models onto Kafka. dbt stages the raw tables into typed columns. Change the contract, regenerate everywhere — a single source of truth for the shape of the system.
+The frontend regenerates TypeScript types from the OpenAPI spec; the
+ingestion layer serialises Pydantic models onto Kafka; dbt stages the raw
+tables into typed columns. CI gates a bidirectional drift test across all
+four artefacts.
 
 ### Kafka earns its place
 
-TfL updates line status roughly every 30 seconds and disruptions continuously. At four polling endpoints with sub-minute cadence, Kafka gives us:
-
-- **Decoupling** — producers keep polling even if consumers are deploying
-- **Replay** — we can rewind topics to backfill a new consumer
-- **Fan-out** — multiple consumers (warehouse writer, live dashboard pusher, agent context hydrator) read the same topic
-
-A cron-to-Postgres pipeline would work; it would also lock us into a single consumer and lose history on restart.
+TfL updates line status every 30 seconds and disruptions continuously. Kafka
+gives us decoupling (producers keep polling while consumers redeploy),
+**replay** (rewinding a topic re-hydrates the warehouse), and **fan-out**
+(multiple consumer groups read the same topic). We exploit all three; we did
+not pay the cost of Kafka for its own sake.
 
 ### dbt over raw SQL
 
-Roughly 10 staging, intermediate, and mart models with dependencies; automatic tests for `unique`, `not_null`, and referential integrity; an auto-generated lineage graph; documentation that ships with the code. Raw SQL scripts would also work — until a second person needs to read the codebase.
+Around ten staging, intermediate, and mart models with dependencies; generic
+tests for `unique`, `not_null`, and referential integrity; eight singular
+tests for business invariants; auto-generated lineage and exposures wiring
+marts to the consuming endpoints.
 
 ### The agent routes between SQL and RAG
 
-A LangGraph agent exposes two tools:
-
-- `query_warehouse(sql: str)` — executes read-only SQL against a restricted role on the mart schema
-- `search_tfl_docs(query: str, top_k: int)` — hybrid (vector + BM25) retrieval over TfL strategy PDFs with reranking
-
-A router node inspects the question and picks the right tool. Answers cite either the SQL query and its rows, or the exact document chunks used. No hallucinations — or if there are, you can see exactly where they came from, traced end-to-end in LangSmith.
+A LangGraph `create_react_agent` exposes five typed tools — four wrap the
+warehouse-backed FastAPI fetchers (so there is one source of truth per
+query) and the fifth is a LlamaIndex retriever fanning out across the three
+Pinecone namespaces. Tool docstrings declare assumptions that reach the
+model (e.g. the documented bus-punctuality proxy). Every step is traced in
+LangSmith.
 
 ### Observability split
 
-Two hosted tools, zero self-hosted telemetry stack:
+Two hosted tools, zero self-hosted telemetry:
 
-- **LangSmith** — traces every LLM call, tool invocation, retrieval step. Answers: *why did the agent pick this tool?*, *which chunks made it into the prompt?*, *how many tokens did this cost?*
-- **Logfire** — instruments FastAPI, Postgres (`psycopg`), HTTP clients. Answers: *is my consumer keeping up?*, *why is this endpoint slow?*, *is TfL rate-limiting me?*
+- **LangSmith** answers *"why did the agent decide that?"*
+- **Logfire** answers *"why is this endpoint slow?"*
 
-Both free tiers cover this project. No Prometheus, no Grafana, no OpenTelemetry collector to babysit.
+Both ride on free tiers. No Prometheus / Grafana / OTel collector to babysit.
 
 ## Local development
 
-Prerequisites: Docker, `uv`, `pnpm`, `make`, `git`. Free TfL API key. Accounts on Pinecone, OpenAI, Anthropic, LangSmith, Logfire. See [`SETUP.md`](./SETUP.md) for the full setup.
+Prerequisites: Docker, `uv`, `pnpm`, `make`, `git`. Free TfL API key, plus
+accounts on Pinecone, OpenAI, Anthropic (or AWS Bedrock), LangSmith, Logfire.
+See [`SETUP.md`](./SETUP.md) for the full quick-start.
 
 ```bash
 git clone git@github.com:hcslomeu/tfl-monitor.git
 cd tfl-monitor
 cp .env.example .env
-# edit .env with your keys
+# fill in the keys you have
 
 make bootstrap        # install Python + Node deps
-make up               # start Postgres, Redpanda, Airflow, MinIO
+make up               # start Postgres, Redpanda, Airflow
 make seed             # load fixtures into local Postgres
-make check            # lint + tests + build
+make check            # lint + tests + build, both halves
+```
 
-# in separate terminals:
-uv run task api       # API on :8000
+In two more terminals:
+
+```bash
+uv run task api       # FastAPI on :8000
 pnpm --dir web dev    # dashboard on :3000
 ```
 
-Visit `http://localhost:3000`.
+Visit <http://localhost:3000>.
 
-Frontend tooling (delegated to `pnpm` — never npm or yarn):
+Tear it down with `make down` (preserves data) or `make clean` (wipes
+volumes).
+
+### Documentation site
+
+Local preview of the MkDocs Material site:
 
 ```bash
-pnpm --dir web lint   # Biome (sole linter/formatter)
-pnpm --dir web test   # Vitest + React Testing Library
-pnpm --dir web build  # Next.js production build
+uv sync --group docs
+uv run task docs-serve   # http://127.0.0.1:8001
 ```
 
-`make check` chains the Python and TypeScript gates for both halves of
-the codebase. See [`web/README.md`](./web/README.md) for the full
-frontend quickstart, including how to regenerate TS types from the
-OpenAPI contract.
+Build for offline review:
 
-Bring it all down with `make down` (preserves data) or `make clean` (wipes volumes).
+```bash
+uv run task docs-build
+open site/index.html
+```
+
+The site is published to GitHub Pages on every merge to `main` via
+`.github/workflows/docs.yml`.
 
 ### RAG ingestion (TM-D4)
 
-Three TfL strategy PDFs are fetched, parsed via Docling, embedded with OpenAI `text-embedding-3-small`, and upserted into the Pinecone serverless index `tfl-strategy-docs`. The fetcher follows the canonical landing pages to discover the current direct-PDF URL, then issues conditional `If-None-Match` / `If-Modified-Since` requests so re-runs only download what has changed.
-
-The three documents and their canonical landing pages (cite these, not the resolved CDN URLs):
-
-- [TfL Business Plan](https://tfl.gov.uk/corporate/publications-and-reports/business-plan)
-- [Mayor's Transport Strategy 2018](https://www.london.gov.uk/programmes-strategies/transport/our-vision-transport/mayors-transport-strategy-2018)
-- [TfL Annual Report and Statement of Accounts](https://tfl.gov.uk/corporate/publications-and-reports/annual-report)
-
-PDFs are TfL / GLA public publications used per their published terms. tfl-monitor stores a local copy under `data/strategy_docs/` (gitignored) for reproducibility but does not redistribute the PDFs.
+Three TfL strategy PDFs are fetched, parsed via Docling, embedded with OpenAI
+`text-embedding-3-small`, and upserted into the Pinecone serverless index
+`tfl-strategy-docs`. The fetcher follows the canonical landing pages to
+discover the current direct-PDF URL, then issues conditional
+`If-None-Match` / `If-Modified-Since` requests so re-runs only download what
+has changed.
 
 ```bash
-# Run once to populate Pinecone (requires PINECONE_API_KEY + OPENAI_API_KEY in .env)
-uv run python -m rag.ingest
-
-# Re-scrape each landing page and rewrite the resolved direct-PDF URL in
-# src/rag/sources.json. Use this when TfL rolls the annual URL stem
-# (e.g. business-plan-2026 → business-plan-2027). The download is still
-# conditional via ETag — unchanged PDFs are 304'd.
-uv run python -m rag.ingest --refresh-urls
-
-# Bypass the ETag cache and re-download every PDF
+uv run python -m rag.ingest                # default — only refetch what changed
+uv run python -m rag.ingest --refresh-urls # rewrite resolved PDF URLs
 uv run python -m rag.ingest --force-refetch
-
-# Run fetch + parse + embed but skip the Pinecone upsert (sizing + smoke check)
-uv run python -m rag.ingest --dry-run
+uv run python -m rag.ingest --dry-run      # skip Pinecone upsert
 ```
 
-If 1 of 3 documents fails its fetch / parse / embed / upsert cycle, the others still complete; the CLI then exits with a non-zero status so any future cron / GitHub Action surfaces the failure instead of swallowing it.
+Cost: a full re-embedding of all three PDFs runs at well under £0.20 one-time.
+Conditional GETs and stable Pinecone IDs mean steady-state runs incur
+near-zero spend.
 
-PDFs cache under `data/strategy_docs/` (gitignored). ETag / sha256 state lives in `data/cache/sources_state.json` (also gitignored). The first run downloads ~60 MB total; subsequent runs typically skip every doc unless TfL has published a new version.
+## Production deployment (TM-A5)
 
-**Cost estimate.** A full re-embedding of all three PDFs runs at well under £0.20 one-time at the current `text-embedding-3-small` price ($0.02 per 1M tokens). Conditional GETs and stable Pinecone ids mean steady-state runs incur near-zero embedding spend.
+| Layer | Host | $/mo |
+|-------|------|------|
+| Backend compute (FastAPI + ingestion + Airflow) | AWS EC2 t4g.small spot via ASG | ~3-4 |
+| LLM | AWS Bedrock (Claude Sonnet 3.5 + Haiku 3.5) | ~2-3 |
+| Postgres warehouse + Airflow metadata | Supabase free | 0 |
+| Kafka broker | Redpanda Cloud Serverless free | 0 |
+| Vector DB | Pinecone serverless free | 0 |
+| Frontend | Vercel hobby free | 0 |
+| HTTPS | DuckDNS subdomain + Caddy auto-LE | 0 |
+| Image registry | GHCR (public repo) | 0 |
+| Observability | Logfire + LangSmith free tiers | 0 |
+| **Steady-state target** | | **~$5-8** |
 
-## Status — work packages
+Full design and provisioning runbook in
+[`docs/deployment`](https://hcslomeu.github.io/tfl-monitor/deployment/) and
+[`.claude/specs/TM-A5-plan.md`](./.claude/specs/TM-A5-plan.md).
 
-Project built as WPs organised into parallel tracks. Track labels indicate which directories a WP touches, so at most 2 agents work simultaneously without collision.
+## Status
 
-| Phase | WP | Title | Track | Status |
-|---|---|---|---|---|
-| 0 | TM-000 | Contracts and scaffold | — | ⬜ |
-| 1 | TM-A1 | Docker Compose + Postgres + Redpanda + Airflow | A-infra | ⬜ |
-| 1 | TM-B1 | Async TfL client + fixtures | B-ingestion | ⬜ |
-| 2 | TM-C1 | dbt scaffold | C-dbt | ⬜ |
-| 2 | TM-D1 | FastAPI skeleton + Logfire wiring | D-api-agent | ⬜ |
-| 3 | TM-B2 | `line-status` producer | B-ingestion | ⬜ |
-| 3 | TM-B3 | `line-status` consumer | B-ingestion | ⬜ |
-| 3 | TM-C2 | dbt staging + first mart | C-dbt | ⬜ |
-| 3 | TM-D2 | Wire endpoints to Postgres | D-api-agent | ⬜ |
-| 3 | TM-E1a | Next.js scaffold + shadcn + Network Now (mocked) | E-frontend | ⬜ |
-| 3 | TM-E1b | Network Now wired to real `/status/live` | E-frontend | ⬜ |
-| 4 | TM-B4 | arrivals + disruptions topics | B-ingestion | ⬜ |
-| 4 | TM-C3 | Remaining marts + tests + exposures | C-dbt | ⬜ |
-| 4 | TM-D3 | Remaining endpoints | D-api-agent | ⬜ |
-| 4 | TM-E2 | Disruption Log view | E-frontend | ⬜ |
-| 5 | TM-A2 | Airflow DAGs | A-infra | ⬜ |
-| 5 | TM-D4 | RAG ingestion: Docling → Pinecone | D-api-agent | ⬜ |
-| 6 | TM-D5 | LangGraph agent (SQL + RAG + Pydantic AI) | D-api-agent | ⬜ |
-| 6 | TM-E3 | Chat view with SSE | E-frontend | ⬜ |
-| 7 | TM-A3 | Supabase provisioning | A-infra | ⬜ |
-| 7 | TM-A4 | Redpanda Cloud | A-infra | ⬜ |
-| 7 | TM-A5 | Railway deploy (Airflow + API + agent + workers) | A-infra | ⬜ |
-| 7 | TM-E4 | Vercel deploy | E-frontend | ⬜ |
-| 7 | TM-F1 | README polish + demo video + live URL | F-polish | ⬜ |
+Codebase is feature-complete; the deploy track is the last open work.
+Source of truth for the WP ledger is [`PROGRESS.md`](./PROGRESS.md), mirrored
+in the [docs roadmap](https://hcslomeu.github.io/tfl-monitor/roadmap/).
+
+| Phase | Title | Status |
+|-------|-------|--------|
+| 0 | Contracts and scaffold | ✅ |
+| 1-2 | Compose, scaffold, dbt + FastAPI skeleton, TfL client | ✅ |
+| 3 | line-status producer + consumer, first mart, `/status/live` + `/status/history` + `/reliability/{id}`, Network Now mock + wired | ✅ |
+| 4 | arrivals + disruptions topics, remaining marts + exposures, `/disruptions/recent` + `/bus/{id}/punctuality`, Disruption Log view | ✅ |
+| 5 | Airflow DAGs, RAG ingestion (Docling → Pinecone) | ✅ |
+| 6 | LangGraph agent + Pydantic AI normaliser, Chat view with SSE | ✅ |
+| 7 | AWS Bedrock + EC2 deploy, Vercel deploy, demo video, live URL | 🚧 |
+
+## Folder map
+
+```text
+tfl-monitor/
+├─ contracts/        # OpenAPI + Pydantic + DDL — single source of truth
+├─ src/
+│  ├─ api/           # FastAPI app + LangGraph agent + Pydantic AI extraction
+│  ├─ ingestion/     # Async TfL client + producers + consumers
+│  ├─ rag/           # Docling → OpenAI → Pinecone ingestion
+│  └─ agent/         # Legacy graph (kept for parity until TM-A5 collapse)
+├─ dbt/              # Staging + marts + tests + exposures
+├─ airflow/          # DAGs (dbt nightly, RAG weekly)
+├─ web/              # Next.js 16 + shadcn dashboard
+├─ tests/            # Pytest unit + integration suites
+├─ scripts/          # Fixture seeding + TfL sample fetcher
+├─ docs/             # MkDocs Material site (this README's expanded form)
+└─ .claude/          # ADRs + WP specs + napkin (coordination memory)
+```
+
+Each folder has its own `README.md` walking its purpose, contents, and
+gotchas — see the docs site for the curated walkthrough.
 
 ## Data sources and attribution
 
-- **TfL Unified API** — live operational feeds. Powered by TfL Open Data. Contains OS data © Crown copyright and database rights.
-- **TfL publications** — Mayor's Transport Strategy, TfL Business Plan, TfL Annual Report. Public documents used under their published terms.
+- **TfL Unified API** — live operational feeds. Powered by TfL Open Data.
+  Contains OS data © Crown copyright and database rights.
+- **TfL publications** — Mayor's Transport Strategy, TfL Business Plan, TfL
+  Annual Report. Public documents used under their published terms.
 
 No personal data is collected, stored, or processed by tfl-monitor.
 
@@ -232,4 +286,6 @@ MIT. See [`LICENSE`](./LICENSE).
 
 ## Author
 
-Built by [Humberto Slomeu](https://github.com/hcslomeu) — AI engineer available for hire. [LinkedIn](https://www.linkedin.com/in/hcslomeu/)
+Built by **[Humberto Slomeu](https://github.com/hcslomeu)** — AI engineer
+available for hire.
+[LinkedIn](https://www.linkedin.com/in/hcslomeu/)

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -1,4 +1,78 @@
 # airflow/
 
-Scaffold only — DAGs land in TM-A2. The Dockerfile pins Airflow 2.10.3 and
-layers any extra provider packages from `requirements.txt`.
+Two DAGs orchestrate the batch-side of the project. Airflow 2.10 LocalExecutor,
+identical local ↔ prod surface (LocalExecutor inside the EC2 box in TM-A5).
+
+## DAGs
+
+| DAG | Schedule | What it runs |
+|-----|----------|--------------|
+| `dbt_nightly` | `0 1 * * *` (UTC) | `uv run dbt build --target dev` over the dbt project |
+| `rag_ingest_weekly` | `0 3 * * 1` (UTC, Monday) | `uv run python -m rag.ingest` (idempotent on HTTP 304) |
+
+```mermaid
+graph LR
+    DBT[dbt_nightly<br/>0 1 * * *] -->|BashOperator| DBTBUILD[uv run dbt build]
+    RAG[rag_ingest_weekly<br/>0 3 * * 1] -->|BashOperator| RAGRUN[uv run python -m rag.ingest]
+```
+
+A third DAG, `static_ingest`, is **deferred** until a `ref.lines` /
+`ref.stations` loader exists. Adding it is one ADR away.
+
+## Shared defaults
+
+```python
+default_args = {
+    "owner": "tfl-monitor",
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+}
+
+@dag(
+    dag_id="dbt_nightly",
+    schedule="0 1 * * *",
+    catchup=False,
+    max_active_runs=1,
+    default_args=default_args,
+)
+```
+
+`catchup=False` — backfilling several months of dbt builds on first deploy
+would burn warehouse budget for no value.
+`max_active_runs=1` — one nightly build at a time; a stuck run does not
+double-book.
+
+## Local boot
+
+```bash
+make up         # starts Airflow alongside Postgres + Redpanda
+# webserver: http://localhost:8080  (admin / admin in dev)
+```
+
+The Airflow image is multi-stage and bakes the project source into
+`/opt/tfl-monitor`. dbt builds run inside the scheduler container by
+shelling out to `uv run`.
+
+## Tests
+
+`tests/airflow/` contains four hermetic DAG-parse tests. They are excluded
+from the default `pytest` invocation via the `airflow` marker; opt in with:
+
+```bash
+uv run pytest -m airflow tests/airflow -v
+# or
+make airflow-test
+```
+
+Tests assert each DAG parses, has the expected `dag_id`, the documented
+schedule, and the expected number of tasks.
+
+## Hosting
+
+| Environment | How |
+|-------------|-----|
+| Local | `make up` brings up scheduler + webserver alongside Postgres / Redpanda |
+| Production | TM-A5 collapses scheduler + webserver onto the single EC2 box; logs land in a docker volume on the host |
+
+No remote logging in v1 — Logfire covers application traces; Airflow's task
+log volume is sufficient for portfolio-scale debugging.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,9 +1,63 @@
 # contracts/
 
-Single source of truth for interfaces crossing service boundaries. **Changes
-here require an ADR in `.claude/adrs/` and a broadcast to every consumer.**
+Single source of truth for every interface that crosses a service boundary.
+**Changes here require an ADR in `.claude/adrs/` and a cross-track broadcast.**
 
-- `schemas/` — Pydantic v2 models for each Kafka topic (producers and consumers agree here).
-- `openapi.yaml` — OpenAPI 3.1 spec for every HTTP endpoint; frontend types generated from this file.
-- `sql/` — Postgres DDL for raw and reference tables, applied in numeric order.
-- `dbt_sources.yml` — dbt sources derived from the DDL; copied into `dbt/sources/tfl.yml`.
+## What lives here
+
+```text
+contracts/
+├─ openapi.yaml               # OpenAPI 3.1 spec — every HTTP endpoint
+├─ schemas/                   # Pydantic v2 — Kafka events
+│  ├─ tfl_api.py              # tier-1: raw TfL Unified API shapes
+│  ├─ line_status.py          # tier-2: internal Kafka event
+│  ├─ arrivals.py             # tier-2: internal Kafka event
+│  └─ disruptions.py          # tier-2: internal Kafka event
+├─ sql/                       # Postgres DDL applied in numeric order
+│  ├─ 001_raw.sql             # raw.* tables (JSONB landing)
+│  ├─ 002_ref.sql             # ref.* lookups (lines, stations, modes)
+│  ├─ 003_analytics.sql       # analytics.* schema (dbt target)
+│  └─ 004_chat.sql            # analytics.chat_messages (TM-D5)
+└─ dbt_sources.yml            # dbt sources — copied into dbt/sources/tfl.yml
+```
+
+## Two-tier schema model
+
+```mermaid
+flowchart LR
+    TFL[TfL Unified API<br/>camelCase JSON] -->|tier-1 parse| C[tfl_client]
+    C -->|normalise| T2[tier-2 Pydantic event<br/>snake_case · frozen]
+    T2 -->|aiokafka| K[(Kafka)]
+    K --> CONSUMERS[consumers]
+    K --> SQL[(raw.* JSONB)]
+```
+
+| Tier | Where | Cardinality | Stability |
+|------|-------|-------------|-----------|
+| **Tier-1** | `schemas/tfl_api.py` | One model per TfL response shape | Optional-heavy; evolves at TfL's pace |
+| **Tier-2** | `schemas/{topic}.py` | One model per Kafka event | Frozen; every consumer reads one shape |
+
+Normalisation tier-1 → tier-2 is the ingestion client's job
+(`src/ingestion/tfl_client/normalise.py`). Synthetic SHA-256 IDs anchor
+disruptions whose upstream payload omits a stable identifier.
+
+## CI invariants
+
+| Drift gate | Mechanism |
+|------------|-----------|
+| `dbt_sources.yml` ↔ `dbt/sources/tfl.yml` | Bash diff in `.github/workflows/ci.yml` |
+| `openapi.yaml` ↔ FastAPI emitted OpenAPI | Pytest test in `tests/api/test_openapi_drift.py` |
+| `openapi.yaml` ↔ `web/lib/types.ts` | `pnpm exec openapi-typescript` regenerated and diffed in CI |
+
+## Adding to the contract
+
+Any change under `contracts/` triggers four downstream updates — three
+artefact regenerations and one ADR:
+
+1. `make openapi-ts` — re-emit `web/lib/types.ts` from the spec.
+2. Run `psql -f contracts/sql/00X_*.sql` against the dev DB.
+3. Re-copy `dbt_sources.yml` into `dbt/sources/tfl.yml` (or update both in
+   the same commit).
+4. Write an ADR at `.claude/adrs/NNN-title.md` explaining the change.
+
+The PR title must be prefixed with `contract:` so reviewers know to look.

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -1,5 +1,66 @@
 # dbt/
 
-Scaffold only — real staging, intermediate, and mart models land in TM-C2 and
-TM-C3. Sources mirror `contracts/dbt_sources.yml`. Run `make dbt-parse` after
-edits to verify the project still compiles.
+Postgres warehouse modelled in dbt — three staging models, four marts, five
+exposures, generic + singular tests, and lineage that ships with the code.
+
+## Layout
+
+```text
+dbt/
+├─ dbt_project.yml         # project metadata + path config
+├─ profiles.yml            # dev + ci targets (Postgres)
+├─ sources/
+│  └─ tfl.yml              # mirror of contracts/dbt_sources.yml
+├─ models/
+│  ├─ staging/             # stg_line_status, stg_arrivals, stg_disruptions
+│  └─ marts/               # mart_tube_reliability_*, mart_disruptions_*, mart_bus_metrics_*
+├─ tests/                  # 8 singular tests
+└─ exposures.yml           # 5 exposures wiring marts to API endpoints
+```
+
+## Lineage
+
+```mermaid
+flowchart TB
+    rls[(raw.line_status)] --> sls[stg_line_status] --> mrd[mart_tube_reliability_daily] --> mrds[mart_tube_reliability_daily_summary]
+    rar[(raw.arrivals)] --> sar[stg_arrivals] --> mbm[mart_bus_metrics_daily]
+    rds[(raw.disruptions)] --> sds[stg_disruptions] --> mdd[mart_disruptions_daily]
+```
+
+## Materialisation strategy
+
+| Layer | Materialisation | Notes |
+|-------|-----------------|-------|
+| Staging | `incremental` `merge` on `event_id`, 5-min lookback, `on_schema_change='fail'` | Defensive `row_number()` dedup |
+| Marts | `incremental` `merge` on composite grain | `(line_id, calendar_date_utc[, status_severity])` |
+
+`merge` is preferred over `delete+insert` for idempotent re-runs across late
+arrivals.
+
+## Local development
+
+```bash
+uv run task dbt-parse        # compile-only check (CI gate)
+uv run task dbt-build        # full build + tests against the dev profile
+uv run task dbt-run          # models only
+uv run task dbt-test          # tests only
+```
+
+The `dev` profile reads `POSTGRES_*` env vars; `ci` reads them from the
+GitHub Actions service container.
+
+## Tests
+
+| Type | Count | Examples |
+|------|-------|----------|
+| Generic | 14 | `unique`, `not_null`, `accepted_values`, `relationships` |
+| Singular | 8 | `pct_good_service ∈ [0, 100]`; `affected_routes` is valid JSONB; disruption category enum |
+
+Singular tests live under `dbt/tests/` and are picked up by `dbt test` /
+`dbt build` automatically.
+
+## Source-of-truth invariant
+
+`dbt/sources/tfl.yml` is a **byte-for-byte mirror** of
+`contracts/dbt_sources.yml`. CI gates the diff. Updating one without the
+other fails the lint job.

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -1,0 +1,42 @@
+# Architectural decisions
+
+ADRs (Architecture Decision Records) live under
+[`.claude/adrs/`](https://github.com/hcslomeu/tfl-monitor/tree/main/.claude/adrs).
+This page is a curated index — the authoritative text is in the repo so it
+travels with `git log`.
+
+| ID | Title | Status | Why it exists |
+|----|-------|--------|---------------|
+| 001 | [Redpanda over Apache Kafka](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/001-redpanda-over-kafka.md) | Accepted | Single-binary Kafka API; identical local ↔ prod surface |
+| 002 | [Contracts-first parallelism](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/002-contracts-first.md) | Accepted | Two-tier Pydantic schemas + OpenAPI as the single source of truth |
+| 003 | [Airflow on Railway](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/003-airflow-on-railway.md) | Superseded by 006 | Original deploy plan for Airflow on Railway free tier |
+| 004 | [Logfire + LangSmith split](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/004-logfire-langsmith-split.md) | Accepted | App vs LLM observability split — what goes where, why |
+| 005 | [Raw-table defaults](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/005-raw-table-defaults.md) | Accepted | DB-side `gen_random_uuid()` + `now()` defaults on `raw.*` |
+| 006 | AWS Bedrock + single-EC2 deploy | Pending (TM-A5) | Replaces 003: $100 AWS credit + Bedrock collapses to one box |
+
+## When does work need an ADR?
+
+If a PR does any of the following, it must ship an ADR alongside the diff:
+
+!!! warning "Mandatory ADR triggers"
+    - **Adds or modifies anything under `contracts/`** — schemas, OpenAPI,
+      DDL, dbt sources mirror.
+    - **Substitutes a locked tech-stack choice** — e.g. swapping Redpanda for
+      RabbitMQ, or LangGraph for LangChain agents.
+    - **Crosses a track boundary** — e.g. a D-track WP touching `src/ingestion/`
+      gets an ADR §"Consequences" entry declaring the cross-touch.
+    - **Adds a new long-running deployment artefact** — service in compose,
+      Airflow DAG, GitHub Actions workflow.
+
+The ADR template lives in
+[`.claude/adrs/`](https://github.com/hcslomeu/tfl-monitor/tree/main/.claude/adrs)
+and follows the standard Context / Decision / Consequences shape.
+
+## Why ADRs over wiki pages
+
+Two reasons:
+
+1. **They travel with git history.** A future reader cloning the repo can read
+   the entire decision log without internet access.
+2. **They are reviewable.** ADRs land via PRs and get reviewed like code, so
+   the decision and the diff that implements it ship together.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,210 @@
+# Architecture
+
+A bird's-eye view of how data flows from TfL into the dashboard, with every
+component pinned to a directory in the repo.
+
+## System diagram
+
+```mermaid
+flowchart LR
+    subgraph SRC[External sources]
+      TFL[TfL Unified API]
+      PDF[TfL strategy PDFs]
+    end
+
+    subgraph INGEST[Streaming ingestion]
+      P1[line-status producer]
+      P2[arrivals producer]
+      P3[disruptions producer]
+      KAFKA[(Redpanda<br/>Kafka topics)]
+      C1[line-status consumer]
+      C2[arrivals consumer]
+      C3[disruptions consumer]
+    end
+
+    subgraph WAREHOUSE[Postgres warehouse]
+      RAW[(raw.*<br/>JSONB)]
+      ANALYTICS[(analytics.*<br/>marts)]
+    end
+
+    subgraph DBT[dbt transformations]
+      STG[staging]
+      MART[marts + exposures]
+    end
+
+    subgraph RAG[RAG layer]
+      DOCLING[Docling parser]
+      EMB[OpenAI embeddings]
+      PINE[(Pinecone<br/>tfl-strategy-docs)]
+    end
+
+    subgraph SERVE[Serving layer]
+      AGENT[LangGraph agent<br/>5 typed tools]
+      API[FastAPI<br/>/status /reliability<br/>/disruptions /bus<br/>/chat/stream SSE]
+      WEB[Next.js dashboard]
+    end
+
+    subgraph OBS[Observability]
+      LS[LangSmith]
+      LF[Logfire]
+    end
+
+    TFL -->|httpx async polling| P1
+    TFL -->|httpx async polling| P2
+    TFL -->|httpx async polling| P3
+    P1 -->|Pydantic event| KAFKA
+    P2 -->|Pydantic event| KAFKA
+    P3 -->|Pydantic event| KAFKA
+    KAFKA --> C1 --> RAW
+    KAFKA --> C2 --> RAW
+    KAFKA --> C3 --> RAW
+    RAW --> STG --> MART --> ANALYTICS
+    PDF --> DOCLING --> EMB --> PINE
+    ANALYTICS --> AGENT
+    PINE --> AGENT
+    AGENT --> API
+    API -->|REST + SSE| WEB
+
+    AGENT -.traces.-> LS
+    API -.spans.-> LF
+    INGEST -.spans.-> LF
+    WAREHOUSE -.queries.-> LF
+```
+
+## Component-to-directory map
+
+| Layer | Directory | Runtime |
+|-------|-----------|---------|
+| Async TfL client | [`src/ingestion/tfl_client/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/ingestion/tfl_client) | Python 3.12 |
+| Producers (×3) | [`src/ingestion/producers/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/ingestion/producers) | aiokafka |
+| Consumers (×3) | [`src/ingestion/consumers/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/ingestion/consumers) | aiokafka + psycopg |
+| Broker | [`docker-compose.yml`](https://github.com/hcslomeu/tfl-monitor/blob/main/docker-compose.yml) | Redpanda local; Redpanda Cloud prod |
+| Warehouse | `raw.*`, `ref.*`, `analytics.*` schemas | Postgres 16 / Supabase |
+| dbt project | [`dbt/`](https://github.com/hcslomeu/tfl-monitor/tree/main/dbt) | dbt-core 1.9 |
+| Orchestration | [`airflow/dags/`](https://github.com/hcslomeu/tfl-monitor/tree/main/airflow/dags) | Airflow 2.10 LocalExecutor |
+| RAG ingestion | [`src/rag/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/rag) | Docling + OpenAI + Pinecone |
+| Agent | [`src/api/agent/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/api/agent) | LangGraph + Pydantic AI |
+| API | [`src/api/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/api) | FastAPI + sse-starlette |
+| Frontend | [`web/`](https://github.com/hcslomeu/tfl-monitor/tree/main/web) | Next.js 16 + shadcn |
+| Contracts | [`contracts/`](https://github.com/hcslomeu/tfl-monitor/tree/main/contracts) | OpenAPI + Pydantic + SQL DDL |
+
+## Data flow walkthrough
+
+### 1. Producers poll TfL and emit Pydantic events
+
+Each producer is an async daemon that wakes on a fixed cadence
+(`LineStatusProducer` every 30 s, `ArrivalsProducer` every 30 s across 5 NaPTAN
+hubs, `DisruptionsProducer` every 300 s across 4 modes), normalises the tier-1
+TfL payload into a tier-2 [Pydantic event](pipelines/ingestion.md#contracts),
+and publishes to Kafka with `acks="all"` and a stable partition key.
+
+### 2. Consumers idempotently land into `raw.*`
+
+`RawEventConsumer[E]` is generic over the event type; `RawEventWriter(table)`
+runs `INSERT … ON CONFLICT (event_id) DO NOTHING` over a single async psycopg
+connection with reconnect-on-`OperationalError`. Lag is traced on every span.
+
+### 3. dbt stages and marts
+
+Staging models (`stg_line_status`, `stg_arrivals`, `stg_disruptions`) unnest
+JSONB into typed columns with defensive `row_number()` dedup. Marts are
+incremental `merge` on stable composite grains and ship with generic + singular
+tests.
+
+```mermaid
+flowchart TB
+    raw_line_status[(raw.line_status<br/>JSONB)] --> stg_line_status[stg_line_status]
+    raw_arrivals[(raw.arrivals)] --> stg_arrivals[stg_arrivals]
+    raw_disruptions[(raw.disruptions)] --> stg_disruptions[stg_disruptions]
+
+    stg_line_status --> reli_daily[mart_tube_reliability_daily]
+    reli_daily --> reli_summary[mart_tube_reliability_daily_summary]
+    stg_disruptions --> disruption_mart[mart_disruptions_daily]
+    stg_arrivals --> bus_mart[mart_bus_metrics_daily]
+```
+
+### 4. RAG ingest is conditional and idempotent
+
+`uv run python -m rag.ingest` resolves the live PDF URL on each landing page,
+issues conditional `If-None-Match` / `If-Modified-Since` GETs, parses with
+Docling's `HybridChunker`, async-batches OpenAI embeddings (100/req, retry on
+429), and upserts into Pinecone with `sha256("{url}::{idx}")` ids — one
+namespace per document, delete-namespace-on-rollover for clean idempotency.
+
+### 5. Agent fans out across five typed tools
+
+```mermaid
+graph TD
+    Q[User question] --> ROUTER{LangGraph<br/>create_react_agent}
+    ROUTER -->|live ops| T1[query_tube_status]
+    ROUTER -->|reliability| T2[query_line_reliability]
+    ROUTER -->|disruptions| T3[query_recent_disruptions]
+    ROUTER -->|bus| T4[query_bus_punctuality]
+    ROUTER -->|strategy| T5[search_tfl_docs]
+
+    T1 --> WH[(warehouse)]
+    T2 --> WH
+    T3 --> WH
+    T4 --> WH
+    T5 --> PC[(Pinecone)]
+
+    T2 -.normalisation.-> PA[Pydantic AI<br/>Haiku LineId extractor]
+```
+
+`compile_agent` returns `None` if any of `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
+/ `PINECONE_API_KEY` is missing, so `/chat/stream` 503s while the history
+endpoint keeps working off `DATABASE_URL` alone.
+
+### 6. SSE projection over LangGraph events
+
+```mermaid
+sequenceDiagram
+  participant W as Web (chat-view)
+  participant A as FastAPI /chat/stream
+  participant G as LangGraph
+  participant DB as analytics.chat_messages
+  W->>A: POST {thread_id, message}
+  A->>DB: INSERT user turn
+  A->>G: agent.astream(stream_mode=["messages","updates"])
+  G-->>A: token / tool / token …
+  A-->>W: data: {"type":"token",...}\n\n
+  G-->>A: end
+  A->>DB: INSERT assistant turn (concatenated tokens)
+  A-->>W: data: {"type":"end",...}\n\n
+```
+
+## Contracts
+
+`contracts/` is the single source of truth for every cross-service interface:
+
+```mermaid
+graph LR
+    subgraph C[contracts/]
+      OAPI[openapi.yaml]
+      PYD[schemas/*.py]
+      SQL[sql/*.sql]
+      DBTSRC[dbt_sources.yml]
+    end
+
+    OAPI --> WEB[web/lib/types.ts<br/>via openapi-typescript]
+    OAPI --> API[FastAPI route signatures]
+    PYD --> PROD[producers]
+    PYD --> CONS[consumers]
+    SQL --> PG[Postgres DDL]
+    SQL --> DBTSRC
+    DBTSRC --> DBT[dbt sources]
+```
+
+Two tiers of Pydantic schemas separate the messy outside world from the clean
+internal wire format — see [tier-1 vs tier-2](pipelines/ingestion.md#contracts).
+
+## Related ADRs
+
+The handful of cross-cutting decisions worth a paper trail:
+
+- [001 — Redpanda over Apache Kafka](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/001-redpanda-over-kafka.md)
+- [002 — Contracts-first parallelism](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/002-contracts-first.md)
+- [003 — Airflow on Railway](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/003-airflow-on-railway.md) (superseded by 006)
+- [004 — Logfire + LangSmith split](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/004-logfire-langsmith-split.md)
+- [005 — Raw-table defaults](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/005-raw-table-defaults.md)
+- 006 — AWS Bedrock + single-EC2 deploy *(landing with TM-A5)*

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="28" fill="#1f2937"/>
+  <text x="32" y="42" font-family="Inter, sans-serif" font-size="32" font-weight="700"
+        text-anchor="middle" fill="#ffffff">tfl</text>
+</svg>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,184 @@
+# Deployment
+
+The production stack is intentionally minimalist: **one EC2 spot instance**
+runs the existing docker-compose layout, **AWS Bedrock** powers the LLM, and
+every other tier rides on a free plan. The full design is locked in
+[`.claude/specs/TM-A5-plan.md`](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/specs/TM-A5-plan.md).
+
+## Cost lock
+
+| Layer | Host | Tier | $/mo |
+|-------|------|------|------|
+| Backend compute | AWS EC2 t4g.small **spot** (`us-east-1`) via ASG min=max=1 | persistent spot | ~3-4 |
+| LLM | AWS Bedrock — `claude-3-5-sonnet-20241022-v2:0` + `claude-3-5-haiku-20241022-v1:0` | on-demand | ~2-3 |
+| Postgres warehouse + Airflow metadata | Supabase | free | 0 |
+| Kafka broker | Redpanda Cloud Serverless | free | 0 |
+| Frontend | Vercel | hobby | 0 |
+| Vector DB | Pinecone serverless | free | 0 |
+| HTTPS termination | DuckDNS subdomain + Caddy auto Let's Encrypt | — | 0 |
+| Image registry | GHCR (public repo) | free | 0 |
+| Observability | Logfire + LangSmith | free | 0 |
+| Bandwidth (≈1 GB egress/mo) | AWS | — | ~0.10 |
+| **Steady-state target** | | | **~$5-8** |
+
+A CloudWatch billing alarm fires at $20/mo as the safety net (~10× the
+expected burn).
+
+## Topology on the box
+
+```mermaid
+flowchart TB
+    INET((Internet))
+    INET -->|443 / 80| CADDY
+    subgraph EC2["EC2 t4g.small spot · Amazon Linux 2023 ARM64"]
+      direction TB
+      subgraph DOCKER["docker compose -f infra/docker-compose.prod.yml"]
+        CADDY[Caddy<br/>auto Let's Encrypt]
+        API[api<br/>FastAPI :8000]
+        PROD[producers<br/>3 daemons in 1 process]
+        CONS[consumers<br/>3 daemons in 1 process]
+        SCH[airflow-scheduler]
+        WEB[airflow-webserver]
+      end
+    end
+    subgraph CLOUD[Managed services]
+      SB[(Supabase Postgres)]
+      RP[(Redpanda Cloud)]
+      PC[(Pinecone)]
+      BR[AWS Bedrock]
+    end
+    subgraph EDGE[Edge]
+      VER[Vercel<br/>tfl-monitor.vercel.app]
+    end
+    CADDY --> API
+    CADDY --> WEB
+    API --> SB
+    API --> BR
+    API --> PC
+    PROD --> RP
+    CONS --> RP
+    CONS --> SB
+    SCH --> SB
+    SCH --> RP
+    VER -.fetch.-> CADDY
+```
+
+Six long-running services on one box (down from 9 in local dev): three
+ingestion producers and three consumers each collapsed into one `asyncio.gather`
+process, plus Airflow (scheduler + webserver), the FastAPI process, and
+Caddy.
+
+## What changed from the original plan
+
+The first iteration of TM-A5 targeted Railway for the backend. Two budget
+constraints flipped the design:
+
+1. The author has **$100 of AWS credit** to spread across two portfolio
+   projects, so AWS-only compute is now essentially free.
+2. Anthropic-direct API spend is real money; **Bedrock pricing** for the same
+   models lands in the same $100 credit envelope.
+
+Hence:
+
+- Single EC2 spot replaces Railway's API + worker boxes.
+- Bedrock replaces Anthropic-direct in production (`ChatBedrockConverse` +
+  `pydantic-ai "bedrock:..."` model strings).
+- Anthropic-direct stays as an opt-in **local-dev fallback** so contributors
+  who only have an Anthropic key can still run the agent.
+
+ADR 003 (Airflow on Railway) becomes superseded by ADR 006 (Bedrock +
+single-EC2 deploy), committed alongside TM-A5.
+
+## Provisioning runbook (high-level)
+
+The full step-by-step runbook lives in
+[`.claude/specs/TM-A5-plan.md` §3](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/specs/TM-A5-plan.md).
+
+```mermaid
+flowchart LR
+    PRE[Step 0<br/>Laptop prereqs] --> BR[Step 1<br/>Bedrock model access]
+    BR --> SAAS[Step 2<br/>Supabase + Redpanda<br/>+ Pinecone + DuckDNS]
+    SAAS --> PR1[PR-1<br/>Bedrock swap +<br/>ingestion collapse]
+    PR1 --> PR2[PR-2<br/>Terraform +<br/>compose.prod +<br/>Caddy + GHA OIDC]
+    PR2 --> FIRST[First deploy<br/>SSM session →<br/>paste .env →<br/>bootstrap]
+    FIRST --> SMOKE[Smoke<br/>curl /health<br/>/status/live<br/>/chat/stream]
+    SMOKE --> PR3[PR-3<br/>ADR 006 +<br/>doc updates]
+```
+
+## Three PRs under the TM-A5 banner
+
+| # | Branch | Tracks | Approx LoC |
+|---|--------|--------|-----------|
+| **PR-1** | `feature/TM-A5-bedrock-swap` | D-api-agent + B-ingestion (declared cross-track) | ~200 src + 80 tests |
+| **PR-2** | `feature/TM-A5-aws-deploy` | A-infra | ~450 |
+| **PR-3** | `feature/TM-A5-adr-progress` | meta (ADRs + ARCHITECTURE / README / PROGRESS) | ~250 markdown |
+
+## Image build + deploy pipeline
+
+```mermaid
+sequenceDiagram
+    participant Dev as Author push
+    participant GHA as GitHub Actions
+    participant GHCR as GHCR
+    participant SSM as AWS SSM
+    participant EC2 as EC2 spot
+
+    Dev->>GHA: push to main
+    GHA->>GHA: matrix build (api, ingestion, airflow)
+    GHA->>GHCR: docker buildx push --platform linux/arm64
+    GHA->>SSM: aws ssm send-command (OIDC role)
+    SSM->>EC2: cd repo && docker compose pull && up -d
+    EC2-->>Dev: services restart, health checks pass
+```
+
+Authentication chain:
+
+1. GitHub OIDC token → IAM role with `ssm:SendCommand`.
+2. EC2 instance profile with `bedrock:InvokeModel*` scoped to the two model
+   ARNs only — no AWS access keys live anywhere on disk.
+3. GHCR pull on the box uses a short-lived `read:packages` PAT pasted once
+   into `.env`.
+
+## Reverse proxy + TLS
+
+```caddy
+{
+    email tflmonitor@example.com
+}
+
+tflmonitor.duckdns.org {
+    handle_path /airflow* {
+        reverse_proxy airflow-webserver:8080
+    }
+    reverse_proxy api:8000 {
+        flush_interval -1   # disable buffering for SSE
+    }
+}
+```
+
+`flush_interval -1` is the difference between SSE working and timing out —
+Caddy buffers by default, which breaks the chat stream.
+
+DuckDNS keeps `tflmonitor.duckdns.org` pointed at the EIP via a 5-minute cron
+on the box. Re-pointing to a custom domain in TM-F1 is one Caddyfile line.
+
+## Disaster scenarios
+
+| Risk | Response |
+|------|----------|
+| Spot interruption | ASG re-launches on `persistent` spot; ~5 min downtime per event, ~1-2× / week |
+| EBS volume loss on spot reclaim | `delete_on_termination = false` preserves the volume; ASG re-attaches |
+| Bedrock model access denied | Fall back to Anthropic-direct via `.env` (`unset BEDROCK_REGION` + set `ANTHROPIC_API_KEY`) |
+| RAM saturation on t4g.small | Drop Airflow webserver (CLI-only operations) — saves ~250 MB |
+| Free-tier expiry on Supabase / Redpanda / Pinecone | All three are indefinite at portfolio scale; documented limits in README |
+| Bedrock cost spike | CloudWatch billing alarm @ $20/mo notifies via SNS |
+
+## Rollback paths
+
+Three granularities:
+
+1. **Per-image** — `docker compose pull` against a previous SHA tag (GHCR
+   retains all SHA tags).
+2. **Per-PR** — `git revert -m 1 <merge-sha>` then `terraform apply`.
+3. **Whole-pivot** — revert the three TM-A5 PRs and ship ADR 003's Railway
+   plan (preserved in git history).

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -1,0 +1,174 @@
+# Engineering principles
+
+The principles below are not aspirations — they are review gates. Every PR is
+checked against them by the author and by Codex (acting as a reviewer agent).
+
+## Lean by default
+
+```mermaid
+quadrantChart
+    title Engineering trade-off space
+    x-axis Hard to review --> Easy to review
+    y-axis Few moving parts --> Many moving parts
+    quadrant-1 "Sweet spot for this repo"
+    quadrant-2 "Fragile but readable"
+    quadrant-3 "Avoid"
+    quadrant-4 "Over-engineered"
+    "1 pyproject + flat compose": [0.85, 0.25]
+    "Sub-packages with own toml": [0.20, 0.75]
+    "Single AbstractVectorStore": [0.30, 0.65]
+    "Plain pinecone client": [0.85, 0.30]
+    "Custom Typer CLI": [0.30, 0.55]
+    "python -m module entry": [0.80, 0.25]
+```
+
+The repo is reviewed by a human + Codex. Anything that takes Codex more than
+30 s to understand *why* it exists is over-engineered.
+
+## Four hard rules
+
+| Rule | Meaning | In practice |
+|------|---------|-------------|
+| **DRY** | Don't Repeat Yourself | Search for an existing helper before writing a new one |
+| **KISS** | Keep It Simple, Stupid | Prefer the most direct working solution |
+| **YAGNI** | You Aren't Gonna Need It | Build only what the WP asks for |
+| **SoC** | Separation of Concerns | One module, one purpose |
+
+The pattern that flags every violation: *"is there a second consumer right
+now?"* If no — the abstraction can wait.
+
+## Contracts-first parallelism
+
+Every cross-service interface lives in `contracts/`. Two tiers of Pydantic
+schemas separate the messy outside world from the clean internal wire format,
+so producers, consumers, FastAPI, and the frontend can be built in parallel by
+separate agents without colliding.
+
+```mermaid
+flowchart TB
+    subgraph SOURCE[contracts/]
+      OAPI[openapi.yaml<br/>OpenAPI 3.1]
+      T1[schemas/tfl_api.py<br/>tier-1 raw shapes]
+      T2[schemas/{line_status,arrivals,disruptions}.py<br/>tier-2 frozen events]
+      DDL[sql/00*.sql<br/>raw + ref + analytics]
+      DBTSRC[dbt_sources.yml]
+    end
+
+    OAPI -->|openapi-typescript| TS[web/lib/types.ts]
+    OAPI -->|FastAPI route shapes| API[src/api]
+    T1 -->|tfl_client normalises| ING[src/ingestion]
+    T2 -->|wire format| KAFKA[(Kafka)]
+    DDL -->|psql -f| PG[(Postgres)]
+    DBTSRC -->|copied to| DBTSOURCES[dbt/sources/tfl.yml]
+```
+
+CI enforces the source-of-truth via `diff contracts/dbt_sources.yml
+dbt/sources/tfl.yml` and a bidirectional OpenAPI ↔ Python drift test.
+
+## Kafka earns its place
+
+A cron-to-Postgres pipeline would technically deliver the same rows. Kafka is
+worth its operational cost only because we exploit three properties:
+
+1. **Decoupling** — producers keep polling while consumers redeploy.
+2. **Replay** — rewinding `line-status` re-hydrates `stg_line_status` without a
+   re-poll.
+3. **Fan-out** — the same `arrivals` topic feeds `mart_bus_metrics_daily` and
+   could feed a future live-dashboard pusher with no producer change.
+
+If the WP only needed (1), we would skip Kafka. We exploit all three.
+
+## dbt over raw SQL
+
+```mermaid
+graph LR
+    raw[(raw.*<br/>JSONB landing)] --> stg[stg_*<br/>incremental merge<br/>defensive dedup]
+    stg --> ints[int_* if needed]
+    ints --> marts[mart_*<br/>composite-grain<br/>generic + singular tests]
+    marts --> exposures[Exposures<br/>→ /reliability /disruptions /bus]
+```
+
+Raw SQL would also work — until a second person reads the codebase. dbt buys
+us tests, lineage, and one-line documentation that ships with the code.
+
+## Agent that does not hallucinate
+
+Two design choices keep the agent honest:
+
+1. **All five tools have typed Pydantic input/output.** The model cannot call
+   `query_line_reliability` with a malformed `line_id` — Pydantic AI's Haiku
+   normaliser canonicalises free text first.
+2. **Retrieval cites chunks.** The RAG tool returns Pinecone chunks with their
+   `doc_id` and `page` so any answer is traceable to a paragraph in a public
+   document. LangSmith records the exact chunks that made it into the context.
+
+If the answer hallucinates, the trace shows where — and the next iteration
+prunes the bad retrieval, not "the LLM."
+
+## Observability split
+
+| Question | Tool |
+|----------|------|
+| How did the agent arrive at that answer? | LangSmith |
+| Which chunks made it into the prompt? | LangSmith |
+| How many tokens did this conversation cost? | LangSmith |
+| Is the Kafka consumer keeping up? | Logfire |
+| Why is `/reliability/{line_id}` p99 latency high? | Logfire |
+| Is TfL throttling us with 429s? | Logfire |
+
+Two hosted tools, zero self-hosted telemetry. ADR 004 has the full rationale.
+
+## Security-first mindset
+
+A short list of non-negotiables, enforced by Bandit + manual review:
+
+- **Zero-trust** — never trust client data; revalidate on the backend.
+- **Secrets** — `SecretStr` (Pydantic) and env vars; nothing in source.
+- **Parameterised queries** — always; no f-string SQL.
+- **CORS** — explicit allowlist; never `*` in production.
+- **Security headers in Next.js** — `X-Frame-Options: DENY`,
+  `X-Content-Type-Options: nosniff`,
+  `Referrer-Policy: strict-origin-when-cross-origin`.
+- **Bandit in CI** — blocks on HIGH severity.
+- **Post-generation bug hunt** — after writing auth or data-handling code, ask
+  *"how would a malicious user bypass this?"* before the PR opens.
+
+## Three-phase WP delivery
+
+For non-trivial WPs the agent runs three phases with `/clear` between them, so
+each phase enters a fresh context window.
+
+```mermaid
+flowchart LR
+    R[Phase 1<br/>Research<br/>read-only] --> CLR1[/clear/]
+    CLR1 --> P[Phase 2<br/>Plan<br/>interactive,<br/>open questions resolved]
+    P --> CLR2[/clear/]
+    CLR2 --> I[Phase 3<br/>Implementation<br/>internal phases<br/>tests after each]
+```
+
+Every spec is a triple under `.claude/specs/`:
+
+```
+TM-XXX-research.md
+TM-XXX-plan.md
+TM-XXX-spec.md   (older WPs only — newer ones merge into the plan)
+```
+
+Phase 3 stops if reality diverges from the plan and reports:
+
+> "Expected: X. Found: Y. How should I proceed?"
+
+This ships small, intentional PRs and avoids drift.
+
+## Trivial vs non-trivial
+
+| Type | Treatment |
+|------|-----------|
+| Typo, one-line fix, dependency bump | Direct PR, tests already cover it |
+| New endpoint with one query | Plan inline, implement, ship |
+| New ingestion topic, new mart, new agent tool | Three phases, fresh context per phase |
+| Anything touching `contracts/` | Mandatory ADR + cross-track broadcast |
+
+Track boundaries (A-infra / B-ingestion / C-dbt / D-api-agent / E-frontend /
+F-polish) keep at most two agents on the codebase concurrently without
+collisions.

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -148,7 +148,7 @@ flowchart LR
 
 Every spec is a triple under `.claude/specs/`:
 
-```
+```text
 TM-XXX-research.md
 TM-XXX-plan.md
 TM-XXX-spec.md   (older WPs only — newer ones merge into the plan)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,86 @@
+# Glossary
+
+Project-specific vocabulary and TfL-specific terms a reviewer might not know.
+
+## Project terms
+
+`WP`
+:   Work Package — the unit of work in this project. Identified `TM-XXX` (e.g.
+    `TM-A5`). Each WP owns a directory track and ships in one PR. Specs live
+    under `.claude/specs/TM-XXX-{spec,research,plan}.md`.
+
+`Track`
+:   A directory boundary. **A** infra, **B** ingestion, **C** dbt,
+    **D** api-agent, **E** frontend, **F** polish. At most two agents work
+    concurrently on different tracks.
+
+`Tier-1 schema`
+:   Pydantic model mirroring the **raw TfL Unified API** payload — camelCase,
+    optional-heavy. Lives in `contracts/schemas/tfl_api.py`. Ingestion parses
+    these on the wire.
+
+`Tier-2 schema`
+:   Pydantic model in **internal Kafka wire format** — snake_case, frozen,
+    flat. Lives in `contracts/schemas/{line_status,arrivals,disruptions}.py`.
+    Producers emit these; consumers and downstream services speak only this.
+
+`ADR`
+:   Architecture Decision Record. Markdown file under `.claude/adrs/` with
+    Context / Decision / Consequences. Required for every change under
+    `contracts/` or any tech-stack substitution.
+
+`Napkin`
+:   A continuously curated runbook at `.claude/napkin.md` (not a session log)
+    capturing recurring high-value guidance for future agents.
+
+## TfL domain terms
+
+`NaPTAN`
+:   National Public Transport Access Node. The UK-wide identifier for stops
+    and stations. Five NaPTAN hubs are sampled by the arrivals producer.
+
+`ATCO`
+:   Association of Transport Coordinating Officers. ATCO codes are the
+    granular bus-stop identifier used in TfL bus arrivals.
+
+`Line ID`
+:   TfL's slug for a transit line — e.g. `piccadilly`, `elizabeth`,
+    `bakerloo`. The `LineId` Pydantic AI normaliser converts free-text
+    questions ("how's the Piccadilly?") into the canonical slug.
+
+`Mode`
+:   TfL's transport-mode classifier — `tube`, `bus`, `dlr`, `overground`,
+    `elizabeth-line`, `tram`, `cable-car`. The disruptions producer polls
+    four modes.
+
+`Status severity`
+:   TfL's enum: `Good Service`, `Minor Delays`, `Severe Delays`, `Part Closure`,
+    `Suspended`, etc. `mart_tube_reliability_daily` aggregates per
+    `(line_id, calendar_date, status_severity)`.
+
+## Stack terms
+
+`Logfire span`
+:   An OpenTelemetry span emitted by Logfire's auto-instrumentation. One per
+    request, query, or HTTP call.
+
+`LangSmith trace`
+:   A LangChain-native trace covering an entire `/chat/stream` invocation —
+    every node, tool call, LLM call, and retrieval inside the LangGraph run.
+
+`SSE` (Server-Sent Events)
+:   The streaming protocol used by `/chat/stream`. Frames are
+    `data: {…}\n\n`-terminated JSON. Caddy needs `flush_interval -1` to avoid
+    buffering them.
+
+`create_react_agent`
+:   LangGraph's prebuilt ReAct loop — model picks tools, runs them, feeds the
+    output back to the model, terminates on a final assistant message.
+
+`Pydantic AI`
+:   Anthropic's typed LLM client; we use it inside one tool (`LineId`
+    extraction with Haiku). LangGraph remains the main agent.
+
+`HybridChunker`
+:   Docling 2.x utility that chunks a parsed document by sections + tables
+    rather than by raw character count, preserving semantic structure.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -78,7 +78,7 @@ Project-specific vocabulary and TfL-specific terms a reviewer might not know.
     output back to the model, terminates on a final assistant message.
 
 `Pydantic AI`
-:   Anthropic's typed LLM client; we use it inside one tool (`LineId`
+:   A typed Python agent framework from the Pydantic team; we use it inside one tool (`LineId`
     extraction with Haiku). LangGraph remains the main agent.
 
 `HybridChunker`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,126 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+# tfl-monitor
+
+> A real-time data + AI engineering portfolio: streaming Transport for London
+> feeds into a dbt-modelled warehouse, with a LangGraph agent that routes
+> between SQL over the warehouse and RAG over TfL strategy documents.
+
+<div class="grid cards" markdown>
+
+-   :material-train-variant:{ .lg .middle } **Live operational data**
+
+    ---
+
+    Async pollers fan TfL line-status, arrivals, and disruptions onto Kafka
+    topics every 30 s — replayable, decoupled from consumers.
+
+    [:octicons-arrow-right-24: Streaming ingestion](pipelines/ingestion.md)
+
+-   :material-database-outline:{ .lg .middle } **dbt-modelled warehouse**
+
+    ---
+
+    Staging + mart models with `merge` incrementality, generic + singular
+    tests, and exposures wiring marts to API endpoints.
+
+    [:octicons-arrow-right-24: dbt warehouse](pipelines/warehouse.md)
+
+-   :material-robot-outline:{ .lg .middle } **Agent that doesn't hallucinate**
+
+    ---
+
+    LangGraph routes between five typed tools (4 SQL + 1 RAG). Pydantic AI
+    extracts structured arguments. Every step traced in LangSmith.
+
+    [:octicons-arrow-right-24: LangGraph agent](pipelines/agent.md)
+
+-   :material-chart-line:{ .lg .middle } **Production-ready observability**
+
+    ---
+
+    LangSmith for LLM/agent decisions, Logfire for FastAPI / Postgres / HTTP.
+    Zero self-hosted telemetry to babysit.
+
+    [:octicons-arrow-right-24: Observability](observability.md)
+
+-   :material-cloud-outline:{ .lg .middle } **Deployable for ~$6/month**
+
+    ---
+
+    Single EC2 spot box + AWS Bedrock + free-tier Supabase / Redpanda Cloud /
+    Vercel / Pinecone. $100 AWS credit covers ~12 months.
+
+    [:octicons-arrow-right-24: Deployment](deployment.md)
+
+-   :material-format-list-checks:{ .lg .middle } **Built in tracked WPs**
+
+    ---
+
+    25 work packages organised into parallel tracks; every WP shipped with
+    tests, ADRs for cross-cutting decisions, contracts-first parallelism.
+
+    [:octicons-arrow-right-24: Roadmap](roadmap.md)
+
+</div>
+
+## What you can ask the agent
+
+```text
+"Which Tube line had the worst reliability last week?"
+   → routes to SQL tool → mart_tube_reliability_daily_summary
+
+"What's TfL's strategy for Piccadilly Line upgrades?"
+   → routes to RAG tool → Pinecone over TfL Business Plan + MTS 2018 +
+     Annual Report (Docling-parsed)
+
+"Is the 207 bus running on time near Ealing Hospital?"
+   → SQL → bus punctuality proxy from arrivals topic
+```
+
+## Why this exists
+
+A portfolio that demonstrates the full data + AI engineering loop on a
+realistic public dataset, not a CRUD demo or a notebook prototype:
+
+- **Streaming that earns its broker.** Four polling endpoints with sub-minute
+  cadence, multiple consumers fanning out from the same topic.
+- **A warehouse modelled properly.** dbt staging → marts with tests, exposures,
+  documentation, and idempotent `merge` incrementality.
+- **An agent grounded in real data and real documents.** SQL tools run typed
+  Pydantic-validated queries; RAG retrieval cites exact PDF chunks.
+- **Everything traced.** LangSmith answers "why did the agent decide X?";
+  Logfire answers "why is the consumer lagging?".
+
+## Tech stack at a glance
+
+| Layer | Choice |
+|-------|--------|
+| Streaming broker | Redpanda (Kafka API) |
+| Warehouse | PostgreSQL 16 / Supabase |
+| Transformations | dbt-core |
+| Orchestration | Apache Airflow 2.10 |
+| Ingestion | Python 3.12 + `httpx` + `aiokafka` |
+| API | FastAPI + `sse-starlette` |
+| Agent | LangGraph 1.x + Pydantic AI |
+| RAG | LlamaIndex + Pinecone + Docling |
+| Frontend | Next.js 16 + shadcn/ui + Biome |
+| LLM observability | LangSmith |
+| App observability | Logfire |
+| Deploy | AWS EC2 spot + Bedrock + Supabase + Redpanda Cloud + Vercel |
+
+[:octicons-arrow-right-24: Full tech-stack table](stack.md){ .md-button }
+[:octicons-arrow-right-24: Architecture deep-dive](architecture.md){ .md-button .md-button--primary }
+
+## About the author
+
+Built by **[Humberto Slomeu](https://github.com/hcslomeu)** — AI engineer
+available for hire.
+
+[:fontawesome-brands-github: GitHub](https://github.com/hcslomeu) ·
+[:fontawesome-brands-linkedin: LinkedIn](https://www.linkedin.com/in/hcslomeu/) ·
+[:material-source-repository: Source code](https://github.com/hcslomeu/tfl-monitor)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,142 @@
+# Observability
+
+Two hosted tools, clearly separated by concern. No self-hosted telemetry stack.
+
+```mermaid
+flowchart LR
+    subgraph SRC[Sources of telemetry]
+      INGEST[Producers + Consumers]
+      API[FastAPI handlers]
+      AGENT[LangGraph agent]
+      DB[(Postgres)]
+      HTTP[httpx outbound]
+    end
+
+    subgraph TELEMETRY[Telemetry collectors]
+      LF[Logfire<br/>OpenTelemetry-native]
+      LS[LangSmith<br/>LangChain-native]
+    end
+
+    INGEST -.spans + structured logs.-> LF
+    API -.spans.-> LF
+    DB -.psycopg spans.-> LF
+    HTTP -.client spans.-> LF
+    AGENT -.LLM + tool + node traces.-> LS
+```
+
+## What goes where
+
+| Question | Tool |
+|----------|------|
+| How did the agent arrive at that answer? | **LangSmith** |
+| Which chunks did the retriever pull? | **LangSmith** |
+| How many tokens did this conversation cost? | **LangSmith** |
+| Why did the router pick the SQL tool over RAG? | **LangSmith** |
+| Which TfL endpoint is throttling us with 429s? | **Logfire** |
+| Why is `/reliability/{line_id}` p99 latency high? | **Logfire** |
+| Is the `arrivals` consumer keeping up with the topic? | **Logfire** |
+| Did the Pinecone upsert succeed? | **Logfire** |
+
+The split is captured formally in [ADR 004 — Logfire + LangSmith
+split](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/004-logfire-langsmith-split.md).
+
+## Logfire wiring
+
+Initialised once in each service entrypoint:
+
+```python
+import logfire
+
+logfire.configure(service_name="tfl-monitor-api")
+logfire.instrument_fastapi(app)
+logfire.instrument_psycopg()
+logfire.instrument_httpx()
+```
+
+What this gives us out of the box:
+
+- One span per FastAPI request, with route + status + duration.
+- One span per psycopg query, with the parameterised SQL.
+- One span per httpx outbound request, with the URL and status.
+- Structured logs via `logfire.info("kafka.consume", lag=…, partition=…)`
+  rather than `print()` or bare `logging`.
+
+### Service boundaries traced
+
+| Span namespace | Code path |
+|----------------|-----------|
+| `tfl-monitor-api` | FastAPI request handlers |
+| `ingestion.line_status.*` | line-status producer + consumer |
+| `ingestion.arrivals.*` | arrivals producer + consumer |
+| `ingestion.disruptions.*` | disruptions producer + consumer |
+| `kafka.produce`, `kafka.consume` | aiokafka events with lag |
+| `httpx.client` | TfL Unified API calls (`app_key` redacted) |
+| `psycopg.*` | Postgres queries |
+
+`app_key` is **redacted before the span is emitted** — see
+`src/ingestion/observability.py`.
+
+## LangSmith wiring
+
+Set three env vars and LangGraph + Pydantic AI auto-instrument:
+
+```bash
+LANGSMITH_TRACING=true
+LANGSMITH_API_KEY=ls__...
+LANGSMITH_PROJECT=tfl-monitor
+```
+
+What this gives us out of the box:
+
+- One trace per `/chat/stream` invocation.
+- One span per LangGraph node and per tool call within the trace.
+- The exact chunks fed into the model context for each RAG retrieval.
+- Token counts per call, per turn, and aggregated per session.
+
+### Trace shape
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API as /chat/stream
+    participant G as LangGraph
+    participant T as Tool (e.g. query_line_reliability)
+    participant L as Sonnet 3.5
+
+    U->>API: POST {message}
+    API->>G: agent.astream(...)
+    G->>L: LLM call (Sonnet)
+    L-->>G: tool_call(query_line_reliability, {line_id: "Piccadilly"})
+    G->>T: invoke
+    T-->>G: rows
+    G->>L: LLM call with tool result
+    L-->>G: final assistant message
+    G-->>API: token / tool / end frames
+    API-->>U: SSE projection
+    Note over G,L: Every arrow is a span in LangSmith
+```
+
+## What we explicitly do not do
+
+!!! danger "No custom observability"
+    The `CLAUDE.md` policy forbids:
+
+    - Prometheus / Grafana / Loki / Jaeger / OpenTelemetry collector sidecars.
+    - Custom structured-logging wrappers around `logging`.
+    - Custom token-cost dashboards.
+    - Per-route metric emitters that duplicate what Logfire already captures.
+
+    Two free-tier hosted tools are sufficient for a portfolio project. They
+    also degrade gracefully — code paths still run if the tokens are missing.
+
+## Cost
+
+Both Logfire and LangSmith free tiers cover this project comfortably.
+
+| Tool | Free tier | Project usage |
+|------|-----------|---------------|
+| Logfire | 10 GB ingest / month | <500 MB at portfolio cadence |
+| LangSmith | 5 k traces / month, 14-day retention | <1 k traces / month |
+
+A LangSmith paid tier becomes interesting only if the agent serves more than a
+handful of recruiters; a budget alarm captures that gracefully.

--- a/docs/pipelines/agent.md
+++ b/docs/pipelines/agent.md
@@ -1,0 +1,182 @@
+# LangGraph agent
+
+A `create_react_agent` over **five typed tools** — four wrap the FastAPI
+fetchers in-process, the fifth is a LlamaIndex retriever fanning out across
+the three Pinecone namespaces. Streaming reaches the browser via SSE.
+
+## Code map
+
+| Concern | Module |
+|---------|--------|
+| Graph compilation | `src/api/agent/graph.py` |
+| Tool wrappers (4 SQL + 1 RAG) | `src/api/agent/tools.py` |
+| LlamaIndex retriever | `src/api/agent/rag_tool.py` |
+| Pydantic AI normaliser | `src/api/agent/extraction.py` |
+| SSE projection | `src/api/agent/streaming.py` |
+| FastAPI route + history | `src/api/main.py` (`/chat/stream`, `/chat/{thread_id}/history`) |
+| Persistence DDL | `contracts/sql/004_chat.sql` |
+
+## Tool surface
+
+```mermaid
+graph LR
+    Q[User question] --> AGENT["create_react_agent<br/>Sonnet 3.5 v2<br/>temperature=0"]
+    AGENT --> T1[query_tube_status<br/>→ /status/live]
+    AGENT --> T2[query_line_reliability<br/>→ /reliability/{line_id}]
+    AGENT --> T3[query_recent_disruptions<br/>→ /disruptions/recent]
+    AGENT --> T4[query_bus_punctuality<br/>→ /bus/{stop_id}/punctuality]
+    AGENT --> T5[search_tfl_docs<br/>→ Pinecone retriever]
+
+    T2 -.normalise.-> EXT["Pydantic AI<br/>Haiku 3.5<br/>LineId extractor"]
+
+    T1 --> WH[(analytics.* via fetchers)]
+    T2 --> WH
+    T3 --> WH
+    T4 --> WH
+    T5 --> PC[(Pinecone<br/>3 namespaces)]
+```
+
+Each tool is a typed LangChain `@tool` that calls the same fetcher functions
+backing the REST endpoints — there is **one source of truth per query** and
+the agent does not duplicate SQL. Tool docstrings declare assumptions that
+should reach the model:
+
+> `query_bus_punctuality(stop_id: str)` — *Bus punctuality is a documented
+> proxy: on-time = arrival within 5 min; early = > 5 min in advance; late =
+> negative seconds. Anchored on TfL's published 5-minute bus performance KPI.*
+
+## Pydantic AI inside one tool
+
+The `LineId` extractor is the only Pydantic AI surface in the project:
+
+```python
+@lru_cache(maxsize=1)
+def _normaliser() -> Agent[None, LineId]:
+    return Agent(
+        model=_haiku_model_string(),
+        output_type=LineId,
+        instructions=(
+            "Extract the canonical TfL line ID from the user's question. "
+            "Map informal names to slugs (e.g. 'Lizzy line' -> 'elizabeth')."
+        ),
+    )
+```
+
+Why Pydantic AI for this and not LangGraph?
+
+- **Single shot, typed output** — Pydantic AI returns a validated `LineId`
+  directly; LangGraph's full state machine is overkill.
+- **Cheap model** — Haiku 3.5 with a one-shot prompt is ~10× cheaper than
+  asking Sonnet to do this inside the main agent loop.
+- **Cacheable** — `lru_cache(maxsize=1)` keeps the agent client warm across
+  requests within the same FastAPI process.
+
+LangGraph remains the main agent. Pydantic AI is a tool-internal helper —
+not a competing framework.
+
+## RAG retriever
+
+```python
+LlamaIndexRetriever(
+    vector_stores=[
+        PineconeVectorStore(index, namespace="tfl_business_plan"),
+        PineconeVectorStore(index, namespace="mts_2018"),
+        PineconeVectorStore(index, namespace="tfl_annual_report"),
+    ],
+    top_k=4,
+    embedder=OpenAIEmbedding("text-embedding-3-small"),
+)
+```
+
+The retriever supports **optional `doc_id` targeting** — if the user mentions
+"Annual Report", the agent passes `doc_id="tfl_annual_report"` and the
+retriever queries that namespace only. A `-1` page sentinel maps onto Docling
+chunks that span tables (no single page).
+
+## Graceful degradation
+
+```mermaid
+flowchart TB
+    boot[FastAPI lifespan] --> check{All 3 keys?<br/>ANTHROPIC_API_KEY<br/>OPENAI_API_KEY<br/>PINECONE_API_KEY}
+    check -->|yes| compile[compile_agent → LangGraph]
+    compile --> cache[app.state.agent]
+    check -->|missing any| none[app.state.agent = None]
+
+    req[/chat/stream POST/] --> read[read app.state.agent]
+    read -->|None| err503[503 Service Unavailable]
+    read -->|graph| stream[agent.astream]
+
+    histreq[/chat/&lt;thread_id&gt;/history GET/] --> dburl{DATABASE_URL?}
+    dburl -->|set| q[query analytics.chat_messages]
+    dburl -->|unset| err503h[503 RFC 7807]
+```
+
+So a deploy missing one of the three keys still serves history, the live
+status views, the disruption log, and the bus punctuality endpoint — the
+chat just 503s.
+
+## SSE projection
+
+LangGraph emits two stream channels — `messages` (token-level deltas) and
+`updates` (tool calls + state changes). `streaming.project` collapses them
+into one frame format the browser consumes:
+
+```python
+async def project(stream: AsyncIterator[Any]) -> AsyncIterator[Frame]:
+    async for kind, payload in stream:
+        if kind == "messages":
+            yield Frame(type="token", content=payload.content)
+        elif kind == "updates":
+            for tool_name in _tool_calls_from(payload):
+                yield Frame(type="tool", content=tool_name)
+    yield Frame(type="end", content="ok")
+```
+
+The projection is the **stable contract** between the agent runtime and the
+frontend. Swapping LangGraph for another framework would only need to keep
+`{type: "token" | "tool" | "end", content: str}` intact.
+
+## Persistence
+
+```mermaid
+sequenceDiagram
+    participant W as Web
+    participant API as /chat/stream
+    participant DB as analytics.chat_messages
+    participant G as LangGraph
+
+    W->>API: POST {thread_id, message}
+    API->>DB: INSERT (thread_id, role=user, content)
+    API->>G: astream
+    loop tokens
+      G-->>API: messages chunk
+      API-->>W: data: {"type":"token", ...}
+    end
+    G-->>API: updates (tool call)
+    API-->>W: data: {"type":"tool", ...}
+    G-->>API: end
+    API->>DB: INSERT (thread_id, role=assistant, content=concatenated)
+    API-->>W: data: {"type":"end", ...}
+```
+
+The user turn lands **before** the first frame so a connection drop never
+loses the question. The assistant turn lands on stream end with the
+concatenated tokens.
+
+The history endpoint reads back `analytics.chat_messages` ordered by
+`(thread_id, created_at ASC)` — the contract is documented in
+`contracts/sql/004_chat.sql`.
+
+## Tests
+
+| Layer | Coverage |
+|-------|----------|
+| `agent/extraction.py` | LineId normalisation 4 tests (canonical, informal, ambiguous, empty) |
+| `agent/tools.py` | 8 tests across the four SQL tools (happy path, empty, parameter validation, db absent) |
+| `agent/rag_tool.py` | 6 tests (retrieval, doc_id targeting, page sentinel, namespace fan-out, empty, sdk failure) |
+| `agent/graph.py` | 5 tests (compile, no-keys, tool registration, model selection, prompt) |
+| `/chat/stream` route | 6 tests (happy path, 503 no graph, 503 no DATABASE_URL, mid-stream end:error, history insert order, abort) |
+| `/chat/{thread_id}/history` route | 3 tests (happy path, empty, RFC 7807 503) |
+| Integration smokes | 3 (history round-trip, chat-stream end-to-end, history-after-stream) — gated on the four-key combo |
+
+36 unit tests + 3 integration smokes total.

--- a/docs/pipelines/api.md
+++ b/docs/pipelines/api.md
@@ -1,0 +1,152 @@
+# FastAPI surface
+
+Six endpoints, all RFC 7807 errors, a single shared async psycopg pool, and
+**OpenAPI 3.1 as the contract** — the frontend regenerates types from it.
+
+## Code map
+
+| Concern | Module |
+|---------|--------|
+| Application factory + lifespan | `src/api/main.py` |
+| Route handlers | `src/api/main.py` (in-line per endpoint) |
+| Postgres pool + fetchers | `src/api/db.py` |
+| Pydantic response models | `src/api/schemas.py` |
+| Logfire wiring | `src/api/observability.py` |
+| Agent compilation | `src/api/agent/` |
+
+## Endpoints
+
+| Method | Path | Source | Notes |
+|--------|------|--------|-------|
+| `GET` | `/health` | static | Liveness — returns build info |
+| `GET` | `/api/v1/status/live` | `raw.line_status` | 15-min freshness window |
+| `GET` | `/api/v1/status/history` | `analytics.stg_line_status` | 30-day cap, `LIMIT 10000` |
+| `GET` | `/api/v1/reliability/{line_id}` | `analytics.mart_tube_reliability_daily` | Aggregate + histogram, 404 on empty window |
+| `GET` | `/api/v1/disruptions/recent` | `analytics.stg_disruptions` | `?limit=50&mode=tube` |
+| `GET` | `/api/v1/bus/{stop_id}/punctuality` | `analytics.stg_arrivals` | 7-day window, on-time/early/late proxy |
+| `POST` | `/api/v1/chat/stream` | LangGraph agent | SSE: `{type, content}` frames |
+| `GET` | `/api/v1/chat/{thread_id}/history` | `analytics.chat_messages` | Replays a thread |
+
+## Lifespan
+
+```mermaid
+sequenceDiagram
+    participant Boot as uvicorn
+    participant App as FastAPI
+    participant DB as Postgres pool
+    participant LLM as compile_agent
+
+    Boot->>App: lifespan startup
+    alt DATABASE_URL set
+      App->>DB: AsyncConnectionPool(min=1, max=4)
+      DB-->>App: open
+    else
+      App->>App: app.state.pool = None
+    end
+    alt All 3 keys present
+      App->>LLM: compile_agent()
+      LLM-->>App: graph
+      App->>App: app.state.agent = graph
+    else
+      App->>App: app.state.agent = None
+    end
+
+    Note over App: serving requests
+    Note over Boot,LLM: lifespan shutdown reverses both
+```
+
+Each handler reads `app.state.pool` / `app.state.agent` and returns a
+RFC 7807 `503` if the dependency is missing — `make check` and unit tests run
+without any external services.
+
+## Error contract
+
+Every error response is `application/problem+json`:
+
+```json
+{
+  "type": "about:blank",
+  "title": "Service Unavailable",
+  "status": 503,
+  "detail": "DATABASE_URL not configured",
+  "instance": "/api/v1/status/live"
+}
+```
+
+The `_problem` helper in `src/api/main.py` wraps the four documented surfaces:
+
+| Status | When |
+|--------|------|
+| 404 | `reliability` window has no rows; bus stop unknown |
+| 422 | Pydantic validation failure (FastAPI default, RFC 7807-mapped) |
+| 503 | Pool unset (no `DATABASE_URL`) or agent unset (missing key) |
+| 502 | Bedrock / Anthropic upstream failure (mapped from `langchain_*` exceptions) |
+
+## Pool sizing
+
+```python
+pool = AsyncConnectionPool(
+    conninfo=os.environ["DATABASE_URL"],
+    min_size=1,
+    max_size=4,
+    open=False,
+)
+```
+
+Two reasons for the `max=4` ceiling:
+
+1. The Supabase free tier caps connections strictly (~30 across all clients
+   sharing the project).
+2. Most queries are single-statement reads that finish in <50 ms, so a small
+   pool sustains the portfolio's RPS comfortably.
+
+## OpenAPI 3.1 as the source of truth
+
+The committed contract lives at
+[`contracts/openapi.yaml`](https://github.com/hcslomeu/tfl-monitor/blob/main/contracts/openapi.yaml)
+and CI enforces a **bidirectional drift test**:
+
+- The OpenAPI emitted by FastAPI must equal `contracts/openapi.yaml`.
+- `web/lib/types.ts` regenerated from the contract must equal the committed
+  `web/lib/types.ts`.
+
+```mermaid
+flowchart LR
+    SRC[src/api/schemas.py<br/>Pydantic models] --> EMITTED[FastAPI OpenAPI emit]
+    CONTRACT[contracts/openapi.yaml] -->|diff| EMITTED
+    CONTRACT -->|openapi-typescript| TS[web/lib/types.ts]
+    GEN[web/lib/types.ts<br/>regenerated] -->|diff| TS
+```
+
+So adding a route involves three pinned files: the Pydantic schema, the
+OpenAPI entry, and the TypeScript types. Drift in any direction breaks CI.
+
+## Observability
+
+Two instruments, configured once in `src/api/observability.py`:
+
+```python
+logfire.instrument_fastapi(app)
+logfire.instrument_psycopg()
+logfire.instrument_httpx()
+```
+
+Per-request spans cover route + status + latency. Per-query spans cover the
+parameterised SQL + duration. LangSmith captures the agent traces — see
+[Observability](../observability.md).
+
+## Tests
+
+| Suite | Count | Notable |
+|-------|-------|---------|
+| `tests/api/test_stubs.py` | parametrised | Validates that every committed route is implemented (no 501 stubs left) |
+| `tests/api/test_status_live.py` | 5 | Freshness window, RFC 7807 on no pool, ordering |
+| `tests/api/test_reliability.py` | 6 | Histogram shape, 404 empty window, severity ordering |
+| `tests/api/test_disruptions.py` | 6 | `mode` filter via EXISTS, `limit` bounds, `last_update DESC NULLS LAST` |
+| `tests/api/test_bus_punctuality.py` | 5 | Proxy math, RFC 7807 404 on empty stop |
+| `tests/api/test_chat_stream.py` | 6 | SSE happy path, 503 no graph, mid-stream `end:error` |
+| `tests/api/test_chat_history.py` | 3 | Order, empty, 503 |
+| Integration smokes | 11 | Gated on `DATABASE_URL`, run with `-m integration` |
+
+`tests/conftest.py::FakeAsyncPool` replaces the live psycopg pool in unit
+tests — the fixture returns predictable rows without a Postgres dependency.

--- a/docs/pipelines/api.md
+++ b/docs/pipelines/api.md
@@ -1,6 +1,6 @@
 # FastAPI surface
 
-Six endpoints, all RFC 7807 errors, a single shared async psycopg pool, and
+Eight endpoints, all RFC 7807 errors, a single shared async psycopg pool, and
 **OpenAPI 3.1 as the contract** — the frontend regenerates types from it.
 
 ## Code map

--- a/docs/pipelines/frontend.md
+++ b/docs/pipelines/frontend.md
@@ -1,0 +1,143 @@
+# Next.js frontend
+
+Three views, all server components by default, types regenerated from the
+OpenAPI contract. Single linter (Biome) and single test runner (Vitest + RTL).
+
+## Code map
+
+| Concern | Path |
+|---------|------|
+| App Router routes | `web/app/{page,disruptions,ask}/page.tsx` |
+| Server-side fetchers | `web/lib/api/*.ts` |
+| SSE parser + chat fetcher | `web/lib/sse-parser.ts`, `web/lib/api/chat-stream.ts` |
+| Generated TS types | `web/lib/types.ts` (do not edit) |
+| Chat UI | `web/components/chat-view.tsx` |
+| shadcn primitives | `web/components/ui/*.tsx` |
+| Security headers | `web/next.config.ts` |
+| Tests | colocated with each module under `web/__tests__/` |
+
+## Views
+
+```mermaid
+flowchart LR
+    LANDING[/page.tsx<br/>Network Now/] -->|server fetch| SL[/api/v1/status/live]
+    DISLOG[/disruptions/page.tsx<br/>Disruption Log/] -->|server fetch| DR[/api/v1/disruptions/recent]
+    ASK[/ask/page.tsx<br/>ChatView/] -->|POST SSE| CHAT[/api/v1/chat/stream]
+
+    LANDING -->|nav link| ASK
+```
+
+| View | Wired endpoint | Highlights |
+|------|----------------|------------|
+| **Network Now** (`/`) | `/api/v1/status/live` | Empty / error states surfaced via `Alert role="alert"`, fetcher catches `ApiError` |
+| **Disruption Log** (`/disruptions`) | `/api/v1/disruptions/recent` | Per-disruption Card with category-tone badge (severe / minor / info / neutral); `closure_text` in destructive Alert |
+| **Ask** (`/ask`) | `/api/v1/chat/stream` | SSE stream → token bubbles, ephemeral "Using tool …" status line |
+
+## Type generation
+
+```bash
+make openapi-ts
+```
+
+This runs `openapi-typescript ../contracts/openapi.yaml -o lib/types.ts`
+inside `web/`. CI also runs the same generation and `diff`s against the
+committed file — drift fails the build.
+
+```mermaid
+flowchart LR
+    OAPI[contracts/openapi.yaml] -->|openapi-typescript| TS[web/lib/types.ts]
+    TS --> FETCHER[web/lib/api/*.ts]
+    FETCHER --> PAGE[web/app/.../page.tsx]
+```
+
+Every fetcher imports the operation type and binds the response shape:
+
+```ts
+import type { paths } from "@/lib/types";
+
+type LineStatus =
+  paths["/api/v1/status/live"]["get"]["responses"]["200"]["content"]["application/json"][number];
+
+export async function getStatusLive(): Promise<LineStatus[]> {
+  return apiFetch<LineStatus[]>("/api/v1/status/live");
+}
+```
+
+## SSE streaming
+
+The chat view consumes a Server-Sent Events stream over `fetch` (not
+`EventSource` — POST + JSON body do not fit the EventSource contract):
+
+```ts
+const response = await fetch(`${API}/api/v1/chat/stream`, {
+  method: "POST",
+  headers: { "content-type": "application/json", accept: "text/event-stream" },
+  body: JSON.stringify({ thread_id, message }),
+  signal,
+});
+
+for await (const frame of parseFrames(response.body!)) {
+  switch (frame.type) {
+    case "token": appendToken(frame.content); break;
+    case "tool":  setToolStatus(frame.content); break;
+    case "end":   if (frame.content === "error") flagErrored(); return;
+  }
+}
+```
+
+`parseFrames` is a stateful 60-line parser that buffers `Uint8Array` chunks
+via a streaming `TextDecoder`, splits on `\n\n`, drops `:`-prefixed comments
+(sse-starlette emits `: ping` periodically), and JSON-parses each `data:`
+line. **Malformed JSON or unknown types are silently dropped** so a single
+corrupt frame does not kill the stream.
+
+## Security headers
+
+`next.config.ts` registers the project-wide headers required by `CLAUDE.md`:
+
+```ts
+const headers = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+```
+
+## Tooling
+
+| Concern | Tool |
+|---------|------|
+| Linter + formatter | Biome (sole) |
+| Test runner | Vitest |
+| DOM helpers | React Testing Library |
+| Build | Next 16 production build |
+| Package manager | `pnpm` (sole) |
+
+```bash
+pnpm --dir web install
+pnpm --dir web dev          # :3000
+pnpm --dir web lint
+pnpm --dir web test
+pnpm --dir web build
+```
+
+`make check` chains both halves of the codebase.
+
+## Tests
+
+54 web tests covering:
+
+- **SSE parser** — single frame, multi-frame chunk, partial chunk buffering,
+  `:`-comment skip, unknown-type drop, malformed-JSON survival.
+- **Fetchers** — URL/headers/body assertions, RFC 7807 `detail` surfacing,
+  network `TypeError` propagation, multi-chunk reader buffering.
+- **Network Now page** — happy path, empty array, `ApiError` alert,
+  non-`ApiError` rejection fallback.
+- **Disruption Log page** — list rendering, category-tone mapping, closure
+  callout shown/hidden, affected-routes list, error fallback.
+- **ChatView** — empty shell, streaming tokens, tool-status lifecycle,
+  503 alert + conversation rollback, mid-stream `end:error` flagging.
+
+`web/__tests__/setup.ts` initialises `jsdom` and stubs `fetch` per test via
+`vi.stubGlobal`.

--- a/docs/pipelines/index.md
+++ b/docs/pipelines/index.md
@@ -1,0 +1,38 @@
+# Pipelines
+
+Six end-to-end flows make up the system. Each page below walks the code path,
+the contract that locks its boundaries, and the tests that protect it.
+
+<div class="grid cards" markdown>
+
+-   :material-source-branch:{ .lg .middle } **[Streaming ingestion](ingestion.md)**
+
+    Async TfL polling → tier-2 Pydantic events → Kafka topics → idempotent
+    `raw.*` writes.
+
+-   :material-database-arrow-down:{ .lg .middle } **[dbt warehouse](warehouse.md)**
+
+    Staging models with defensive dedup, marts on stable composite grains,
+    exposures that wire marts to API endpoints.
+
+-   :material-file-document-multiple-outline:{ .lg .middle } **[RAG ingestion](rag.md)**
+
+    Conditional GET on TfL strategy PDFs → Docling parse → OpenAI embeddings
+    → Pinecone namespace per document.
+
+-   :material-graph:{ .lg .middle } **[LangGraph agent](agent.md)**
+
+    Five typed tools (4 SQL + 1 RAG), a Haiku normaliser for `LineId`, and a
+    SSE projection for streaming.
+
+-   :material-api:{ .lg .middle } **[FastAPI surface](api.md)**
+
+    Six endpoints, all RFC 7807 errors, a single async psycopg pool, and
+    OpenAPI 3.1 as the contract.
+
+-   :material-language-typescript:{ .lg .middle } **[Next.js frontend](frontend.md)**
+
+    Three views (Network Now, Disruption Log, Ask), all server components by
+    default, types regenerated from OpenAPI.
+
+</div>

--- a/docs/pipelines/ingestion.md
+++ b/docs/pipelines/ingestion.md
@@ -1,0 +1,125 @@
+# Streaming ingestion
+
+The ingestion layer turns four polling endpoints on the TfL Unified API into
+three Kafka topics and three Postgres `raw.*` tables. Every byte that crosses
+a service boundary is a Pydantic v2 model.
+
+## Code map
+
+| Concern | Module |
+|---------|--------|
+| Async HTTP client to TfL | `src/ingestion/tfl_client/` |
+| Producers | `src/ingestion/producers/{line_status,arrivals,disruptions}.py` |
+| Consumers | `src/ingestion/consumers/{line_status,arrivals,disruptions}.py` |
+| Generic consumer + writer | `src/ingestion/consumers/_base.py` |
+| Logfire wiring | `src/ingestion/observability.py` |
+
+## Contracts
+
+```mermaid
+flowchart LR
+    TFL[TfL Unified API<br/>camelCase JSON] -->|httpx GET| C[tfl_client<br/>tier-1 parse]
+    C -->|normalise| T2["tier-2 Pydantic event<br/>snake_case · frozen<br/>UUIDv4 event_id<br/>UTC ingested_at"]
+    T2 -->|aiokafka| K[(Kafka topic)]
+    K -->|generic consumer| W[RawEventWriter]
+    W -->|"INSERT … ON CONFLICT (event_id)"| R[(raw.* JSONB)]
+```
+
+Tier-1 = the wire format from TfL — messy, optional-heavy, evolves at TfL's
+pace. Tier-2 = our internal wire format — flat, frozen, every consumer reads
+one shape.
+
+The normalisation tier-1 → tier-2 is a single-purpose step inside
+`tfl_client/normalise.py`. Synthetic SHA-256 IDs anchor disruptions whose
+upstream payload omits a stable identifier.
+
+## Producers
+
+Three async daemons, one shape:
+
+```python
+class LineStatusProducer:
+    POLL_INTERVAL_SECONDS = 30
+
+    async def run_forever(self) -> None:
+        async for ts in clock_ticks(self.POLL_INTERVAL_SECONDS):
+            payload = await self._client.fetch_line_status()
+            event = normalise_line_status(payload, ingested_at=ts)
+            await self._producer.send(event, key=event.line_id)
+```
+
+| Producer | Cadence | Partition key | `event_type` |
+|----------|---------|---------------|--------------|
+| `LineStatusProducer` | 30 s | `line_id` | `line-status.snapshot` |
+| `ArrivalsProducer` (×5 NaPTAN hubs in one process) | 30 s | `station_id` | `arrivals.snapshot` |
+| `DisruptionsProducer` (×4 modes) | 300 s | `disruption_id` | `disruptions.snapshot` |
+
+Producers are idempotent at the broker level: `acks="all"`, `enable_idempotence=true`,
+UUIDv4 `event_id`. A retry never duplicates a row downstream.
+
+## Kafka choice (and why we exploit it)
+
+```mermaid
+flowchart LR
+    P[producer] -->|publish| T[(topic)]
+    T -->|consumer-group A| C1[raw.line_status writer]
+    T -->|future consumer-group B| C2[live dashboard pusher]
+    T -->|future consumer-group C| C3[agent context hydrator]
+```
+
+Three properties earn Kafka its place:
+
+1. **Decoupling** — producer keeps polling while a consumer redeploys.
+2. **Replay** — rewinding a topic re-hydrates the warehouse without
+   re-polling.
+3. **Fan-out** — the same `arrivals` topic feeds both
+   `mart_bus_metrics_daily` and any future stream consumer.
+
+A cron-to-Postgres pipeline would deliver the same rows. It would also lose
+all three properties on day one.
+
+## Consumers
+
+`RawEventConsumer[E]` is generic over the event type; `RawEventWriter(table)`
+writes JSONB rows. The `line-status` consumer became the parametric template
+for arrivals + disruptions in TM-B4 — same code path, different topic.
+
+```python
+async def consume_one(self, msg: ConsumerRecord) -> None:
+    event = self._codec.decode(msg.value)
+    try:
+        await self._writer.write(event)
+    except OperationalError:
+        await self._writer.reconnect()
+        raise   # let the consumer retry the offset
+    await self._consumer.commit({tp: msg.offset + 1})
+```
+
+### Failure isolation
+
+| Failure | Handling | Trace |
+|---------|----------|-------|
+| Poison pill (decode error) | skip + commit | `kafka.consume.skip` |
+| Transient DB error (`OperationalError`) | reconnect + replay offset | `psycopg.reconnect` |
+| Unknown exception | log + replay offset | `kafka.consume.error` |
+
+Idempotency comes from `INSERT … ON CONFLICT (event_id) DO NOTHING` — a replay
+of a successful offset is a no-op at the row level.
+
+### Lag observability
+
+Lag is computed on every `kafka.consume` span and refreshed every
+**50 messages or 30 s** (whichever comes first), so a slow partition cannot
+hide behind a fast one.
+
+## Tests
+
+| Layer | Coverage |
+|-------|----------|
+| Unit (per producer) | retry on 429, retry on 5xx, retry on timeout, `app_key` redaction, payload normalisation |
+| Unit (per consumer) | poison pill, transient DB, replay-on-error, lag bookkeeping, namespace override |
+| Integration smoke | Producer round-trip with embedded Redpanda + Postgres (gated on `DATABASE_URL` + `KAFKA_BOOTSTRAP_SERVERS`) |
+
+Total: ~70 unit tests + 4 integration smokes across the three topics. All
+fixtures live under `tests/fixtures/tfl/` — production code never hits the
+live TfL API in tests.

--- a/docs/pipelines/rag.md
+++ b/docs/pipelines/rag.md
@@ -1,0 +1,117 @@
+# RAG ingestion
+
+Three TfL strategy documents are fetched, parsed, embedded, and upserted into
+Pinecone. The pipeline is **conditional** (only re-downloads what changed) and
+**idempotent** (re-running upserts the same row IDs).
+
+## Documents indexed
+
+| Doc ID | Title | Landing page |
+|--------|-------|--------------|
+| `tfl_business_plan` | TfL Business Plan | https://tfl.gov.uk/corporate/publications-and-reports/business-plan |
+| `mts_2018` | Mayor's Transport Strategy 2018 | https://www.london.gov.uk/programmes-strategies/transport/our-vision-transport/mayors-transport-strategy-2018 |
+| `tfl_annual_report` | TfL Annual Report and Statement of Accounts | https://tfl.gov.uk/corporate/publications-and-reports/annual-report |
+
+The landing pages are the citation surface; the resolved CDN URLs are not
+because TfL roll the URL stem yearly (`business-plan-2026` → `2027`).
+
+## Pipeline
+
+```mermaid
+flowchart LR
+    subgraph DISCOVER[Discovery]
+      L[Landing page] -->|regex allowlist| URL[Resolved PDF URL]
+    end
+
+    subgraph FETCH[Fetch]
+      URL -->|If-None-Match + If-Modified-Since| HTTP[httpx GET]
+      HTTP -->|200| LOCAL[data/strategy_docs/]
+      HTTP -->|304| LOCAL
+    end
+
+    subgraph PARSE[Parse]
+      LOCAL --> DOC[Docling DocumentConverter]
+      DOC --> CHUNK[HybridChunker<br/>section + table aware]
+    end
+
+    subgraph EMBED[Embed]
+      CHUNK -->|"100 chunks/req"| OAI[OpenAI<br/>text-embedding-3-small]
+      OAI -->|retry on 429| VEC[1536-dim vectors]
+    end
+
+    subgraph UPSERT[Upsert]
+      VEC -->|sha256 id| PC[Pinecone<br/>tfl-strategy-docs]
+      PC -->|namespace per doc_id| NS[(tfl_business_plan<br/>mts_2018<br/>tfl_annual_report)]
+    end
+```
+
+## Idempotency strategy
+
+| Stage | Mechanism | Why |
+|-------|-----------|-----|
+| Fetch | `If-None-Match` + `If-Modified-Since` from `data/cache/sources_state.json` | TfL serves 304 unless the PDF changed |
+| Parse | Pure function of bytes → no caching needed | Docling output is deterministic |
+| Embed | OpenAI batch endpoint with retry on 429 | Async-batches 100 chunks per request |
+| Upsert | Stable id `sha256("{resolved_url}::{chunk_index}")` | Re-upsert produces the same vector ids |
+| Rollover | Delete-namespace before re-ingest | New URL stem ⇒ wipe stale vectors cleanly |
+
+## CLI
+
+```bash
+# Default — only refetch what changed
+uv run python -m rag.ingest
+
+# Re-scrape each landing page and rewrite resolved URLs
+uv run python -m rag.ingest --refresh-urls
+
+# Bypass ETag cache and re-download every PDF
+uv run python -m rag.ingest --force-refetch
+
+# Run fetch + parse + embed; skip Pinecone upsert (sizing dry-run)
+uv run python -m rag.ingest --dry-run
+```
+
+If 1 of 3 documents fails its fetch / parse / embed / upsert cycle, the
+others still complete and the CLI exits non-zero so any future cron / GitHub
+Action surfaces the failure instead of swallowing it.
+
+A weekly Airflow DAG (`airflow/dags/rag_ingest_weekly.py`) re-runs the
+pipeline at `0 3 * * 1`.
+
+## Cost
+
+A full re-embedding of all three PDFs runs at well under £0.20 one-time at
+the current `text-embedding-3-small` price ($0.02 per 1M tokens).
+**Conditional GETs and stable Pinecone IDs mean steady-state runs incur
+near-zero embedding spend** — most weeks every doc returns 304 and the
+pipeline exits in under a second.
+
+## Pinecone index shape
+
+| Property | Value |
+|----------|-------|
+| Index name | `tfl-strategy-docs` |
+| Dimension | 1536 |
+| Metric | cosine |
+| Cloud | AWS, `us-east-1` (serverless) |
+| Namespaces | `tfl_business_plan`, `mts_2018`, `tfl_annual_report` |
+| Metadata fields | `doc_id`, `chunk_index`, `page`, `text` |
+
+The agent fans out across all three namespaces by default with optional
+`doc_id` targeting — see [LangGraph agent](agent.md).
+
+## Tests
+
+28 unit tests with fakes for httpx / Docling / OpenAI / Pinecone:
+
+| Module | Coverage |
+|--------|----------|
+| `sources.py` | landing-page resolver picks the right PDF URL via per-source allowlist |
+| `fetch.py` | 304 short-circuit, 200 with body, ETag round-trip, retry on 5xx |
+| `parse.py` | Docling output → chunks with stable text + page metadata |
+| `embed.py` | Batch sizing, retry on 429, async ordering preserved |
+| `upsert.py` | Id stability, namespace rollover, partial-failure handling |
+| `ingest.py` | Orchestrator argument parsing, exit-non-zero on partial failure |
+
+No live network is hit in unit tests — fakes ride alongside production
+clients via constructor injection.

--- a/docs/pipelines/warehouse.md
+++ b/docs/pipelines/warehouse.md
@@ -1,0 +1,153 @@
+# dbt warehouse
+
+Three Postgres schemas, ten dbt models, generic + singular tests, and five
+exposures wiring marts to the API endpoints that consume them.
+
+## Schema layout
+
+| Schema | Purpose | Owned by |
+|--------|---------|----------|
+| `raw.*` | Append-only JSONB landing tables | Consumers (`src/ingestion/consumers/`) |
+| `ref.*` | Reference data (lines, stations, modes) | TM-A2 static-ingest DAG (deferred) |
+| `analytics.*` | dbt-built staging + marts | dbt project under `dbt/models/` |
+
+## Lineage
+
+```mermaid
+flowchart TB
+    subgraph RAW[raw schema]
+      r1[(raw.line_status)]
+      r2[(raw.arrivals)]
+      r3[(raw.disruptions)]
+    end
+
+    subgraph STG[staging]
+      s1[stg_line_status]
+      s2[stg_arrivals]
+      s3[stg_disruptions]
+    end
+
+    subgraph MART[marts]
+      m1[mart_tube_reliability_daily]
+      m2[mart_tube_reliability_daily_summary]
+      m3[mart_disruptions_daily]
+      m4[mart_bus_metrics_daily]
+    end
+
+    subgraph EXP[exposures]
+      e1[/status/live, /status/history]
+      e2[/reliability/{line_id}]
+      e3[/disruptions/recent]
+      e4[/bus/{stop_id}/punctuality]
+    end
+
+    r1 --> s1 --> m1 --> m2
+    r2 --> s2 --> m4
+    r3 --> s3 --> m3
+
+    s1 --> e1
+    m2 --> e2
+    s3 --> e3
+    s2 --> e4
+```
+
+## Staging models
+
+All three staging models share the same shape:
+
+- **Materialisation:** `incremental` with `unique_key='event_id'`, `merge`
+  strategy, `on_schema_change='fail'`.
+- **Lookback:** 5 minutes — incremental runs scan the last 5 min of `raw` rows
+  in case a late event arrives.
+- **Defensive dedup:** `row_number() OVER (PARTITION BY event_id ORDER BY
+  ingested_at DESC)` then keep `rn = 1`.
+- **JSONB unnesting:** explicit casts into typed columns (text / int /
+  numeric / timestamptz). No silent JSONB leakage downstream.
+
+Reading the staging models is the cheapest way to understand the wire format
+of each topic.
+
+## Marts
+
+| Model | Grain | Notable columns |
+|-------|-------|-----------------|
+| `mart_tube_reliability_daily` | `(line_id, calendar_date_utc, status_severity)` | `snapshot_count`, `first_observed_at`, `last_observed_at`, `minutes_observed_estimate` |
+| `mart_tube_reliability_daily_summary` | `(line_id, calendar_date_utc)` | `pct_good_service`, `longest_disruption_window_minutes` (gaps-and-islands) |
+| `mart_disruptions_daily` | `(calendar_date_utc, line_id)` | `affected_routes` JSONB fan-out, `distinct_categories`, `max_severity` |
+| `mart_bus_metrics_daily` | `(calendar_date_utc, line_id, station_id)` | Filtered to bus lines via `source('tfl', 'lines')` |
+
+The `mart_tube_reliability_daily_summary` model is the most interesting — it
+runs a gaps-and-islands SQL pattern to compute the longest contiguous
+non-`Good Service` window per line per day:
+
+```sql
+with islands as (
+    select
+        line_id,
+        calendar_date_utc,
+        last_observed_at,
+        sum(case when status_severity = 'Good Service' then 1 else 0 end)
+            over (partition by line_id, calendar_date_utc order by last_observed_at) as island_id
+    from {{ ref('mart_tube_reliability_daily') }}
+)
+select
+    line_id,
+    calendar_date_utc,
+    max(extract(epoch from (last_observed_at - first_observed_at)) / 60.0)
+        as longest_disruption_window_minutes
+from (
+    select
+        line_id,
+        calendar_date_utc,
+        island_id,
+        min(last_observed_at) as first_observed_at,
+        max(last_observed_at) as last_observed_at
+    from islands
+    where status_severity != 'Good Service'
+    group by 1, 2, 3
+) windows
+group by 1, 2
+```
+
+## Tests
+
+| Type | Count | Examples |
+|------|-------|----------|
+| Generic (`unique`, `not_null`, `accepted_values`, relationships) | 14 | `event_id` is unique on every staging model |
+| Singular | 8 | `pct_good_service` is bounded `[0, 100]`; `affected_routes` is valid JSONB; disruption category enum |
+
+Singular tests live under `dbt/tests/` and run via `dbt test`. CI gates the
+parser via `uv run task dbt-parse` on every PR.
+
+## Exposures
+
+Five exposures wire marts to the FastAPI endpoints that consume them, so
+`dbt docs generate` produces a useful lineage graph for a recruiter:
+
+```yaml
+- name: api_status_live
+  type: application
+  url: https://tflmonitor.duckdns.org/api/v1/status/live
+  depends_on: [source('tfl', 'line_status')]
+
+- name: api_reliability_window
+  type: application
+  url: https://tflmonitor.duckdns.org/api/v1/reliability/{line_id}
+  depends_on: [ref('mart_tube_reliability_daily')]
+```
+
+Five total — one per warehouse-backed endpoint.
+
+## Idempotency and lateness
+
+Three properties combine to make every mart re-runnable from scratch:
+
+1. **`merge` materialisation** with `unique_key='event_id'` — re-running a
+   batch updates rows in place rather than appending duplicates.
+2. **5-minute lookback** — staging models scan the last 5 min of `raw` rows
+   to catch late arrivals.
+3. **UTC anchoring** — every `calendar_date_utc` derives from `ingested_at` in
+   UTC, so re-running across timezones yields identical rows.
+
+A nightly `dbt build` (`0 1 * * *` in `airflow/dags/dbt_nightly.py`)
+rebuilds the marts from staging.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,103 @@
+# Roadmap
+
+The project is built as **work packages** (WPs), grouped into parallel tracks
+so at most two agents can collide-free at any time.
+
+## Track structure
+
+| Track | Owner directories | Purpose |
+|-------|------------------|---------|
+| **A — infra** | `docker-compose.yml`, `infra/`, `airflow/`, `.github/` | Boots, deploys, schedules |
+| **B — ingestion** | `src/ingestion/` | Producers + consumers + tfl-client |
+| **C — dbt** | `dbt/` | Staging, marts, exposures, tests |
+| **D — api-agent** | `src/api/`, `src/agent/`, `src/rag/` | FastAPI + LangGraph + RAG |
+| **E — frontend** | `web/` | Next.js dashboard |
+| **F — polish** | top-level docs, `README.md` | Demo, video, polish |
+
+## Status
+
+```mermaid
+gantt
+    dateFormat  YYYY-MM-DD
+    title       tfl-monitor delivery timeline (✅ complete · 🚧 next up)
+    section Foundations
+    TM-000 Contracts + scaffold        :done, 2026-04-22, 1d
+    TM-A1 Compose + Postgres + Redpanda :done, 2026-04-23, 1d
+    TM-C1 dbt scaffold                 :done, 2026-04-23, 1d
+    TM-D1 FastAPI skeleton             :done, 2026-04-26, 1d
+    TM-B1 TfL client + fixtures        :done, 2026-04-26, 1d
+    section Streaming
+    TM-B2 line-status producer         :done, 2026-04-27, 1d
+    TM-B3 line-status consumer         :done, 2026-04-28, 1d
+    TM-B4 arrivals + disruptions       :done, 2026-04-28, 1d
+    section Warehouse
+    TM-C2 staging + first mart         :done, 2026-04-28, 1d
+    TM-C3 remaining marts + exposures  :done, 2026-04-28, 1d
+    section API + agent
+    TM-D2 endpoints to Postgres        :done, 2026-04-28, 1d
+    TM-D3 disruptions + bus endpoints  :done, 2026-04-28, 1d
+    TM-D4 RAG ingestion                :done, 2026-04-28, 1d
+    TM-D5 LangGraph agent              :done, 2026-04-29, 1d
+    section Frontend
+    TM-E1a scaffold + Network Now      :done, 2026-04-28, 1d
+    TM-E1b Network Now wired           :done, 2026-04-28, 1d
+    TM-E2 Disruption Log view          :done, 2026-04-28, 1d
+    TM-E3 Chat view + SSE              :done, 2026-04-29, 1d
+    section Orchestration
+    TM-A2 Airflow DAGs                 :done, 2026-04-28, 1d
+    section Deploy + polish
+    TM-A5 AWS Bedrock + EC2 deploy    :active, 2026-04-29, 3d
+    TM-E4 Vercel deploy               :2026-05-02, 1d
+    TM-F1 README polish + demo         :2026-05-03, 2d
+```
+
+## WP ledger
+
+Source of truth: [`PROGRESS.md`](https://github.com/hcslomeu/tfl-monitor/blob/main/PROGRESS.md).
+
+| Phase | WP | Title | Track | Status |
+|-------|----|-------|-------|--------|
+| 0 | TM-000 | Contracts + scaffold | — | ✅ 2026-04-22 |
+| 1 | TM-A1 | Docker Compose + Postgres + Redpanda + Airflow | A | ✅ 2026-04-23 |
+| 1 | TM-B1 | Async TfL client + fixtures | B | ✅ 2026-04-26 |
+| 2 | TM-C1 | dbt scaffold | C | ✅ 2026-04-23 |
+| 2 | TM-D1 | FastAPI skeleton + Logfire wiring | D | ✅ 2026-04-26 |
+| 3 | TM-B2 | line-status producer | B | ✅ 2026-04-27 |
+| 3 | TM-B3 | line-status consumer | B | ✅ 2026-04-28 |
+| 3 | TM-C2 | dbt staging + first mart | C | ✅ 2026-04-28 |
+| 3 | TM-D2 | Wire endpoints to Postgres | D | ✅ 2026-04-28 |
+| 3 | TM-E1a | Next.js scaffold + Network Now (mocked) | E | ✅ 2026-04-28 |
+| 3 | TM-E1b | Network Now wired to `/status/live` | E | ✅ 2026-04-28 |
+| 4 | TM-B4 | arrivals + disruptions topics | B | ✅ 2026-04-28 |
+| 4 | TM-C3 | Remaining marts + tests + exposures | C | ✅ 2026-04-28 |
+| 4 | TM-D3 | Remaining endpoints | D | ✅ 2026-04-28 |
+| 4 | TM-E2 | Disruption Log view | E | ✅ 2026-04-28 |
+| 5 | TM-A2 | Airflow DAGs | A | ✅ 2026-04-28 |
+| 5 | TM-D4 | RAG ingestion: Docling → Pinecone | D | ✅ 2026-04-28 |
+| 6 | TM-D5 | LangGraph agent (SQL + RAG + Pydantic AI) | D | ✅ 2026-04-29 |
+| 6 | TM-E3 | Chat view with SSE | E | ✅ 2026-04-29 |
+| 7 | TM-A3 | Supabase provisioning | A | 🚧 absorbed into TM-A5 |
+| 7 | TM-A4 | Redpanda Cloud | A | 🚧 absorbed into TM-A5 |
+| 7 | TM-A5 | AWS Bedrock + EC2 deploy | A | 🚧 in progress |
+| 7 | TM-E4 | Vercel deploy | E | ⬜ |
+| 7 | TM-F1 | README polish + demo video + live URL | F | ⬜ |
+
+## What "in progress" means
+
+A WP is *in progress* once its plan in `.claude/specs/TM-XXX-plan.md` has
+been signed off by the author and Phase 3 (implementation) has started. The
+[TM-A5 plan](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/specs/TM-A5-plan.md)
+is the latest active document.
+
+## How a WP closes
+
+Every WP runs through this checklist before being marked `✅`:
+
+- [x] All acceptance criteria from the spec met
+- [x] `uv run task lint` (Ruff + Mypy strict) passes
+- [x] `uv run task test` (Pytest, no integration / no airflow markers) passes
+- [x] `uv run task dbt-parse` passes if `dbt/` or `contracts/sql/` was touched
+- [x] `make check` (Python + TS gates chained) passes end-to-end
+- [x] `PROGRESS.md` updated with completion date and notes
+- [x] Linear issue moved to `Done`
+- [x] PR opened, referencing the Linear issue, body in English

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -1,0 +1,96 @@
+# Tech stack
+
+Every choice is locked unless an ADR overrides it. The rejection column says
+*why* the choice was made, so reviewers can see the trade-off without digging.
+
+## Locked stack
+
+| Layer | Choice | Why this, not the alternative |
+|-------|--------|-------------------------------|
+| Python package manager | [`uv`](https://docs.astral.sh/uv/) | Fast, single static binary, lockfile-first |
+| Python | 3.12 | Match production base images; PEP 695 generics |
+| Streaming broker | [Redpanda](https://redpanda.com/) | Kafka API, single binary, identical local ↔ prod |
+| Warehouse | PostgreSQL 16 | Supabase-compatible, JSONB-native, mature dbt adapter |
+| Transformations | [dbt-core](https://www.getdbt.com/) + dbt-postgres | Tests, docs, lineage — modern warehouse standard |
+| Orchestration | [Apache Airflow](https://airflow.apache.org/) 2.10+ | LocalExecutor; portfolio-relevant skill |
+| Ingestion | `httpx` + `aiokafka` + Pydantic v2 | Async retry, typed events end-to-end |
+| API | [FastAPI](https://fastapi.tiangolo.com/) + `sse-starlette` | Async, typed, OpenAPI 3.1 auto-emitted |
+| Agent framework | [LangGraph](https://langchain-ai.github.io/langgraph/) 1.x | Stateful graph, native tool calling, LangSmith integration |
+| Structured extraction | [Pydantic AI](https://ai.pydantic.dev/) | Tool-level typed LLM calls (e.g. `LineId` normaliser) |
+| RAG | [LlamaIndex](https://www.llamaindex.ai/) | `PineconeVectorStore`, namespace-per-doc fan-out |
+| Vector DB | [Pinecone](https://www.pinecone.io/) (serverless, free) | Single index `tfl-strategy-docs` (1536 dim, cosine) |
+| PDF | [Docling](https://github.com/DS4SD/docling) 2.x | `HybridChunker` with native section + table awareness |
+| Embeddings | OpenAI `text-embedding-3-small` | $0.02 / 1M tokens; ~£0.20 one-off for the corpus |
+| LLMs | Claude Sonnet (answers) + Haiku (router/extractor) | Sonnet 3.5 v2 + Haiku 3.5 — top-of-class tool calling |
+| Validation | Pydantic v2 | Used at *every* boundary: Kafka, FastAPI, config, tools |
+| LLM observability | [LangSmith](https://www.langchain.com/langsmith) | Auto-instruments LangGraph nodes / tools / LLM calls |
+| App observability | [Logfire](https://logfire.pydantic.dev/) | OpenTelemetry-native: FastAPI / Postgres / HTTP |
+| Frontend | Next.js 16 + shadcn/ui (Radix + Nova) | Server components, Tailwind v4, claude.design preset |
+| Python lint/format | [Ruff](https://docs.astral.sh/ruff/) | Sole linter and formatter — no Black, no isort |
+| Type checker | [Mypy](https://mypy.readthedocs.io/) strict | Across `src/` and `contracts/` |
+| TS lint/format | [Biome](https://biomejs.dev/) | Sole TS tool — no ESLint, no Prettier |
+| Python tests | Pytest + `pytest-asyncio` | Markers separate `unit`, `integration`, `airflow` |
+| TS tests | Vitest + RTL | Same import paths as Next, `jsdom` env |
+
+## Hosting (production)
+
+| Concern | Host | Tier |
+|---------|------|------|
+| Backend compute | AWS EC2 t4g.small spot, single instance | ~$4/mo |
+| LLM | AWS Bedrock (`us-east-1`) | ~$2-3/mo at portfolio traffic |
+| Postgres | Supabase free | $0 |
+| Kafka | Redpanda Cloud Serverless free | $0 |
+| Vector DB | Pinecone serverless free | $0 |
+| Frontend | Vercel hobby free | $0 |
+| Image registry | GHCR (public repo) | $0 |
+| HTTPS | DuckDNS + Caddy auto-LE | $0 |
+| Observability | Logfire + LangSmith free tiers | $0 |
+
+Steady-state target: **~$6/mo**. Full breakdown lives in
+[Deployment](deployment.md).
+
+## What we explicitly avoid
+
+These are not oversights — they are deliberate, motivated by the *lean by
+default* principle in [`CLAUDE.md`](https://github.com/hcslomeu/tfl-monitor/blob/main/CLAUDE.md).
+
+!!! danger "Anti-patterns"
+    - **Multiple `pyproject.toml`s.** One root, one source of truth.
+    - **Sidecar observability stacks.** No Prometheus / Grafana / OTel collector — Logfire and LangSmith cover what we need.
+    - **Single-implementation abstractions.** No `VectorStoreFactory` for one Pinecone, no `LLMProvider` for one Claude.
+    - **Custom CLIs (Typer, Click)** when a 20-line `python -m` script does the job.
+    - **Duplicate tooling.** No Biome + ESLint, no Ruff + Black.
+    - **Custom structured logging.** Logfire wraps `logging`; `logfire.info(...)` for everything it does not auto-instrument.
+
+When in doubt between *elegant* and *simple*: simple wins. The reviewer would
+rather read 40 direct lines than 200 well-structured ones.
+
+## Tooling commands
+
+The two entry-points an outside reader needs:
+
+=== "Python"
+
+    ```bash
+    uv sync                     # install deps from lockfile
+    uv run task lint            # ruff + mypy strict
+    uv run task test            # pytest (no integration, no airflow)
+    uv run task dbt-parse       # dbt project compiles
+    ```
+
+=== "TypeScript"
+
+    ```bash
+    pnpm --dir web install
+    pnpm --dir web lint         # Biome
+    pnpm --dir web test         # Vitest + RTL
+    pnpm --dir web build        # Next production build
+    ```
+
+=== "Everything"
+
+    ```bash
+    make check     # chains all of the above
+    make up        # boots Postgres + Redpanda + Airflow locally
+    make seed      # loads fixtures into local Postgres
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,167 @@
+site_name: tfl-monitor
+site_description: >-
+  A real-time data + AI engineering portfolio project — streaming TfL feeds
+  into a dbt-modelled warehouse, with a RAG agent over TfL strategy documents.
+site_author: Humberto Slomeu
+site_url: https://hcslomeu.github.io/tfl-monitor/
+
+repo_name: hcslomeu/tfl-monitor
+repo_url: https://github.com/hcslomeu/tfl-monitor
+edit_uri: edit/main/docs/
+
+copyright: Copyright &copy; 2026 Humberto Slomeu — MIT licence
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  language: en
+  font:
+    text: Inter
+    code: JetBrains Mono
+  icon:
+    repo: fontawesome/brands/github
+    logo: material/train-variant
+  favicon: assets/favicon.svg
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: deep purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: deep purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+  features:
+    - announce.dismiss
+    - content.action.edit
+    - content.action.view
+    - content.code.annotate
+    - content.code.copy
+    - content.code.select
+    - content.tabs.link
+    - content.tooltips
+    - navigation.footer
+    - navigation.indexes
+    - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.instant.progress
+    - navigation.path
+    - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
+    - navigation.tracking
+    - search.highlight
+    - search.share
+    - search.suggest
+    - toc.follow
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/hcslomeu
+      name: GitHub
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/in/hcslomeu/
+      name: LinkedIn
+  generator: false
+  status:
+    new: Recently added
+    deprecated: Deprecated
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.snippets:
+      check_paths: true
+      base_path:
+        - docs
+        - .
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+plugins:
+  - search:
+      separator: '[\s​\-_,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
+  - mermaid2:
+      version: 10.9.1
+  - glightbox:
+      touchNavigation: true
+      loop: false
+      effect: zoom
+      slide_effect: slide
+      width: 100%
+      height: auto
+      zoomable: true
+      draggable: true
+  - minify:
+      minify_html: true
+
+nav:
+  - Home: index.md
+  - Architecture:
+      - Overview: architecture.md
+      - Tech stack: stack.md
+      - Engineering principles: engineering.md
+      - Observability: observability.md
+  - Pipelines:
+      - pipelines/index.md
+      - Streaming ingestion: pipelines/ingestion.md
+      - dbt warehouse: pipelines/warehouse.md
+      - RAG ingestion: pipelines/rag.md
+      - LangGraph agent: pipelines/agent.md
+      - FastAPI surface: pipelines/api.md
+      - Next.js frontend: pipelines/frontend.md
+  - Operations:
+      - Deployment: deployment.md
+      - Roadmap: roadmap.md
+  - Reference:
+      - ADRs: adrs.md
+      - Glossary: glossary.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,14 @@ dev = [
     "taskipy>=1.14",
     "apache-airflow>=2.10,<3.0",
 ]
+docs = [
+    "mkdocs>=1.6",
+    "mkdocs-material>=9.5",
+    "mkdocs-mermaid2-plugin>=1.2",
+    "mkdocs-glightbox>=0.4",
+    "mkdocs-minify-plugin>=0.8",
+    "pymdown-extensions>=10.0",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -116,3 +124,5 @@ ingest-arrivals = "python -m ingestion.producers.arrivals"
 consume-arrivals = "python -m ingestion.consumers.arrivals"
 ingest-disruptions = "python -m ingestion.producers.disruptions"
 consume-disruptions = "python -m ingestion.consumers.disruptions"
+docs-serve = "mkdocs serve --config-file mkdocs.yml --dev-addr 127.0.0.1:8001"
+docs-build = "mkdocs build --config-file mkdocs.yml --strict"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,32 @@
+# scripts/
+
+One-off Python utilities supporting development. Excluded from Mypy
+(`pyproject.toml` `tool.mypy.exclude = ["scripts/"]`) — the type discipline
+kicks in at the package boundary, not in throwaway helpers.
+
+## Contents
+
+| Script | Purpose |
+|--------|---------|
+| [`fetch_tfl_samples.py`](./fetch_tfl_samples.py) | Pulls live TfL Unified API responses into `tests/fixtures/tfl/`. Re-run when TfL changes a schema. |
+| [`seed_fixtures.py`](./seed_fixtures.py) | Loads the captured fixtures into the local Postgres `raw.*` tables so the dashboard has data without running ingestion. |
+
+## When to re-run them
+
+```bash
+# After TfL change a response shape (rare):
+uv run python scripts/fetch_tfl_samples.py
+
+# After `make up` to populate the dashboard locally:
+make seed     # wraps `uv run python scripts/seed_fixtures.py`
+```
+
+`fetch_tfl_samples.py` reads the TfL `app_key` from `.env`. The captured
+fixtures are committed under `tests/fixtures/tfl/` so unit tests do not need
+network access.
+
+## Why these are scripts and not packages
+
+They are run **at most a few times a year** and have no external consumers.
+A Typer CLI or click subcommand would add dependencies and indirection for a
+problem that does not exist (CLAUDE.md *Principle #1*).

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,62 @@
+# src/
+
+Python source — four packages, one wheel target. Every cross-package import
+flows through `contracts/`; nothing in `src/` defines its own DTOs.
+
+## Packages
+
+| Path | Track | Purpose |
+|------|-------|---------|
+| [`api/`](./api) | D-api-agent | FastAPI app, route handlers, async psycopg pool, LangGraph agent |
+| [`agent/`](./agent) | D-api-agent | Legacy graph (kept for parity until TM-A5 collapses it) |
+| [`ingestion/`](./ingestion) | B-ingestion | Async TfL client, three producers, three consumers |
+| [`rag/`](./rag) | D-api-agent | Docling → OpenAI → Pinecone ingestion CLI |
+
+```mermaid
+flowchart LR
+    CONTRACTS[contracts/] --> ING[src/ingestion]
+    CONTRACTS --> API[src/api]
+    CONTRACTS --> RAG[src/rag]
+    ING --> KAFKA[(Kafka)]
+    KAFKA --> CONS[src/ingestion/consumers]
+    CONS --> PG[(Postgres)]
+    PG --> API
+    RAG --> PINE[(Pinecone)]
+    PINE --> API
+```
+
+## Build
+
+A single `pyproject.toml` at the repo root drives everything. The wheel is
+configured to package these four directories:
+
+```toml
+[tool.hatch.build.targets.wheel]
+packages = ["src/ingestion", "src/api", "src/agent", "src/rag", "contracts"]
+```
+
+`tests/conftest.py` adds `src/` to `sys.path` via the pytest ini option, so
+imports look like `from api.main import app`, not `from src.api.main`.
+
+## Running
+
+Each package has a documented `python -m` entrypoint — see the individual
+README in each subfolder. The most common ones:
+
+```bash
+uv run task api                    # FastAPI on :8000
+uv run python -m ingestion.producers.line_status
+uv run python -m ingestion.consumers.line_status
+uv run python -m rag.ingest
+```
+
+## Lint + types
+
+Ruff and Mypy strict run across `src/` and `contracts/` only:
+
+```bash
+uv run task lint   # ruff check + ruff format --check + mypy src contracts
+```
+
+`scripts/` is excluded from Mypy (one-off scripts; type discipline kicks in
+at the package boundary).

--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -1,0 +1,32 @@
+# src/agent/
+
+Legacy LangGraph package, kept for parity with earlier WPs. **The active
+agent lives at [`src/api/agent/`](../api/agent)** — TM-D5 moved the graph
+under the API package so the FastAPI lifespan can compile it once and cache
+it on `app.state.agent`.
+
+## Why this directory still exists
+
+- A small number of tests under `tests/agent/` import `agent.observability`
+  for span-namespace assertions. Removing the package would churn the test
+  paths in a separate WP.
+- `pyproject.toml`'s wheel target lists `src/agent` so removing it is a
+  packaging change that needs an ADR.
+
+## What's inside
+
+```text
+src/agent/
+├─ __init__.py
+├─ graph.py             # legacy graph factory — used only by test fixtures
+└─ observability.py     # Logfire span-namespace constants
+```
+
+## Migration path
+
+| When | Action |
+|------|--------|
+| TM-A5 PR-1 (Bedrock swap) | Validate that no production code path imports from `src/agent`. |
+| Post-TM-A5 | Delete `src/agent/`, update `pyproject.toml` wheel target, migrate test fixtures to `src/api/agent`. |
+
+This README will be removed alongside the directory in that follow-up PR.

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,93 @@
+# src/api/
+
+FastAPI application — six warehouse-backed endpoints, an SSE chat stream, a
+LangGraph agent compiled at startup, and OpenAPI 3.1 as the contract.
+
+## Layout
+
+```text
+src/api/
+├─ __init__.py
+├─ main.py             # FastAPI app, lifespan, route handlers
+├─ db.py               # Async psycopg pool + per-endpoint fetchers
+├─ schemas.py          # Pydantic response models (mirror contracts/openapi.yaml)
+├─ observability.py    # Logfire wiring (FastAPI / psycopg / httpx)
+└─ agent/              # LangGraph agent — see src/api/agent/README.md
+```
+
+## Lifespan
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    if database_url := os.environ.get("DATABASE_URL"):
+        app.state.pool = AsyncConnectionPool(database_url, min_size=1, max_size=4)
+        await app.state.pool.open()
+    else:
+        app.state.pool = None
+
+    app.state.agent = compile_agent()  # None if any of 3 keys missing
+    yield
+    if app.state.pool:
+        await app.state.pool.close()
+```
+
+So the app boots and serves a meaningful subset of routes whether or not the
+database / LLM credentials are set — every route that needs a missing
+dependency returns RFC 7807 `503` instead of crashing.
+
+## Endpoints
+
+| Method | Path | Source |
+|--------|------|--------|
+| `GET`  | `/health` | static |
+| `GET`  | `/api/v1/status/live` | `raw.line_status` (15-min freshness) |
+| `GET`  | `/api/v1/status/history` | `analytics.stg_line_status` (30-day cap) |
+| `GET`  | `/api/v1/reliability/{line_id}` | `analytics.mart_tube_reliability_daily` |
+| `GET`  | `/api/v1/disruptions/recent` | `analytics.stg_disruptions` |
+| `GET`  | `/api/v1/bus/{stop_id}/punctuality` | `analytics.stg_arrivals` |
+| `POST` | `/api/v1/chat/stream` | LangGraph agent (SSE) |
+| `GET`  | `/api/v1/chat/{thread_id}/history` | `analytics.chat_messages` |
+
+Every error is `application/problem+json` (RFC 7807) — see the
+[FastAPI surface](../../docs/pipelines/api.md) doc.
+
+## OpenAPI invariants
+
+CI runs a bidirectional drift test between `contracts/openapi.yaml` and the
+OpenAPI emitted by FastAPI at startup — drift in either direction fails the
+test in `tests/api/test_openapi_drift.py`.
+
+## Observability
+
+Three lines in `observability.py`:
+
+```python
+logfire.instrument_fastapi(app)
+logfire.instrument_psycopg()
+logfire.instrument_httpx()
+```
+
+This auto-emits one span per request, query, and outbound HTTP call. Token
+costs and tool decisions land in LangSmith via the agent — see
+[`src/api/agent/README.md`](./agent).
+
+## Run
+
+```bash
+uv run task api                       # uvicorn api.main:app --reload --app-dir src
+```
+
+Health check:
+
+```bash
+curl http://localhost:8000/health
+```
+
+Smoke against `/chat/stream` (requires the three LLM-side keys):
+
+```bash
+curl -N -X POST http://localhost:8000/api/v1/chat/stream \
+  -H 'content-type: application/json' \
+  -d '{"thread_id":"smoke","message":"Which Tube line had the worst reliability last week?"}'
+```

--- a/src/api/agent/README.md
+++ b/src/api/agent/README.md
@@ -1,0 +1,92 @@
+# src/api/agent/
+
+The LangGraph agent — `create_react_agent` over five typed tools, a Pydantic
+AI Haiku normaliser for `LineId`, an SSE projection for streaming, and a
+history adapter that persists chat turns into `analytics.chat_messages`.
+
+## Layout
+
+```text
+src/api/agent/
+├─ __init__.py
+├─ graph.py          # compile_agent() — returns None if any 3 keys missing
+├─ tools.py          # 4 SQL tools (wraps src/api/db.py fetchers)
+├─ rag.py            # 1 RAG tool — LlamaIndex retriever over Pinecone
+├─ extraction.py     # Pydantic AI Haiku → LineId
+├─ prompts.py        # System prompt + tool instructions
+├─ streaming.py      # LangGraph stream → SSE Frame projector
+└─ history.py        # analytics.chat_messages reader/writer
+```
+
+## Compilation
+
+```python
+def compile_agent() -> CompiledGraph | None:
+    if not (anthropic_key and openai_key and pinecone_key):
+        return None
+    model = _build_chat_model()           # Sonnet, temperature=0
+    tools = [
+        query_tube_status,                # → /status/live fetcher
+        query_line_reliability,           # → /reliability fetcher (with LineId normaliser)
+        query_recent_disruptions,         # → /disruptions/recent fetcher
+        query_bus_punctuality,            # → bus/.../punctuality fetcher
+        search_tfl_docs,                  # → Pinecone retriever (3 namespaces)
+    ]
+    return create_react_agent(model, tools, checkpointer=InMemorySaver())
+```
+
+`compile_agent` returns `None` when any of `ANTHROPIC_API_KEY` /
+`OPENAI_API_KEY` / `PINECONE_API_KEY` is missing, so the FastAPI lifespan
+caches `None` on `app.state.agent` and `/chat/stream` 503s gracefully while
+the rest of the app keeps serving.
+
+## Streaming
+
+```python
+async def project(stream: AsyncIterator[tuple[str, Any]]) -> AsyncIterator[Frame]:
+    async for kind, payload in stream:
+        if kind == "messages":
+            yield Frame(type="token", content=payload.content)
+        elif kind == "updates":
+            for tool_name in _tool_calls_from(payload):
+                yield Frame(type="tool", content=tool_name)
+    yield Frame(type="end", content="ok")
+```
+
+`Frame` is the **stable contract** with the frontend:
+`{type: "token" | "tool" | "end", content: str}`. Replacing LangGraph would
+not change a single line in the web client.
+
+## Persistence
+
+Chat turns land in `analytics.chat_messages` (DDL in
+`contracts/sql/004_chat.sql`):
+
+| Step | When |
+|------|------|
+| Insert user turn | Before the first frame is sent — a connection drop never loses the question |
+| Insert assistant turn | On stream end with the concatenated tokens |
+
+The `/chat/{thread_id}/history` endpoint replays the table ordered by
+`(thread_id, created_at ASC)`.
+
+## Tests
+
+| Module | Count | What it covers |
+|--------|-------|----------------|
+| `extraction.py` | 4 | Canonical / informal / ambiguous / empty `LineId` |
+| `tools.py` | 8 | Happy path, empty, parameter validation, db absent |
+| `rag.py` | 6 | Retrieval, doc_id targeting, page sentinel, namespace fan-out, empty, sdk failure |
+| `graph.py` | 5 | Compile, no-keys, tool registration, model selection, prompt |
+| Route smokes | 9 | SSE happy / 503 / mid-stream `end:error`; history happy / empty / 503 |
+
+All run with fakes for Anthropic / OpenAI / Pinecone — no live LLM cost in
+unit tests. Integration smokes are gated on the four-key combo plus
+`DATABASE_URL`.
+
+## Bedrock swap (TM-A5)
+
+Once TM-A5 ships, this package will switch from `ChatAnthropic` /
+`anthropic:...` to `ChatBedrockConverse` / `bedrock:...` driven by the
+`BEDROCK_REGION` env var. Anthropic-direct stays as a local-dev fallback —
+see [Deployment](../../../docs/deployment.md) for the full design.

--- a/src/ingestion/README.md
+++ b/src/ingestion/README.md
@@ -1,0 +1,113 @@
+# src/ingestion/
+
+The streaming half: an async TfL client, three Kafka producers, and three
+consumers writing JSONB rows into `raw.*`. Every byte that crosses the wire
+is a Pydantic v2 model.
+
+## Layout
+
+```text
+src/ingestion/
+├─ Dockerfile               # ARM64 slim image (rebuilt by GHA matrix)
+├─ observability.py         # Logfire span helpers + namespace overrides
+├─ tfl_client/
+│  ├─ client.py             # async httpx with hand-rolled retry
+│  ├─ retry.py              # 429/5xx/timeout backoff
+│  └─ normalise.py          # tier-1 → tier-2 transformations
+├─ producers/
+│  ├─ kafka.py              # KafkaEventProducer wrapper (acks=all, idempotent)
+│  ├─ line_status.py        # 30s cadence, partition key=line_id
+│  ├─ arrivals.py           # 30s cadence × 5 NaPTAN hubs
+│  └─ disruptions.py        # 300s cadence × 4 modes
+└─ consumers/
+   ├─ kafka.py              # KafkaEventConsumer wrapper
+   ├─ event_consumer.py     # generic RawEventConsumer[E]
+   ├─ postgres.py           # RawEventWriter — INSERT … ON CONFLICT (event_id) DO NOTHING
+   ├─ line_status.py        # binds the generic consumer to the line-status topic
+   ├─ arrivals.py
+   └─ disruptions.py
+```
+
+## Producer cadences
+
+| Producer | Cadence | Partition key | Event type |
+|----------|---------|---------------|------------|
+| `LineStatusProducer` | 30 s | `line_id` | `line-status.snapshot` |
+| `ArrivalsProducer` | 30 s × 5 hubs | `station_id` | `arrivals.snapshot` |
+| `DisruptionsProducer` | 300 s × 4 modes | `disruption_id` | `disruptions.snapshot` |
+
+All three share the `KafkaEventProducer` wrapper — `acks="all"`,
+`enable_idempotence=true`, UUIDv4 `event_id`. A retry never duplicates a row.
+
+## Consumer guarantees
+
+| Failure | Handling |
+|---------|----------|
+| Poison pill (decode error) | Skip + commit |
+| Transient `OperationalError` | Reconnect + replay offset |
+| Unknown exception | Log + replay offset |
+
+Idempotency comes from `INSERT … ON CONFLICT (event_id) DO NOTHING` — a
+replay of a successful offset is a no-op at the row level.
+
+Lag is computed on every `kafka.consume` span and refreshed every
+**50 messages or 30 s** (whichever comes first).
+
+## Run locally
+
+```bash
+make up                       # boots Postgres + Redpanda + Airflow
+make seed                     # loads fixtures
+uv run task init-topics       # creates Redpanda topics
+
+# In separate terminals:
+uv run task ingest-line-status     uv run task consume-line-status
+uv run task ingest-arrivals        uv run task consume-arrivals
+uv run task ingest-disruptions     uv run task consume-disruptions
+```
+
+## Run in production
+
+TM-A5 collapses the six daemons into **two processes** so the EC2 box only
+runs two ingestion containers:
+
+```python
+# src/ingestion/run_producers.py (TM-A5)
+async def main() -> None:
+    await asyncio.gather(
+        LineStatusProducer().run_forever(),
+        ArrivalsProducer().run_forever(),
+        DisruptionsProducer().run_forever(),
+    )
+```
+
+`run_consumers.py` mirrors. The existing producer/consumer classes are
+untouched — only the entrypoint changes.
+
+## Observability
+
+`observability.py` exposes per-topic span namespaces and **redacts the
+`app_key`** before any span is emitted. Logfire instruments httpx
+automatically, so the redaction guards against the auto-instrumented spans
+as well.
+
+```python
+@logfire.instrument(
+    "ingestion.line_status.poll",
+    record_return=False,                 # payload is large; we record metadata
+)
+async def fetch_line_status(self) -> tier1.LineStatusResponse:
+    ...
+```
+
+## Tests
+
+| Layer | Count |
+|-------|-------|
+| `tfl_client` (retry, normalise, redaction) | 14 |
+| Producers (×3) | 21 |
+| Consumers (×3, parametrised) | 28 |
+| Integration smokes (Redpanda + Postgres) | 4 |
+
+Total ~70 unit tests. Fixtures live under `tests/fixtures/tfl/` — tests
+never hit the live TfL API.

--- a/src/rag/README.md
+++ b/src/rag/README.md
@@ -1,0 +1,100 @@
+# src/rag/
+
+The RAG ingestion CLI: TfL strategy PDFs → Docling parse → OpenAI embeddings
+→ Pinecone serverless. **Conditional** (only refetches what changed) and
+**idempotent** (re-running upserts the same vector ids).
+
+## Layout
+
+```text
+src/rag/
+├─ __init__.py
+├─ config.py        # Settings (BaseSettings) — env-driven config
+├─ sources.json     # Resolved direct-PDF URLs (overwritten by --refresh-urls)
+├─ sources.py       # Landing-page URL resolver (per-source allowlist)
+├─ fetch.py         # Conditional GET via If-None-Match + If-Modified-Since
+├─ parse.py         # Docling DocumentConverter + HybridChunker
+├─ embed.py         # Async-batched OpenAI text-embedding-3-small
+├─ upsert.py        # Pinecone serverless — namespace per doc_id
+└─ ingest.py        # Orchestrator — `python -m rag.ingest`
+```
+
+## CLI
+
+```bash
+uv run python -m rag.ingest                 # only refetch what changed
+uv run python -m rag.ingest --refresh-urls  # rewrite sources.json
+uv run python -m rag.ingest --force-refetch # bypass ETag cache
+uv run python -m rag.ingest --dry-run       # skip Pinecone upsert
+```
+
+If 1 of 3 documents fails its fetch / parse / embed / upsert cycle, the
+others still complete and the CLI exits non-zero so a future cron / GitHub
+Action surfaces the failure instead of swallowing it.
+
+## Documents indexed
+
+| `doc_id` | Title | Landing page |
+|----------|-------|--------------|
+| `tfl_business_plan` | TfL Business Plan | `tfl.gov.uk/.../business-plan` |
+| `mts_2018` | Mayor's Transport Strategy 2018 | `london.gov.uk/.../mayors-transport-strategy-2018` |
+| `tfl_annual_report` | TfL Annual Report and Statement of Accounts | `tfl.gov.uk/.../annual-report` |
+
+Landing pages are the citation surface; resolved CDN URLs are not, because
+TfL roll the URL stem yearly.
+
+## Idempotency strategy
+
+| Stage | Mechanism |
+|-------|-----------|
+| Fetch | `If-None-Match` + `If-Modified-Since` from `data/cache/sources_state.json` |
+| Embed | OpenAI batch endpoint, retry on 429 |
+| Upsert | Stable id `sha256("{resolved_url}::{chunk_index}")` |
+| Rollover | Delete-namespace before re-ingest when `--refresh-urls` flips the URL |
+
+## Pinecone index shape
+
+```text
+Index:        tfl-strategy-docs
+Dimension:    1536
+Metric:       cosine
+Cloud:        AWS, us-east-1 (serverless)
+Namespaces:   tfl_business_plan / mts_2018 / tfl_annual_report
+Metadata:     doc_id, chunk_index, page, text
+```
+
+## Config
+
+All settings ride on `BaseSettings` — env-driven, no CLI flags for static
+config:
+
+| Env var | Default |
+|---------|---------|
+| `OPENAI_API_KEY` | (required) |
+| `PINECONE_API_KEY` | (required) |
+| `PINECONE_INDEX` | `tfl-strategy-docs` |
+| `EMBEDDING_MODEL` | `text-embedding-3-small` |
+| `RAG_SOURCES_PATH` | `src/rag/sources.json` |
+| `RAG_CACHE_DIR` | `data/cache` |
+| `RAG_LOCAL_PDF_DIR` | `data/strategy_docs` |
+
+## Cost
+
+A full re-embedding of all three PDFs runs at well under £0.20 one-time at
+the current `text-embedding-3-small` price ($0.02 per 1M tokens).
+**Conditional GETs and stable Pinecone IDs mean steady-state runs incur
+near-zero embedding spend** — most weeks every doc returns 304 and the CLI
+exits in under a second.
+
+## Tests
+
+28 unit tests with fakes for httpx / Docling / OpenAI / Pinecone:
+
+| Module | Coverage |
+|--------|----------|
+| `sources.py` | landing-page resolver picks the right PDF URL via per-source allowlist |
+| `fetch.py` | 304 short-circuit, 200 with body, ETag round-trip |
+| `parse.py` | Docling output → chunks with stable text + page metadata |
+| `embed.py` | Batch sizing, retry on 429, async ordering preserved |
+| `upsert.py` | Id stability, namespace rollover, partial-failure handling |
+| `ingest.py` | Orchestrator argument parsing, exit-non-zero on partial failure |

--- a/tests/README.md
+++ b/tests/README.md
@@ -72,7 +72,7 @@ CI runs the default suite + frontend Vitest in parallel jobs.
 
 The fixtures are deliberately **not** factory-style — they return concrete
 shapes the tests can assert on. Rebuilding fixtures from the live API uses
-[`scripts/fetch_tfl_samples.py`](../scripts).
+[`scripts/fetch_tfl_samples.py`](../scripts/fetch_tfl_samples.py).
 
 ## Conventions
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,84 @@
+# tests/
+
+Pytest suite for the Python half of the codebase. Markers separate fast unit
+tests from external-dependency-gated integration smokes.
+
+## Layout
+
+```text
+tests/
+├─ conftest.py            # Shared fixtures (FakeAsyncPool, FakeKafka, ...)
+├─ test_contracts.py      # contracts/ drift + invariants
+├─ test_health.py         # /health smoke
+├─ agent/                 # Legacy agent observability (used by fixtures)
+├─ airflow/               # Hermetic DAG-parse tests (marker: airflow)
+├─ api/                   # Route handlers + OpenAPI drift + chat
+├─ ingestion/             # tfl_client / producers / consumers
+├─ rag/                   # fetch / parse / embed / upsert / ingest
+├─ integration/           # External-dependency smokes (marker: integration)
+└─ fixtures/              # JSON fixtures captured from the live TfL API
+   └─ tfl/
+```
+
+## Markers
+
+```toml
+markers = [
+    "integration: requires live services (Postgres, Kafka, etc.); opt in with -m integration",
+    "airflow:     requires apache-airflow installed; opt in with -m airflow",
+    "slow:        spends real LLM / RAG budget; opt in with -m 'integration and slow'",
+]
+```
+
+Default invocation **excludes** `integration` and `airflow`:
+
+```toml
+addopts = "-m 'not integration and not airflow'"
+```
+
+## Running
+
+```bash
+uv run task test                              # default — fast unit suite
+uv run pytest -m integration                  # external-deps smokes
+uv run pytest -m airflow tests/airflow -v     # DAG parse
+uv run pytest -m 'integration and slow'       # spends LLM budget
+```
+
+CI runs the default suite + frontend Vitest in parallel jobs.
+
+## Test counts
+
+| Suite | Unit | Integration | Notes |
+|-------|------|-------------|-------|
+| `api/` | ~50 | 14 | OpenAPI drift, all 6 endpoints, SSE chat, history |
+| `ingestion/` | ~70 | 4 | Per-topic producer + consumer, retry, redaction |
+| `rag/` | 28 | 0 | Fakes for httpx / Docling / OpenAI / Pinecone |
+| `agent/` | (covered via `api/agent/`) | 3 | History round-trip + chat-stream + history-after-stream |
+| `airflow/` | 4 | 0 | DAG-parse hermetic |
+| `test_contracts.py` | parametrised | 0 | Pydantic-vs-DDL invariants |
+
+## Fixtures
+
+`conftest.py` exposes:
+
+| Fixture | Purpose |
+|---------|---------|
+| `client` | FastAPI TestClient with overridable `app.state` |
+| `FakeAsyncPool` | psycopg pool that returns predictable rows |
+| `FakeKafka` | aiokafka stand-in (Producer + Consumer) |
+| `monkey_settings` | Patches env-driven settings without touching `os.environ` |
+| `tfl_fixtures` | Canonical TfL JSON payloads from `tests/fixtures/tfl/` |
+
+The fixtures are deliberately **not** factory-style — they return concrete
+shapes the tests can assert on. Rebuilding fixtures from the live API uses
+[`scripts/fetch_tfl_samples.py`](../scripts).
+
+## Conventions
+
+- **One assertion per test name.** A test called `test_returns_404_on_empty_window`
+  asserts exactly that, not a four-line happy-path.
+- **No live network.** Production code accepts client objects via constructor
+  injection so fakes drop in without monkeypatching.
+- **`-m 'integration and slow'` for LLM tests.** They cost real money — they
+  should never run unless explicitly opted in.

--- a/uv.lock
+++ b/uv.lock
@@ -588,6 +588,19 @@ wheels = [
 ]
 
 [[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+]
+
+[[package]]
 name = "bandit"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1032,6 +1045,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
     { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
 ]
+
+[[package]]
+name = "csscompressor"
+version = "0.9.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/2a/8c3ac3d8bc94e6de8d7ae270bb5bc437b210bb9d6d9e46630c98f4abd20c/csscompressor-0.9.5.tar.gz", hash = "sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05", size = 237808, upload-time = "2017-11-26T21:13:08.238Z" }
 
 [[package]]
 name = "cuda-bindings"
@@ -1501,6 +1520,15 @@ wheels = [
 ]
 
 [[package]]
+name = "editorconfig"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3a/a61d9a1f319a186b05d14df17daea42fcddea63c213bcd61a929fb3a6796/editorconfig-0.17.1.tar.gz", hash = "sha256:23c08b00e8e08cc3adcddb825251c497478df1dada6aefeb01e626ad37303745", size = 14695, upload-time = "2025-06-09T08:21:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82", size = 16360, upload-time = "2025-06-09T08:21:35.654Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1936,6 +1964,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2218,6 +2258,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
     { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
     { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
+name = "htmlmin2"
+version = "0.1.13"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/31/a76f4bfa885f93b8167cb4c85cf32b54d1f64384d0b897d45bc6d19b7b45/htmlmin2-0.1.13-py3-none-any.whl", hash = "sha256:75609f2a42e64f7ce57dbff28a39890363bde9e7e5885db633317efbdf8c79a2", size = 34486, upload-time = "2023-03-14T21:28:30.388Z" },
 ]
 
 [[package]]
@@ -2527,6 +2575,25 @@ sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
 ]
+
+[[package]]
+name = "jsbeautifier"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
+]
+
+[[package]]
+name = "jsmin"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc", size = 13925, upload-time = "2022-01-16T20:35:59.13Z" }
 
 [[package]]
 name = "jsonlines"
@@ -3162,6 +3229,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3347,6 +3423,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
 name = "methodtools"
 version = "0.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -3412,6 +3497,119 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/e2/fb226b81fdfba702a59ad50635fd9e72d6321cb92b2b4e76adfef7fe1903/mistralai-2.4.1.tar.gz", hash = "sha256:9aad8270b3085e84a1a88b07a7824aa6b97ee8470baee1a57f23a3f2b17b286c", size = 413448, upload-time = "2026-04-21T13:44:59.563Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/03/1ab3de0cb123c0b5e4df612bacce65a5ad4c4f322dcdf95db2786092ea6d/mistralai-2.4.1-py3-none-any.whl", hash = "sha256:a535ac7fafec368ce66e7ecd22380489ce04d8b1466a35a20905c45e020f660e", size = 975691, upload-time = "2026-04-21T13:44:57.586Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-glightbox"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "selectolax" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/26/c793459622da8e31f954c6f5fb51e8f098143fdfc147b1e3c25bf686f4aa/mkdocs_glightbox-0.5.2.tar.gz", hash = "sha256:c7622799347c32310878e01ccf14f70648445561010911c80590cec0353370ac", size = 510586, upload-time = "2025-10-23T14:55:18.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl", hash = "sha256:23a431ea802b60b1030c73323db2eed6ba859df1a0822ce575afa43e0ea3f47e", size = 26458, upload-time = "2025-10-23T14:55:17.43Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-mermaid2-plugin"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "jsbeautifier" },
+    { name = "mkdocs" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/6d/308f443a558b6a97ce55782658174c0d07c414405cfc0a44d36ad37e36f9/mkdocs_mermaid2_plugin-1.2.3.tar.gz", hash = "sha256:fb6f901d53e5191e93db78f93f219cad926ccc4d51e176271ca5161b6cc5368c", size = 16220, upload-time = "2025-10-17T19:38:53.047Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/4b/6fd6dd632019b7f522f1b1f794ab6115cd79890330986614be56fd18f0eb/mkdocs_mermaid2_plugin-1.2.3-py3-none-any.whl", hash = "sha256:33f60c582be623ed53829a96e19284fc7f1b74a1dbae78d4d2e47fe00c3e190d", size = 17299, upload-time = "2025-10-17T19:38:51.874Z" },
+]
+
+[[package]]
+name = "mkdocs-minify-plugin"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "csscompressor" },
+    { name = "htmlmin2" },
+    { name = "jsmin" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/67/fe4b77e7a8ae7628392e28b14122588beaf6078b53eb91c7ed000fd158ac/mkdocs-minify-plugin-0.8.0.tar.gz", hash = "sha256:bc11b78b8120d79e817308e2b11539d790d21445eb63df831e393f76e52e753d", size = 8366, upload-time = "2024-01-29T16:11:32.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/cd/2e8d0d92421916e2ea4ff97f10a544a9bd5588eb747556701c983581df13/mkdocs_minify_plugin-0.8.0-py3-none-any.whl", hash = "sha256:5fba1a3f7bd9a2142c9954a6559a57e946587b21f133165ece30ea145c66aee6", size = 6723, upload-time = "2024-01-29T16:11:31.851Z" },
 ]
 
 [[package]]
@@ -4827,6 +5025,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5695,6 +5902,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5d/ab/34ec41718af73c00119d0351b7a2531d2ebddb51833a36448fc7b862be60/pylatexenc-2.10.tar.gz", hash = "sha256:3dd8fd84eb46dc30bee1e23eaab8d8fb5a7f507347b23e5f38ad9675c84f40d3", size = 162597, upload-time = "2021-04-06T07:56:07.854Z" }
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
 name = "pyobjc-core"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -6022,6 +6242,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -6462,6 +6694,50 @@ wheels = [
 ]
 
 [[package]]
+name = "selectolax"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/5c/bf049c4aec4c102977abcac68a90dfb1031edc225e9a754fe2c7e624a2d2/selectolax-0.4.7.tar.gz", hash = "sha256:17f7ba5a21714d450b4eea0451608a36be2bba8d327990ddbda812eb3f36fa51", size = 4822635, upload-time = "2026-03-06T09:25:15.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/1d/8d3db7dcc053f7f4088a826f9089324c7b37617f9caaf6a03f0ff5854bbd/selectolax-0.4.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8fa541a520cc6213d754ec747ebbff12fdcc5b9f6bb7615784486e18697209fb", size = 2059304, upload-time = "2026-03-06T09:24:04.861Z" },
+    { url = "https://files.pythonhosted.org/packages/42/64/de442c5056aa4f42d140556a8093bfadee72545919384cf38d6f651b75b0/selectolax-0.4.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a0e9b1e3b1d091a0133b44b3967c79db8de73d99efe38af85bab615775aa4e8", size = 2057450, upload-time = "2026-03-06T09:24:06.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/42/969e084f59c845fbb304d55f8e3899ffe823f3cd78d85d083edffe772766/selectolax-0.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7134b119c011e18d1e914d5adbb8f953e391649b4af734fcec61dad691a16f59", size = 2251180, upload-time = "2026-03-06T09:24:07.536Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/1b/d8f84cb6385637cd793aad3a53618d3ee1b4329e0feb0f4db7a7f81af4da/selectolax-0.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3840b79f5f39744b95dc80e3b428cf4e49b86d8c6e9cbb3e7df3e702bf240cce", size = 2292532, upload-time = "2026-03-06T09:24:08.896Z" },
+    { url = "https://files.pythonhosted.org/packages/85/54/15c3b5d94cf969748ffcca7289245d477ef69ce30a359c5a764b0bc2226e/selectolax-0.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:eb6faf15e6cc6a7c61c04e15c3490e3f6693c98f732e531941687093de36db81", size = 2263969, upload-time = "2026-03-06T09:24:10.556Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4f/fa4125a9a92b2a15a3b332592270e003e9092bb97c3d6c3a7f2714b4c507/selectolax-0.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3799b39d60266f7d4c48f322fac8eaecc6dec38f4342d6d3b17085d11815bcb4", size = 2298497, upload-time = "2026-03-06T09:24:11.919Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/fef3b7d4f8da87762574ea20ff9612485639d6b0a9b7d3839738d8ced105/selectolax-0.4.7-cp312-cp312-win32.whl", hash = "sha256:88344c8764f3a2fbcae2fd2353201c330920943c2da34a16e9b063f918deb7d6", size = 1735965, upload-time = "2026-03-06T09:24:13.407Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/5b893677a0acfc579d9ccb3f01204c4554ba533db5c144cc3b18e33e347b/selectolax-0.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:00953c3c6a7e4dfd990a5651315b713d50131706c239c1f1c5b6d4a75a11975a", size = 1833805, upload-time = "2026-03-06T09:24:14.726Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ad/bb94f409f33871b6d9b3b4d56fb82d14d9b2fd2e7657f32c25a35167187e/selectolax-0.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:e6b8d0f7cbdc6ca5cbf52dbd37f70c170184040499ac59a23409724724276784", size = 1783620, upload-time = "2026-03-06T09:24:16.062Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6b/238c03a1be1aa73c5392026ae4efbcf9f8356bb5a07dda1134f07d33e78c/selectolax-0.4.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fb8f169511f037b662dac1a0e27cff30f4317f9aa30af2e37c8a37c3ca8c7e3c", size = 2058636, upload-time = "2026-03-06T09:24:17.787Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/44/22e433b7dc31ff83574051dd9951175bcd0e36b56c0e25cb277929e77ecb/selectolax-0.4.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:feaea6ac95da2fa137abad3c1ae13596bffed44c8e2bfa7802f89a37a1e5e39a", size = 2056263, upload-time = "2026-03-06T09:24:19.51Z" },
+    { url = "https://files.pythonhosted.org/packages/af/95/05f264c622d0f0839954d0f197d420cffe5723354521b6ce543d32b272a1/selectolax-0.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc5ec34ccce3a691e1664a14bf0f40ad6a41117e5de88e85d8ac8e68a7ea8bd", size = 2247850, upload-time = "2026-03-06T09:24:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/59/24/324a271f7ef49786d7bed5674e23718504fe996866e23c75f91ac06c3bfa/selectolax-0.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a7016db9c55ae541f1669a3433aee03fc0a1111d70c84aa5636a5a6b9499854", size = 2287889, upload-time = "2026-03-06T09:24:23.948Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b0/779ab6c428be5cf53ebae1bc2539ebe9df9d8b76e2f9810f107a0338800e/selectolax-0.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d3da9e1609cefc9bb403f62c2b03d2f5622cbe3057c2f06e308a29fad8ae5654", size = 2261143, upload-time = "2026-03-06T09:24:25.552Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/c2/34b132d14922b7d8dbb50d0b487d22aeb7af8a47421baaf05f2cc1cc2dbd/selectolax-0.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9c70be8f4154a80b8d435bcc3217c04a82f928849fa2f6acd554d24c5b911db6", size = 2293796, upload-time = "2026-03-06T09:24:26.974Z" },
+    { url = "https://files.pythonhosted.org/packages/24/67/6ba2b7140d7e92a3a0f815ac6c8001171973248a9f27206b339019e0b288/selectolax-0.4.7-cp313-cp313-win32.whl", hash = "sha256:df8a8db519484c868839f1d36be720feeb228c8f75cf7b745e325db183b319c6", size = 1735965, upload-time = "2026-03-06T09:24:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/1c/d22cbd6c5828a59addd42626c22b2afb3422bfce59cf88d15095da05243f/selectolax-0.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:5a613760d2b890d7befd2e585a37dd0bdae9e23eee0cacb15d24adb83232c94e", size = 1834806, upload-time = "2026-03-06T09:24:29.875Z" },
+    { url = "https://files.pythonhosted.org/packages/59/d7/d2206d9f38a534b4fc4383c7dd427ba0b927075c96881274a60978411723/selectolax-0.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:7cbd1143920b7bd1b80e092d5a16c97fdc741b0325a42862f20edcb55ab493e8", size = 1783517, upload-time = "2026-03-06T09:24:31.843Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/76f9ee49b4bbb27ebe2d3b26ad84b6887f41d181dd8682278ccea50ed75f/selectolax-0.4.7-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:9f29ad4506fe84152391998ae5b05aaae80d237795567009a518496d0daf4908", size = 2078520, upload-time = "2026-03-06T09:24:33.283Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7d/bcc37be0537802f8d94e61d30f4d36130afa2ae2fa59758b534e4bbe80e7/selectolax-0.4.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2f19bb52c27f526d89383ec178daa31fcb93dbec90106bfb3e2d43c2970f3b72", size = 2076219, upload-time = "2026-03-06T09:24:34.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/4c/544385da484f6a3b8ba70ea4ad15a121adb0cf2b55b74f2560b8e01f44cc/selectolax-0.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a6735711f492532a83df6d501e8647feea48d893e703f0354e61ba868757f9b", size = 2255094, upload-time = "2026-03-06T09:24:36.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e7/bbb13633f4378dbc390c874be4321fd4d09388a44b66f1c26625730030ba/selectolax-0.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea46dbb3592ec0aa78662ecdcac8c083313dafbc6bd8277620b8301db658d638", size = 2289342, upload-time = "2026-03-06T09:24:38.429Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1b/c1fc7711ad8b1c3b60a987fa258d47cb93a8b3b9f21ca8a6aa24e5e7705c/selectolax-0.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4782cc1e162ca422a325302cdad344cd853cfde19004b870e5b6c3df651abab", size = 2285919, upload-time = "2026-03-06T09:24:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/51/d5f8bc697c84bdae90c6d5fd038662d3509879c28f2076ef70fdbd0ab61a/selectolax-0.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e7f847b38195c45f6f6c966df5d8600ab9d522df632d61b28db2edd92deeb3c", size = 2313967, upload-time = "2026-03-06T09:24:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/01/277d3c3fa5d3c669bf8d20bd12fcde50258408dc4bd9e3f8c5fc2d28fcd6/selectolax-0.4.7-cp314-cp314-win32.whl", hash = "sha256:eaf2e15076fa7e2e5fe7c3b5a88e54b14bbd49a53da983534f6cb448f3f0e300", size = 1846621, upload-time = "2026-03-06T09:24:43.074Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c6/5b4ae2b211161b597cc6bc02e517616d045a859dbfa98b2c0dd372614bf9/selectolax-0.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:87bd651514491b9bdd8254e71295e43b790575021b87ebc2351ed6a2aeaa9313", size = 1943489, upload-time = "2026-03-06T09:24:45.049Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c6/ab1544bbc731e653dd59dcb4f497fccbede8c84af3783c4f340ef1d6b606/selectolax-0.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:771710fe52b082804d959944e3e0fe67f094ea1bf81669b4f654b957a7490d95", size = 1896489, upload-time = "2026-03-06T09:24:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/83/77/59593bfd132f6af138720c09cae3f0969d3f5366e3457c5309ab9c020d92/selectolax-0.4.7-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8edbec5ad8a51cb60e6761231d88d34ed3a8158db3ae1f448aede2d146111d0f", size = 2098945, upload-time = "2026-03-06T09:24:47.935Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/74/90d0718b9f7898aa422ae5f9969fb43b3c5abc543cfd4eb64987aa052fe4/selectolax-0.4.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c275e5e5579e308a09ae77922c468a8ca63666534d00a42ebfd912f3c842a2e", size = 2098041, upload-time = "2026-03-06T09:24:49.377Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bc/bbe7c98a3eb4b83e164c56a3245a272427b2d03672a18456bd96325a1929/selectolax-0.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9591ec48af16003a79db89f070688fe0fb68d2c16ac6b479b0ee8b78eb4e486", size = 2263047, upload-time = "2026-03-06T09:24:50.743Z" },
+    { url = "https://files.pythonhosted.org/packages/de/0e/5929821c7f7a9c9a753feef59433ba16a0ca8e5f8f7ac0efa2dea6a84edf/selectolax-0.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc504cad873bc4e95fca9141008ccf0d5e44350dfe450b71ccee86bd0b7b0572", size = 2290751, upload-time = "2026-03-06T09:24:52.088Z" },
+    { url = "https://files.pythonhosted.org/packages/34/30/3426668e83dcaf7f8fac3117140119556436e8de00de4ebbfde5bbf56d45/selectolax-0.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:64de787422ad342b35fef86e488d8b76d70fc3266cb74dfc154d4a89291c62b1", size = 2297728, upload-time = "2026-03-06T09:24:53.494Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/a1937960cf98bf3cdc32963fb3ed30ee6364cf8e4c458bba21ca8cf98308/selectolax-0.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb2757147ba48c2ac75ad79ad47e4b4d9e7ddb08ac614b90347cdff6b98c860b", size = 2315531, upload-time = "2026-03-06T09:24:54.929Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/64/1f699580093cc0582c07124137bdb78162086d7ef822dabbad2a2b051793/selectolax-0.4.7-cp314-cp314t-win32.whl", hash = "sha256:da9afa778ebce19c48de1e6fe5ff5bf7c719cd7f9cd14e5d530bd00ec15b149f", size = 1900408, upload-time = "2026-03-06T09:24:56.294Z" },
+    { url = "https://files.pythonhosted.org/packages/26/df/1035432c42eb76feaf696b7318411be908dab01b5b2907566c820d390fdb/selectolax-0.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:ad71d3b31ceb49820787d19d983e2851835ad03bbfd302c6e243a97215e36557", size = 2011199, upload-time = "2026-03-06T09:24:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/61/99/d4de702bdd436e108891df2105adb7c6f44a11833a88c08686b18d4a6693/selectolax-0.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:85e4ada1c4a3a69e503c9866e74bce24e716bd0ada060c7c2b56677d4f073928", size = 1915624, upload-time = "2026-03-06T09:24:59.406Z" },
+]
+
+[[package]]
 name = "semchunk"
 version = "3.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -6852,6 +7128,14 @@ dev = [
     { name = "ruff" },
     { name = "taskipy" },
 ]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-glightbox" },
+    { name = "mkdocs-material" },
+    { name = "mkdocs-mermaid2-plugin" },
+    { name = "mkdocs-minify-plugin" },
+    { name = "pymdown-extensions" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -6889,6 +7173,14 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.8" },
     { name = "taskipy", specifier = ">=1.14" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6" },
+    { name = "mkdocs-glightbox", specifier = ">=0.4" },
+    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2" },
+    { name = "mkdocs-minify-plugin", specifier = ">=0.8" },
+    { name = "pymdown-extensions", specifier = ">=10.0" },
 ]
 
 [[package]]
@@ -7427,6 +7719,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]

--- a/web/README.md
+++ b/web/README.md
@@ -1,58 +1,112 @@
 # web/
 
-Next.js 16 dashboard for tfl-monitor — Network Now, Disruption Log,
-Reliability, and the conversational Ask view land progressively across
-TM-E1 → TM-E3.
+Next.js 16 dashboard for tfl-monitor — three views (Network Now, Disruption
+Log, Ask), all server components by default, types regenerated from the
+OpenAPI contract.
 
 ## Stack
 
-- Next.js 16 App Router on React 19
-- Tailwind CSS 4 (PostCSS pipeline)
-- shadcn/ui — Radix Nova preset
-- Biome (sole linter + formatter; no ESLint, no Prettier)
-- Vitest + React Testing Library (sole test runner)
+- **Next.js 16** App Router on React 19
+- **Tailwind CSS 4** (PostCSS pipeline)
+- **shadcn/ui** — Radix Nova preset
+- **Biome** — sole linter + formatter (no ESLint, no Prettier)
+- **Vitest + React Testing Library** — sole test runner
 - TypeScript types regenerated from `contracts/openapi.yaml` via
   `make openapi-ts` (writes `web/lib/types.ts`)
+- **pnpm** — sole package manager (no npm, no yarn)
+
+## Layout
+
+```text
+web/
+├─ app/                      # App Router routes
+│  ├─ page.tsx               # Network Now (/)
+│  ├─ disruptions/page.tsx   # Disruption Log
+│  └─ ask/page.tsx           # ChatView host
+├─ components/
+│  ├─ chat-view.tsx          # SSE-streaming chat
+│  └─ ui/                    # shadcn primitives
+├─ lib/
+│  ├─ api/                   # Server-side fetchers
+│  ├─ sse-parser.ts          # 60-line stateful SSE parser
+│  └─ types.ts               # generated — do not edit
+├─ __tests__/                # Vitest specs
+├─ next.config.ts            # Security headers
+└─ biome.json                # Single config for lint + format
+```
 
 ## Quickstart
 
 ```bash
-pnpm --dir web install   # only needed if you skipped `make bootstrap`
-pnpm --dir web dev       # dev server on :3000
-pnpm --dir web lint      # Biome check
-pnpm --dir web test      # Vitest run
-pnpm --dir web build     # Next production build
+pnpm --dir web install        # only needed if you skipped `make bootstrap`
+pnpm --dir web dev            # dev server on :3000
+pnpm --dir web lint           # Biome check
+pnpm --dir web test           # Vitest run
+pnpm --dir web build          # Next production build
 ```
 
-`make check` at the repo root chains lint + test + build for both
-Python and TypeScript.
+`make check` at the repo root chains lint + test + build for both Python and
+TypeScript.
 
-## Status
+## Views and wiring
 
-- TM-E1a (this WP) ships the scaffold, security headers, shadcn
-  primitives, the Vitest suite, and a Network Now view that renders
-  **mocked** `/status/live` data committed under
-  `web/lib/mocks/status-live.json`.
-- Real-API wiring is deferred to TM-E1b: swap the body of
-  `web/lib/api/status-live.ts` for `apiFetch<LineStatus[]>(...)` once
-  TM-D2 connects the FastAPI handler to Postgres. The fetcher
-  signature is the contract — call sites do not change.
+| Route | Endpoint | Highlights |
+|-------|----------|------------|
+| `/` | `/api/v1/status/live` | Empty / error states via `Alert role="alert"`; fetcher catches `ApiError` |
+| `/disruptions` | `/api/v1/disruptions/recent` | Per-disruption Card, category-tone badge, closure callout |
+| `/ask` | `/api/v1/chat/stream` (POST SSE) | Token bubbles, ephemeral "Using tool …" status, mid-stream error flag |
+
+Each fetcher imports its operation type from `lib/types.ts` so the response
+shape is end-to-end typed:
+
+```ts
+import type { paths } from "@/lib/types";
+type LineStatus = paths["/api/v1/status/live"]["get"]["responses"]["200"]
+  ["content"]["application/json"][number];
+```
 
 ## Regenerating types from the OpenAPI contract
 
 ```bash
-make openapi-ts
+make openapi-ts   # runs openapi-typescript ../contracts/openapi.yaml -o lib/types.ts
 ```
 
-This runs `openapi-typescript ../contracts/openapi.yaml -o lib/types.ts`
-inside `web/`. Re-run any time `contracts/openapi.yaml` changes.
+Re-run any time `contracts/openapi.yaml` changes. CI runs the same
+generation and `diff`s against the committed file — drift fails the build.
 
 ## Security headers
 
-`next.config.ts` registers the project-wide headers required by
-`CLAUDE.md`:
+`next.config.ts` registers the project-wide headers required by `CLAUDE.md`:
 
 - `X-Frame-Options: DENY`
 - `X-Content-Type-Options: nosniff`
 - `Referrer-Policy: strict-origin-when-cross-origin`
 - `Permissions-Policy: camera=(), microphone=(), geolocation=()`
+
+## Tests
+
+54 specs across:
+
+- **SSE parser** — single frame, multi-frame chunk, partial chunk buffering,
+  ping comments, unknown-type drop, malformed-JSON survival.
+- **Fetchers** — URL/headers/body assertions, RFC 7807 surfacing, network
+  failure propagation, multi-chunk reader buffering.
+- **Pages** — happy path, empty state, error state, RTL queries scoped via
+  `findByRole("alert")` to disambiguate title/description.
+- **ChatView** — empty shell, streaming tokens, tool-status lifecycle,
+  503 alert + conversation rollback, mid-stream `end:error` flagging via
+  `data-errored`.
+
+`web/__tests__/setup.ts` initialises `jsdom` and stubs `fetch` per test via
+`vi.stubGlobal`.
+
+## Status
+
+Feature-complete:
+
+- TM-E1a: scaffold, security headers, shadcn primitives, Vitest suite.
+- TM-E1b: Network Now wired to live `/status/live`.
+- TM-E2: Disruption Log view.
+- TM-E3: Chat view with SSE.
+- TM-E4 (next): Vercel deploy, `NEXT_PUBLIC_API_URL` pointing at the EC2
+  HTTPS endpoint.


### PR DESCRIPTION
Sets up mkdocs documentation site under docs/ with GitHub Actions workflow to build and publish. Adds cross-module READMEs pointing to published docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comprehensive documentation site published covering architecture, deployment strategy, engineering practices, and operational runbooks
  * Added detailed pipeline documentation with system diagrams for data ingestion, warehouse transformations, RAG, LangGraph agent, API, and frontend layers
  * Published tech stack overview, project roadmap, glossary, and architecture decision records index

* **Chores**
  * Automated documentation deployment to GitHub Pages via workflow trigger

<!-- end of auto-generated comment: release notes by coderabbit.ai -->