### PR TITLE
feat(web): TM-E5 PR-1 useAutoRefresh hook + label tokens + shadcn primitives

### DIFF
--- a/web/components/ui/drawer.tsx
+++ b/web/components/ui/drawer.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import type * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@/lib/utils";
+
+function Drawer({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+	return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+	return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+	return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+	return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+	return (
+		<DrawerPrimitive.Overlay
+			data-slot="drawer-overlay"
+			className={cn(
+				"fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DrawerContent({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+	return (
+		<DrawerPortal data-slot="drawer-portal">
+			<DrawerOverlay />
+			<DrawerPrimitive.Content
+				data-slot="drawer-content"
+				className={cn(
+					"group/drawer-content fixed z-50 flex h-auto flex-col bg-popover text-sm text-popover-foreground data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm",
+					className,
+				)}
+				{...props}
+			>
+				<div className="mx-auto mt-4 hidden h-1 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+				{children}
+			</DrawerPrimitive.Content>
+		</DrawerPortal>
+	);
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="drawer-header"
+			className={cn(
+				"flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-0.5 md:text-left",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="drawer-footer"
+			className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+			{...props}
+		/>
+	);
+}
+
+function DrawerTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+	return (
+		<DrawerPrimitive.Title
+			data-slot="drawer-title"
+			className={cn(
+				"font-heading text-base font-medium text-foreground",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DrawerDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+	return (
+		<DrawerPrimitive.Description
+			data-slot="drawer-description"
+			className={cn("text-sm text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerDescription,
+	DrawerFooter,
+	DrawerHeader,
+	DrawerOverlay,
+	DrawerPortal,
+	DrawerTitle,
+	DrawerTrigger,
+};

--- a/web/components/ui/sheet.tsx
+++ b/web/components/ui/sheet.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { XIcon } from "lucide-react";
+import { Dialog as SheetPrimitive } from "radix-ui";
+import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+	return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+	return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+	return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+	return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+	return (
+		<SheetPrimitive.Overlay
+			data-slot="sheet-overlay"
+			className={cn(
+				"fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function SheetContent({
+	className,
+	children,
+	side = "right",
+	showCloseButton = true,
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+	side?: "top" | "right" | "bottom" | "left";
+	showCloseButton?: boolean;
+}) {
+	return (
+		<SheetPortal>
+			<SheetOverlay />
+			<SheetPrimitive.Content
+				data-slot="sheet-content"
+				data-side={side}
+				className={cn(
+					"fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				{showCloseButton && (
+					<SheetPrimitive.Close data-slot="sheet-close" asChild>
+						<Button
+							variant="ghost"
+							className="absolute top-3 right-3"
+							size="icon-sm"
+						>
+							<XIcon />
+							<span className="sr-only">Close</span>
+						</Button>
+					</SheetPrimitive.Close>
+				)}
+			</SheetPrimitive.Content>
+		</SheetPortal>
+	);
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="sheet-header"
+			className={cn("flex flex-col gap-0.5 p-4", className)}
+			{...props}
+		/>
+	);
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="sheet-footer"
+			className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+			{...props}
+		/>
+	);
+}
+
+function SheetTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+	return (
+		<SheetPrimitive.Title
+			data-slot="sheet-title"
+			className={cn(
+				"font-heading text-base font-medium text-foreground",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function SheetDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+	return (
+		<SheetPrimitive.Description
+			data-slot="sheet-description"
+			className={cn("text-sm text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Sheet,
+	SheetClose,
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+};

--- a/web/lib/__tests__/labels.test.ts
+++ b/web/lib/__tests__/labels.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { MODE_LABELS, modeLabel } from "@/lib/labels";
+
+describe("modeLabel", () => {
+	it("returns the brand-correct label for every TfL mode", () => {
+		expect(modeLabel("tube")).toBe("Tube");
+		expect(modeLabel("elizabeth-line")).toBe("Elizabeth Line");
+		expect(modeLabel("national-rail")).toBe("National Rail");
+		expect(modeLabel("river-bus")).toBe("River Bus");
+		expect(modeLabel("cable-car")).toBe("Cable Car");
+	});
+
+	it("exposes the same set of keys as the OpenAPI mode enum", () => {
+		expect(Object.keys(MODE_LABELS).sort()).toEqual(
+			[
+				"bus",
+				"cable-car",
+				"dlr",
+				"elizabeth-line",
+				"national-rail",
+				"overground",
+				"river-bus",
+				"tram",
+				"tube",
+			].sort(),
+		);
+	});
+});

--- a/web/lib/__tests__/labels.test.ts
+++ b/web/lib/__tests__/labels.test.ts
@@ -5,7 +5,7 @@ import { MODE_LABELS, modeLabel } from "@/lib/labels";
 describe("modeLabel", () => {
 	it("returns the brand-correct label for every TfL mode", () => {
 		expect(modeLabel("tube")).toBe("Tube");
-		expect(modeLabel("elizabeth-line")).toBe("Elizabeth Line");
+		expect(modeLabel("elizabeth-line")).toBe("Elizabeth line");
 		expect(modeLabel("national-rail")).toBe("National Rail");
 		expect(modeLabel("river-bus")).toBe("River Bus");
 		expect(modeLabel("cable-car")).toBe("Cable Car");

--- a/web/lib/hooks/__tests__/use-auto-refresh.test.ts
+++ b/web/lib/hooks/__tests__/use-auto-refresh.test.ts
@@ -1,0 +1,97 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAutoRefresh } from "@/lib/hooks/use-auto-refresh";
+
+describe("useAutoRefresh", () => {
+	beforeEach(() => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		Object.defineProperty(document, "visibilityState", {
+			configurable: true,
+			value: "visible",
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("calls the fetcher once on mount and exposes the result", async () => {
+		const fetcher = vi.fn().mockResolvedValue({ ok: true });
+		const { result } = renderHook(() => useAutoRefresh(fetcher, 1000));
+
+		await waitFor(() => {
+			expect(fetcher).toHaveBeenCalledTimes(1);
+			expect(result.current.data).toEqual({ ok: true });
+			expect(result.current.error).toBeNull();
+			expect(result.current.lastUpdated).toBeInstanceOf(Date);
+		});
+	});
+
+	it("re-fetches every interval", async () => {
+		const fetcher = vi.fn().mockResolvedValue("data");
+		renderHook(() => useAutoRefresh(fetcher, 1000));
+
+		await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+			await Promise.resolve();
+		});
+
+		expect(fetcher).toHaveBeenCalledTimes(2);
+	});
+
+	it("clears the interval on unmount", async () => {
+		const fetcher = vi.fn().mockResolvedValue("data");
+		const { unmount } = renderHook(() => useAutoRefresh(fetcher, 1000));
+
+		await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+		unmount();
+
+		act(() => {
+			vi.advanceTimersByTime(5000);
+		});
+
+		expect(fetcher).toHaveBeenCalledTimes(1);
+	});
+
+	it("pauses while the document is hidden and resumes on visibility", async () => {
+		const fetcher = vi.fn().mockResolvedValue("data");
+		renderHook(() => useAutoRefresh(fetcher, 1000));
+
+		await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+
+		Object.defineProperty(document, "visibilityState", {
+			configurable: true,
+			value: "hidden",
+		});
+		document.dispatchEvent(new Event("visibilitychange"));
+
+		act(() => {
+			vi.advanceTimersByTime(2500);
+		});
+		expect(fetcher).toHaveBeenCalledTimes(1);
+
+		Object.defineProperty(document, "visibilityState", {
+			configurable: true,
+			value: "visible",
+		});
+		await act(async () => {
+			document.dispatchEvent(new Event("visibilitychange"));
+			await Promise.resolve();
+		});
+
+		expect(fetcher).toHaveBeenCalledTimes(2);
+	});
+
+	it("surfaces fetcher errors on the result", async () => {
+		const fetcher = vi.fn().mockRejectedValue(new Error("boom"));
+		const { result } = renderHook(() => useAutoRefresh(fetcher, 1000));
+
+		await waitFor(() => {
+			expect(result.current.error?.message).toBe("boom");
+			expect(result.current.data).toBeNull();
+		});
+	});
+});

--- a/web/lib/hooks/__tests__/use-auto-refresh.test.ts
+++ b/web/lib/hooks/__tests__/use-auto-refresh.test.ts
@@ -17,7 +17,9 @@ describe("useAutoRefresh", () => {
 	});
 
 	it("calls the fetcher once on mount and exposes the result", async () => {
-		const fetcher = vi.fn().mockResolvedValue({ ok: true });
+		const fetcher = vi.fn((_signal: AbortSignal) =>
+			Promise.resolve({ ok: true }),
+		);
 		const { result } = renderHook(() => useAutoRefresh(fetcher, 1000));
 
 		await waitFor(() => {
@@ -29,7 +31,7 @@ describe("useAutoRefresh", () => {
 	});
 
 	it("re-fetches every interval", async () => {
-		const fetcher = vi.fn().mockResolvedValue("data");
+		const fetcher = vi.fn((_signal: AbortSignal) => Promise.resolve("data"));
 		renderHook(() => useAutoRefresh(fetcher, 1000));
 
 		await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
@@ -43,7 +45,7 @@ describe("useAutoRefresh", () => {
 	});
 
 	it("clears the interval on unmount", async () => {
-		const fetcher = vi.fn().mockResolvedValue("data");
+		const fetcher = vi.fn((_signal: AbortSignal) => Promise.resolve("data"));
 		const { unmount } = renderHook(() => useAutoRefresh(fetcher, 1000));
 
 		await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
@@ -57,7 +59,7 @@ describe("useAutoRefresh", () => {
 	});
 
 	it("pauses while the document is hidden and resumes on visibility", async () => {
-		const fetcher = vi.fn().mockResolvedValue("data");
+		const fetcher = vi.fn((_signal: AbortSignal) => Promise.resolve("data"));
 		renderHook(() => useAutoRefresh(fetcher, 1000));
 
 		await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
@@ -86,12 +88,76 @@ describe("useAutoRefresh", () => {
 	});
 
 	it("surfaces fetcher errors on the result", async () => {
-		const fetcher = vi.fn().mockRejectedValue(new Error("boom"));
+		const fetcher = vi.fn((_signal: AbortSignal) =>
+			Promise.reject(new Error("boom")),
+		);
 		const { result } = renderHook(() => useAutoRefresh(fetcher, 1000));
 
 		await waitFor(() => {
 			expect(result.current.error?.message).toBe("boom");
 			expect(result.current.data).toBeNull();
 		});
+	});
+
+	it("cancels in-flight request when component unmounts", async () => {
+		let capturedSignal: AbortSignal | null = null;
+		const fetcher = vi.fn((signal: AbortSignal) => {
+			capturedSignal = signal;
+			return new Promise<string>(() => {
+				// Never resolves — simulates a slow request.
+			});
+		});
+
+		const { unmount } = renderHook(() => useAutoRefresh(fetcher, 1000));
+
+		await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+		expect(capturedSignal).not.toBeNull();
+		expect((capturedSignal as AbortSignal).aborted).toBe(false);
+
+		unmount();
+
+		expect((capturedSignal as AbortSignal).aborted).toBe(true);
+	});
+
+	it("skips the initial fetch when the document starts hidden", async () => {
+		Object.defineProperty(document, "visibilityState", {
+			configurable: true,
+			value: "hidden",
+		});
+
+		const fetcher = vi.fn((_signal: AbortSignal) => Promise.resolve("data"));
+		renderHook(() => useAutoRefresh(fetcher, 1000));
+
+		act(() => {
+			vi.advanceTimersByTime(2500);
+		});
+
+		expect(fetcher).not.toHaveBeenCalled();
+
+		Object.defineProperty(document, "visibilityState", {
+			configurable: true,
+			value: "visible",
+		});
+		await act(async () => {
+			document.dispatchEvent(new Event("visibilitychange"));
+			await Promise.resolve();
+		});
+
+		expect(fetcher).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores AbortError from in-flight cancellation", async () => {
+		const abortError = new DOMException("Aborted", "AbortError");
+		const fetcher = vi.fn((_signal: AbortSignal) => Promise.reject(abortError));
+		const { result } = renderHook(() => useAutoRefresh(fetcher, 1000));
+
+		// Give the promise time to reject.
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		// AbortError must not surface to error state.
+		expect(result.current.error).toBeNull();
+		expect(result.current.data).toBeNull();
 	});
 });

--- a/web/lib/hooks/use-auto-refresh.ts
+++ b/web/lib/hooks/use-auto-refresh.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export interface AutoRefreshState<T> {
+	data: T | null;
+	error: Error | null;
+	lastUpdated: Date | null;
+}
+
+/**
+ * Polls `fetcher` every `intervalMs` milliseconds and exposes the
+ * latest snapshot.
+ *
+ * - Calls once on mount, then on each tick.
+ * - Pauses while `document.visibilityState !== "visible"` and resumes
+ *   when the tab becomes visible again (battery-friendly + avoids
+ *   redundant requests for backgrounded tabs).
+ * - Aborts the in-flight request on unmount and on each new tick.
+ * - Caller-supplied `fetcher` does not need to be memoised; the hook
+ *   captures it through a ref so re-renders don't restart polling.
+ */
+export function useAutoRefresh<T>(
+	fetcher: () => Promise<T>,
+	intervalMs: number,
+): AutoRefreshState<T> {
+	const [data, setData] = useState<T | null>(null);
+	const [error, setError] = useState<Error | null>(null);
+	const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+	const fetcherRef = useRef(fetcher);
+	useEffect(() => {
+		fetcherRef.current = fetcher;
+	}, [fetcher]);
+
+	useEffect(() => {
+		let cancelled = false;
+		let timer: ReturnType<typeof setInterval> | null = null;
+		let abort: AbortController | null = null;
+
+		const run = async () => {
+			abort?.abort();
+			abort = new AbortController();
+			try {
+				const next = await fetcherRef.current();
+				if (cancelled) return;
+				setData(next);
+				setError(null);
+				setLastUpdated(new Date());
+			} catch (err) {
+				if (cancelled) return;
+				setError(err instanceof Error ? err : new Error(String(err)));
+			}
+		};
+
+		const start = () => {
+			if (timer !== null) return;
+			void run();
+			timer = setInterval(run, intervalMs);
+		};
+
+		const stop = () => {
+			if (timer !== null) {
+				clearInterval(timer);
+				timer = null;
+			}
+		};
+
+		const handleVisibility = () => {
+			if (document.visibilityState === "visible") {
+				start();
+			} else {
+				stop();
+			}
+		};
+
+		start();
+		document.addEventListener("visibilitychange", handleVisibility);
+
+		return () => {
+			cancelled = true;
+			stop();
+			abort?.abort();
+			document.removeEventListener("visibilitychange", handleVisibility);
+		};
+	}, [intervalMs]);
+
+	return { data, error, lastUpdated };
+}

--- a/web/lib/hooks/use-auto-refresh.ts
+++ b/web/lib/hooks/use-auto-refresh.ts
@@ -13,15 +13,21 @@ export interface AutoRefreshState<T> {
  * latest snapshot.
  *
  * - Calls once on mount, then on each tick.
+ * - Passes an `AbortSignal` to the fetcher so in-flight requests can
+ *   be cancelled on unmount or when a newer tick supersedes them.
  * - Pauses while `document.visibilityState !== "visible"` and resumes
  *   when the tab becomes visible again (battery-friendly + avoids
- *   redundant requests for backgrounded tabs).
- * - Aborts the in-flight request on unmount and on each new tick.
+ *   redundant requests for backgrounded tabs). The mount-time check
+ *   also skips the initial fetch when the tab starts hidden.
+ * - Captures the controller in a local const inside `run` to prevent
+ *   race conditions where a stale resolution overwrites newer data.
+ * - Silently discards `AbortError` so cancellation never surfaces to
+ *   UI error state.
  * - Caller-supplied `fetcher` does not need to be memoised; the hook
  *   captures it through a ref so re-renders don't restart polling.
  */
 export function useAutoRefresh<T>(
-	fetcher: () => Promise<T>,
+	fetcher: (signal: AbortSignal) => Promise<T>,
 	intervalMs: number,
 ): AutoRefreshState<T> {
 	const [data, setData] = useState<T | null>(null);
@@ -40,15 +46,21 @@ export function useAutoRefresh<T>(
 
 		const run = async () => {
 			abort?.abort();
-			abort = new AbortController();
+			const controller = new AbortController();
+			abort = controller;
 			try {
-				const next = await fetcherRef.current();
-				if (cancelled) return;
+				const next = await fetcherRef.current(controller.signal);
+				if (cancelled || controller.signal.aborted) return;
 				setData(next);
 				setError(null);
 				setLastUpdated(new Date());
 			} catch (err) {
-				if (cancelled) return;
+				if (
+					cancelled ||
+					controller.signal.aborted ||
+					(err instanceof DOMException && err.name === "AbortError")
+				)
+					return;
 				setError(err instanceof Error ? err : new Error(String(err)));
 			}
 		};
@@ -74,7 +86,9 @@ export function useAutoRefresh<T>(
 			}
 		};
 
-		start();
+		if (document.visibilityState === "visible") {
+			start();
+		}
 		document.addEventListener("visibilitychange", handleVisibility);
 
 		return () => {

--- a/web/lib/labels.ts
+++ b/web/lib/labels.ts
@@ -1,0 +1,26 @@
+import type { LineStatus } from "@/lib/api/status-live";
+
+export type Mode = LineStatus["mode"];
+
+/**
+ * TfL brand-correct labels for each transport mode.
+ *
+ * The OpenAPI enum is kebab-case (`elizabeth-line`, `national-rail`, …);
+ * blindly replacing hyphens and using Tailwind `capitalize` produces
+ * `Elizabeth line` and `National rail`, which both miss the brand.
+ */
+export const MODE_LABELS: Record<Mode, string> = {
+	tube: "Tube",
+	"elizabeth-line": "Elizabeth Line",
+	overground: "Overground",
+	dlr: "DLR",
+	bus: "Bus",
+	"national-rail": "National Rail",
+	"river-bus": "River Bus",
+	"cable-car": "Cable Car",
+	tram: "Tram",
+};
+
+export function modeLabel(mode: Mode): string {
+	return MODE_LABELS[mode];
+}

--- a/web/lib/labels.ts
+++ b/web/lib/labels.ts
@@ -5,13 +5,13 @@ export type Mode = LineStatus["mode"];
 /**
  * TfL brand-correct labels for each transport mode.
  *
- * The OpenAPI enum is kebab-case (`elizabeth-line`, `national-rail`, …);
- * blindly replacing hyphens and using Tailwind `capitalize` produces
- * `Elizabeth line` and `National rail`, which both miss the brand.
+ * The OpenAPI enum is kebab-case (`elizabeth-line`, `national-rail`, …).
+ * `Elizabeth line` (lowercase 'l') and `National Rail` are correct per
+ * TfL brand guidelines.
  */
 export const MODE_LABELS: Record<Mode, string> = {
 	tube: "Tube",
-	"elizabeth-line": "Elizabeth Line",
+	"elizabeth-line": "Elizabeth line",
 	overground: "Overground",
 	dlr: "DLR",
 	bus: "Bus",

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,8 @@
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
 		"tailwind-merge": "^3.5.0",
-		"tw-animate-css": "^1.4.0"
+		"tw-animate-css": "^1.4.0",
+		"vaul": "^1.1.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.12",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.12
@@ -3211,6 +3214,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -6485,6 +6494,15 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vite@8.0.10(@types/node@20.19.39)(jiti@2.6.1):
     dependencies:


### PR DESCRIPTION
First sub-PR of TM-E5. Adds useAutoRefresh hook (TDD coverage), label tokens, and shadcn primitives required by subsequent dashboard cards (PR-2). Tasks: 1, 2, 3. See docs/superpowers/plans/2026-05-03-dashboard-chat-implementation.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drawer and sheet panel UI components with customizable styling and positioning options.
  * Introduced auto-refresh functionality for dynamically updating data with pause/resume on tab visibility changes.
  * Added transport mode labeling system.

* **Tests**
  * Added comprehensive test coverage for label utilities, auto-refresh hook, and related functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/51)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->