### PR TITLE
feat(web): TM-E5 dashboard cards + chat panel

### DIFF
--- a/web/components/about-sheet.tsx
+++ b/web/components/about-sheet.tsx
@@ -40,7 +40,7 @@ export function AboutSheet() {
 							className="underline underline-offset-4"
 							href="https://github.com/hcslomeu/tfl-monitor"
 							target="_blank"
-							rel="noreferrer"
+							rel="noopener noreferrer"
 						>
 							Source on GitHub →
 						</a>

--- a/web/components/about-sheet.tsx
+++ b/web/components/about-sheet.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Info } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "@/components/ui/sheet";
+
+export function AboutSheet() {
+	return (
+		<Sheet>
+			<SheetTrigger asChild>
+				<Button variant="ghost" size="sm" aria-label="About this project">
+					<Info className="size-4" />
+					<span>About</span>
+				</Button>
+			</SheetTrigger>
+			<SheetContent>
+				<SheetHeader>
+					<SheetTitle>tfl-monitor</SheetTitle>
+					<SheetDescription>
+						Live London transport status, planned works, and an agent that
+						answers questions over TfL data and strategy documents.
+					</SheetDescription>
+				</SheetHeader>
+				<div className="mt-6 space-y-3 text-sm">
+					<p>
+						Pipeline: TfL public APIs → Redpanda → Postgres (dbt) → FastAPI →
+						this UI. Chat agent uses LangGraph with tool calls into the
+						warehouse and a Pinecone vector store over TfL strategy PDFs.
+					</p>
+					<p>
+						<a
+							className="underline underline-offset-4"
+							href="https://github.com/hcslomeu/tfl-monitor"
+							target="_blank"
+							rel="noreferrer"
+						>
+							Source on GitHub →
+						</a>
+					</p>
+				</div>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/web/components/dashboard/__tests__/chat-panel.test.tsx
+++ b/web/components/dashboard/__tests__/chat-panel.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/chat-view", () => ({
+	ChatView: () => <div data-testid="chat-view-stub">stub</div>,
+}));
+
+import { ChatPanel } from "@/components/dashboard/chat-panel";
+
+describe("<ChatPanel>", () => {
+	it("mounts ChatView inside the sticky aside on lg+", () => {
+		render(<ChatPanel />);
+		const stub = screen.getAllByTestId("chat-view-stub");
+		expect(stub.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("opens the drawer when the FAB is clicked", async () => {
+		const user = userEvent.setup();
+		render(<ChatPanel />);
+
+		const fab = screen.getByRole("button", { name: /open chat/i });
+		await user.click(fab);
+
+		expect(
+			await screen.findByRole("dialog", { name: /ask the agent/i }),
+		).toBeInTheDocument();
+	});
+
+	it("does not unmount the sticky ChatView when the drawer opens", async () => {
+		const user = userEvent.setup();
+		render(<ChatPanel />);
+
+		const before = screen.getAllByTestId("chat-view-stub").length;
+		const fab = screen.getByRole("button", { name: /open chat/i });
+		await user.click(fab);
+
+		const after = screen.getAllByTestId("chat-view-stub").length;
+		expect(after).toBeGreaterThanOrEqual(before);
+	});
+});

--- a/web/components/dashboard/__tests__/coming-up-card.test.tsx
+++ b/web/components/dashboard/__tests__/coming-up-card.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ComingUpCard } from "@/components/dashboard/coming-up-card";
+import type { Disruption } from "@/lib/api/disruptions-recent";
+
+function disruption(
+	over: Partial<Disruption> & { disruption_id: string },
+): Disruption {
+	return {
+		disruption_id: over.disruption_id,
+		category: over.category ?? "PlannedWork",
+		category_description: over.category_description ?? "Planned Work",
+		summary: over.summary ?? "Weekend closure",
+		description: over.description ?? "",
+		affected_routes: over.affected_routes ?? [],
+		affected_stops: over.affected_stops ?? [],
+		closure_text: over.closure_text ?? "",
+		severity: over.severity ?? 6,
+		created: over.created ?? "2026-05-03T00:00:00Z",
+		last_update: over.last_update ?? "2026-05-03T00:00:00Z",
+	};
+}
+
+describe("<ComingUpCard>", () => {
+	it("filters to PlannedWork sorted by created ASC and caps at 5", () => {
+		const items = [
+			disruption({
+				disruption_id: "rt",
+				category: "RealTime",
+				summary: "RT excluded",
+			}),
+			disruption({
+				disruption_id: "1",
+				created: "2026-05-08T00:00:00Z",
+				summary: "May 8",
+			}),
+			disruption({
+				disruption_id: "2",
+				created: "2026-05-09T00:00:00Z",
+				summary: "May 9",
+			}),
+			disruption({
+				disruption_id: "3",
+				created: "2026-05-15T00:00:00Z",
+				summary: "May 15",
+			}),
+			disruption({
+				disruption_id: "4",
+				created: "2026-05-16T00:00:00Z",
+				summary: "May 16",
+			}),
+			disruption({
+				disruption_id: "5",
+				created: "2026-05-17T00:00:00Z",
+				summary: "May 17",
+			}),
+			disruption({
+				disruption_id: "6",
+				created: "2026-05-20T00:00:00Z",
+				summary: "May 20 (capped out)",
+			}),
+		];
+		render(<ComingUpCard disruptions={items} />);
+
+		const list = screen.getByRole("list", { name: /upcoming/i });
+		const rendered = within(list).getAllByRole("listitem");
+		expect(rendered).toHaveLength(5);
+		expect(rendered[0]).toHaveTextContent("May 8");
+		expect(rendered[4]).toHaveTextContent("May 17");
+		expect(screen.queryByText("RT excluded")).not.toBeInTheDocument();
+		expect(screen.queryByText("May 20 (capped out)")).not.toBeInTheDocument();
+	});
+
+	it("shows a friendly empty state when there is no planned work", () => {
+		render(<ComingUpCard disruptions={[]} />);
+
+		expect(screen.getByText(/no planned work/i)).toBeInTheDocument();
+	});
+
+	it("ignores other categories entirely", () => {
+		const items = [
+			disruption({
+				disruption_id: "a",
+				category: "Information",
+				summary: "Info note",
+			}),
+			disruption({
+				disruption_id: "b",
+				category: "Incident",
+				summary: "Incident",
+			}),
+		];
+		render(<ComingUpCard disruptions={items} />);
+
+		expect(screen.getByText(/no planned work/i)).toBeInTheDocument();
+	});
+});

--- a/web/components/dashboard/__tests__/happening-now-card.test.tsx
+++ b/web/components/dashboard/__tests__/happening-now-card.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HappeningNowCard } from "@/components/dashboard/happening-now-card";
+import type { Disruption } from "@/lib/api/disruptions-recent";
+
+function disruption(
+	over: Partial<Disruption> & { disruption_id: string },
+): Disruption {
+	return {
+		disruption_id: over.disruption_id,
+		category: over.category ?? "RealTime",
+		category_description: over.category_description ?? "Real Time",
+		summary: over.summary ?? "Severe delays",
+		description: over.description ?? "Signal failure",
+		affected_routes: over.affected_routes ?? [],
+		affected_stops: over.affected_stops ?? [],
+		closure_text: over.closure_text ?? "",
+		severity: over.severity ?? 6,
+		created: over.created ?? "2026-05-03T08:00:00Z",
+		last_update: over.last_update ?? "2026-05-03T09:00:00Z",
+	};
+}
+
+describe("<HappeningNowCard>", () => {
+	it("renders only RealTime and Incident disruptions, sorted by last_update DESC", () => {
+		const items: Disruption[] = [
+			disruption({
+				disruption_id: "a",
+				category: "RealTime",
+				summary: "Older RT",
+				last_update: "2026-05-03T08:00:00Z",
+			}),
+			disruption({
+				disruption_id: "b",
+				category: "PlannedWork",
+				summary: "Planned (excluded)",
+			}),
+			disruption({
+				disruption_id: "c",
+				category: "Incident",
+				summary: "Latest incident",
+				last_update: "2026-05-03T10:00:00Z",
+			}),
+		];
+		render(<HappeningNowCard disruptions={items} />);
+
+		const list = screen.getByRole("list", { name: /active disruptions/i });
+		const rendered = within(list).getAllByRole("listitem");
+		expect(rendered).toHaveLength(2);
+		expect(rendered[0]).toHaveTextContent("Latest incident");
+		expect(rendered[1]).toHaveTextContent("Older RT");
+		expect(screen.queryByText("Planned (excluded)")).not.toBeInTheDocument();
+	});
+
+	it("shows a friendly empty state when nothing is happening", () => {
+		render(<HappeningNowCard disruptions={[]} />);
+
+		expect(screen.getByText(/all clear/i)).toBeInTheDocument();
+	});
+
+	it("surfaces closure_text in a destructive Alert", () => {
+		const items = [
+			disruption({
+				disruption_id: "a",
+				category: "RealTime",
+				closure_text: "Aldgate–Baker St only",
+			}),
+		];
+		render(<HappeningNowCard disruptions={items} />);
+
+		expect(screen.getByText(/Aldgate–Baker St only/)).toBeInTheDocument();
+	});
+
+	it("renders affected_routes as outline badges", () => {
+		const items = [
+			disruption({
+				disruption_id: "a",
+				category: "RealTime",
+				affected_routes: ["Piccadilly westbound", "Piccadilly eastbound"],
+			}),
+		];
+		render(<HappeningNowCard disruptions={items} />);
+
+		expect(screen.getByText("Piccadilly westbound")).toBeInTheDocument();
+		expect(screen.getByText("Piccadilly eastbound")).toBeInTheDocument();
+	});
+});

--- a/web/components/dashboard/__tests__/network-pulse-tile.test.tsx
+++ b/web/components/dashboard/__tests__/network-pulse-tile.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { NetworkPulseTile } from "@/components/dashboard/network-pulse-tile";
+import type { LineStatus } from "@/lib/api/status-live";
+
+function line(
+	overrides: Partial<LineStatus> & {
+		line_id: string;
+		mode: LineStatus["mode"];
+	},
+): LineStatus {
+	return {
+		line_id: overrides.line_id,
+		line_name: overrides.line_id,
+		mode: overrides.mode,
+		status_severity: overrides.status_severity ?? 10,
+		status_severity_description:
+			overrides.status_severity_description ?? "Good Service",
+		reason: overrides.reason ?? null,
+		valid_from: overrides.valid_from ?? "2026-05-03T00:00:00Z",
+		valid_to: overrides.valid_to ?? "2026-05-03T23:59:59Z",
+	};
+}
+
+describe("<NetworkPulseTile>", () => {
+	it("renders the Tube fraction headline", () => {
+		const lines = [
+			line({ line_id: "bakerloo", mode: "tube", status_severity: 6 }),
+			line({ line_id: "central", mode: "tube", status_severity: 10 }),
+			line({ line_id: "circle", mode: "tube", status_severity: 10 }),
+		];
+		render(<NetworkPulseTile lines={lines} />);
+
+		expect(screen.getAllByText(/2 of 3/).length).toBeGreaterThan(0);
+		expect(screen.getByText(/Tube lines/i)).toBeInTheDocument();
+	});
+
+	it("counts good-service across all modes for the cross-mode total", () => {
+		const lines = [
+			line({ line_id: "bakerloo", mode: "tube", status_severity: 10 }),
+			line({ line_id: "12", mode: "bus", status_severity: 10 }),
+			line({ line_id: "ncn", mode: "bus", status_severity: 6 }),
+		];
+		render(<NetworkPulseTile lines={lines} />);
+
+		expect(screen.getByText(/2 of 3/i)).toBeInTheDocument();
+		expect(screen.getByText(/all modes/i)).toBeInTheDocument();
+	});
+
+	it("buckets severities into red/amber/green tally with TfL boundaries", () => {
+		const lines = [
+			line({ line_id: "a", mode: "tube", status_severity: 0 }),
+			line({ line_id: "b", mode: "tube", status_severity: 6 }),
+			line({ line_id: "c", mode: "tube", status_severity: 9 }),
+			line({ line_id: "d", mode: "tube", status_severity: 10 }),
+			line({ line_id: "e", mode: "tube", status_severity: 18 }),
+			line({ line_id: "f", mode: "tube", status_severity: 19 }),
+		];
+		render(<NetworkPulseTile lines={lines} />);
+
+		expect(screen.getByLabelText(/severe lines: 2/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/degraded lines: 1/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/good lines: 2/i)).toBeInTheDocument();
+	});
+
+	it("renders zero-state when no lines are reported", () => {
+		render(<NetworkPulseTile lines={[]} />);
+
+		expect(screen.getAllByText(/0 of 0/).length).toBeGreaterThan(0);
+	});
+});

--- a/web/components/dashboard/__tests__/network-pulse-tile.test.tsx
+++ b/web/components/dashboard/__tests__/network-pulse-tile.test.tsx
@@ -50,18 +50,18 @@ describe("<NetworkPulseTile>", () => {
 
 	it("buckets severities into red/amber/green tally with TfL boundaries", () => {
 		const lines = [
-			line({ line_id: "a", mode: "tube", status_severity: 0 }),
-			line({ line_id: "b", mode: "tube", status_severity: 6 }),
-			line({ line_id: "c", mode: "tube", status_severity: 9 }),
-			line({ line_id: "d", mode: "tube", status_severity: 10 }),
-			line({ line_id: "e", mode: "tube", status_severity: 18 }),
-			line({ line_id: "f", mode: "tube", status_severity: 19 }),
+			line({ line_id: "a", mode: "tube", status_severity: 0 }), // severe (Closed)
+			line({ line_id: "b", mode: "tube", status_severity: 6 }), // severe (Suspended)
+			line({ line_id: "c", mode: "tube", status_severity: 9 }), // degraded (Minor Delays)
+			line({ line_id: "d", mode: "tube", status_severity: 10 }), // good (Good Service)
+			line({ line_id: "e", mode: "tube", status_severity: 18 }), // degraded (Part Closure)
+			line({ line_id: "f", mode: "tube", status_severity: 19 }), // other (unmapped)
 		];
 		render(<NetworkPulseTile lines={lines} />);
 
 		expect(screen.getByLabelText(/severe lines: 2/i)).toBeInTheDocument();
-		expect(screen.getByLabelText(/degraded lines: 1/i)).toBeInTheDocument();
-		expect(screen.getByLabelText(/good lines: 2/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/degraded lines: 2/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/good lines: 1/i)).toBeInTheDocument();
 	});
 
 	it("renders zero-state when no lines are reported", () => {

--- a/web/components/dashboard/__tests__/network-status-card.test.tsx
+++ b/web/components/dashboard/__tests__/network-status-card.test.tsx
@@ -1,0 +1,93 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { NetworkStatusCard } from "@/components/dashboard/network-status-card";
+import type { LineStatus } from "@/lib/api/status-live";
+
+function line(
+	id: string,
+	mode: LineStatus["mode"],
+	severity = 10,
+	desc = "Good Service",
+): LineStatus {
+	return {
+		line_id: id,
+		line_name: id,
+		mode,
+		status_severity: severity,
+		status_severity_description: desc,
+		reason: null,
+		valid_from: "2026-05-03T00:00:00Z",
+		valid_to: "2026-05-03T23:59:59Z",
+	};
+}
+
+describe("<NetworkStatusCard>", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+	afterEach(() => {
+		localStorage.clear();
+	});
+
+	it("defaults to the Tube tab and renders only Tube lines", () => {
+		const lines = [
+			line("piccadilly", "tube"),
+			line("12", "bus"),
+			line("woolwich", "elizabeth-line"),
+		];
+		render(<NetworkStatusCard lines={lines} lastUpdated={null} />);
+
+		const grid = screen.getByRole("list", { name: /tube lines/i });
+		const cells = within(grid).getAllByRole("listitem");
+		expect(cells).toHaveLength(1);
+		expect(cells[0]).toHaveTextContent("piccadilly");
+	});
+
+	it("switches mode on tab click and persists to localStorage", async () => {
+		const user = userEvent.setup();
+		const lines = [line("piccadilly", "tube"), line("12", "bus")];
+		render(<NetworkStatusCard lines={lines} lastUpdated={null} />);
+
+		await user.click(screen.getByRole("tab", { name: /^bus$/i }));
+
+		const grid = screen.getByRole("list", { name: /bus lines/i });
+		expect(within(grid).getByText("12")).toBeInTheDocument();
+		expect(localStorage.getItem("tfl-monitor:last-mode")).toBe("bus");
+	});
+
+	it("restores the last selected mode from localStorage on mount", () => {
+		localStorage.setItem("tfl-monitor:last-mode", "elizabeth-line");
+		const lines = [
+			line("piccadilly", "tube"),
+			line("woolwich", "elizabeth-line"),
+		];
+		render(<NetworkStatusCard lines={lines} lastUpdated={null} />);
+
+		const grid = screen.getByRole("list", { name: /elizabeth line lines/i });
+		expect(within(grid).getByText("woolwich")).toBeInTheDocument();
+	});
+
+	it("falls back to Tube when localStorage holds a value not in the enum", () => {
+		localStorage.setItem("tfl-monitor:last-mode", "spaceship");
+		const lines = [line("piccadilly", "tube")];
+		render(<NetworkStatusCard lines={lines} lastUpdated={null} />);
+
+		expect(
+			screen.getByRole("list", { name: /tube lines/i }),
+		).toBeInTheDocument();
+	});
+
+	it("shows an empty-state alert when the active mode has zero lines", async () => {
+		const user = userEvent.setup();
+		const lines = [line("piccadilly", "tube")];
+		render(<NetworkStatusCard lines={lines} lastUpdated={null} />);
+
+		await act(async () => {
+			await user.click(screen.getByRole("tab", { name: /^bus$/i }));
+		});
+
+		expect(screen.getByText(/no lines reported/i)).toBeInTheDocument();
+	});
+});

--- a/web/components/dashboard/chat-panel.tsx
+++ b/web/components/dashboard/chat-panel.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { MessageCircle } from "lucide-react";
+import { useState } from "react";
+
+import { ChatView } from "@/components/chat-view";
+import { Button } from "@/components/ui/button";
+import {
+	Drawer,
+	DrawerContent,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerTrigger,
+} from "@/components/ui/drawer";
+
+export function ChatPanel() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<>
+			<aside
+				aria-label="Agent chat"
+				className="hidden lg:sticky lg:top-6 lg:flex lg:h-[calc(100vh-3rem)] lg:flex-col"
+			>
+				<ChatView />
+			</aside>
+
+			<div className="lg:hidden">
+				<Drawer open={open} onOpenChange={setOpen}>
+					<DrawerTrigger asChild>
+						<Button
+							size="icon"
+							className="fixed right-6 bottom-6 size-14 rounded-full shadow-lg"
+							aria-label="Open chat"
+						>
+							<MessageCircle className="size-6" />
+						</Button>
+					</DrawerTrigger>
+					<DrawerContent className="h-[60vh]">
+						<DrawerHeader>
+							<DrawerTitle>Ask the agent</DrawerTitle>
+						</DrawerHeader>
+						<div className="flex-1 overflow-hidden px-4 pb-4">
+							<ChatView />
+						</div>
+					</DrawerContent>
+				</Drawer>
+			</div>
+		</>
+	);
+}

--- a/web/components/dashboard/coming-up-card.tsx
+++ b/web/components/dashboard/coming-up-card.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useMemo } from "react";
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import type { Disruption } from "@/lib/api/disruptions-recent";
+
+interface ComingUpCardProps {
+	disruptions: Disruption[];
+}
+
+const MAX_ITEMS = 5;
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-GB", {
+	day: "2-digit",
+	month: "short",
+	timeZone: "Europe/London",
+});
+
+function formatStart(iso: string): string {
+	return DATE_FORMATTER.format(new Date(iso));
+}
+
+export function ComingUpCard({ disruptions }: ComingUpCardProps) {
+	const upcoming = useMemo(() => {
+		return disruptions
+			.filter((d) => d.category === "PlannedWork")
+			.sort(
+				(a, b) => new Date(a.created).getTime() - new Date(b.created).getTime(),
+			)
+			.slice(0, MAX_ITEMS);
+	}, [disruptions]);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>📅 Coming up</CardTitle>
+				<CardDescription>Planned work · next 14 days</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{upcoming.length === 0 ? (
+					<p className="text-sm text-muted-foreground">
+						No planned work scheduled.
+					</p>
+				) : (
+					<ul
+						className="flex flex-col gap-2"
+						aria-label="Upcoming planned work"
+					>
+						{upcoming.map((d) => (
+							<li
+								key={`${d.disruption_id}-${d.created}`}
+								className="rounded border-l-4 border-indigo-500 bg-indigo-50 p-2 dark:bg-indigo-950/30"
+							>
+								<div className="text-sm font-semibold">
+									{formatStart(d.created)} · {d.summary}
+								</div>
+								{d.description ? (
+									<p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+										{d.description}
+									</p>
+								) : null}
+							</li>
+						))}
+					</ul>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/web/components/dashboard/coming-up-card.tsx
+++ b/web/components/dashboard/coming-up-card.tsx
@@ -40,7 +40,7 @@ export function ComingUpCard({ disruptions }: ComingUpCardProps) {
 		<Card>
 			<CardHeader>
 				<CardTitle>📅 Coming up</CardTitle>
-				<CardDescription>Planned work · next 14 days</CardDescription>
+				<CardDescription>Planned work · upcoming</CardDescription>
 			</CardHeader>
 			<CardContent>
 				{upcoming.length === 0 ? (

--- a/web/components/dashboard/happening-now-card.tsx
+++ b/web/components/dashboard/happening-now-card.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import type { Disruption } from "@/lib/api/disruptions-recent";
+
+interface HappeningNowCardProps {
+	disruptions: Disruption[];
+}
+
+const ACTIVE_CATEGORIES: ReadonlySet<Disruption["category"]> = new Set([
+	"RealTime",
+	"Incident",
+]);
+
+export function HappeningNowCard({ disruptions }: HappeningNowCardProps) {
+	const active = useMemo(() => {
+		return disruptions
+			.filter((d) => ACTIVE_CATEGORIES.has(d.category))
+			.sort(
+				(a, b) =>
+					new Date(b.last_update).getTime() - new Date(a.last_update).getTime(),
+			);
+	}, [disruptions]);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>⚠ Happening now</CardTitle>
+				<CardDescription>RealTime · Incident</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{active.length === 0 ? (
+					<p className="text-sm text-muted-foreground">
+						✅ All clear across the network.
+					</p>
+				) : (
+					<ul className="flex flex-col gap-2" aria-label="Active disruptions">
+						{active.map((d) => (
+							<li
+								key={`${d.disruption_id}-${d.last_update}`}
+								className="rounded border-l-4 border-red-600 bg-red-50 p-2 dark:bg-red-950/30"
+							>
+								<div className="text-sm font-semibold">{d.summary}</div>
+								{d.description ? (
+									<p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+										{d.description}
+									</p>
+								) : null}
+								{d.affected_routes.length > 0 ? (
+									<ul
+										className="mt-2 flex flex-wrap gap-1"
+										aria-label="Affected routes"
+									>
+										{d.affected_routes.map((r) => (
+											<li key={r}>
+												<Badge variant="outline">{r}</Badge>
+											</li>
+										))}
+									</ul>
+								) : null}
+								{d.closure_text ? (
+									<Alert variant="destructive" className="mt-2">
+										<AlertDescription>{d.closure_text}</AlertDescription>
+									</Alert>
+								) : null}
+							</li>
+						))}
+					</ul>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/web/components/dashboard/network-pulse-tile.tsx
+++ b/web/components/dashboard/network-pulse-tile.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useMemo } from "react";
+
 import { Card } from "@/components/ui/card";
 import type { LineStatus } from "@/lib/api/status-live";
 
@@ -10,7 +12,12 @@ interface NetworkPulseTileProps {
 interface Pulse {
 	tube: { good: number; total: number };
 	all: { good: number; total: number };
-	bySeverity: { severe: number; degraded: number; good: number };
+	bySeverity: {
+		severe: number;
+		degraded: number;
+		good: number;
+		other: number;
+	};
 }
 
 const TFL_SEVERITY = {
@@ -51,6 +58,7 @@ const DEGRADED = new Set<number>([
 	TFL_SEVERITY.PART_SUSPENDED,
 	TFL_SEVERITY.SEVERE_DELAYS,
 	TFL_SEVERITY.MINOR_DELAYS,
+	TFL_SEVERITY.PART_CLOSURE,
 	TFL_SEVERITY.ISSUES,
 	TFL_SEVERITY.NO_STEP_FREE,
 	TFL_SEVERITY.CHANGE_OF_FREQ,
@@ -58,10 +66,7 @@ const DEGRADED = new Set<number>([
 	TFL_SEVERITY.NOT_RUNNING,
 	TFL_SEVERITY.INFORMATION,
 ]);
-const GOOD = new Set<number>([
-	TFL_SEVERITY.GOOD_SERVICE,
-	TFL_SEVERITY.PART_CLOSURE,
-]);
+const GOOD = new Set<number>([TFL_SEVERITY.GOOD_SERVICE]);
 
 function pulse(lines: LineStatus[]): Pulse {
 	const tube = lines.filter((l) => l.mode === "tube");
@@ -71,21 +76,23 @@ function pulse(lines: LineStatus[]): Pulse {
 	let severe = 0;
 	let degraded = 0;
 	let good = 0;
+	let other = 0;
 	for (const l of lines) {
 		if (SEVERE.has(l.status_severity)) severe += 1;
 		else if (DEGRADED.has(l.status_severity)) degraded += 1;
 		else if (GOOD.has(l.status_severity)) good += 1;
+		else other += 1;
 	}
 
 	return {
 		tube: { good: goodTube, total: tube.length },
 		all: { good: goodAll, total: lines.length },
-		bySeverity: { severe, degraded, good },
+		bySeverity: { severe, degraded, good, other },
 	};
 }
 
 export function NetworkPulseTile({ lines }: NetworkPulseTileProps) {
-	const p = pulse(lines);
+	const p = useMemo(() => pulse(lines), [lines]);
 	const allPct =
 		p.all.total > 0 ? Math.round((p.all.good / p.all.total) * 1000) / 10 : 0;
 

--- a/web/components/dashboard/network-pulse-tile.tsx
+++ b/web/components/dashboard/network-pulse-tile.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import type { LineStatus } from "@/lib/api/status-live";
+
+interface NetworkPulseTileProps {
+	lines: LineStatus[];
+}
+
+interface Pulse {
+	tube: { good: number; total: number };
+	all: { good: number; total: number };
+	bySeverity: { severe: number; degraded: number; good: number };
+}
+
+const TFL_SEVERITY = {
+	GOOD_SERVICE: 10,
+	PART_CLOSURE: 18,
+	MINOR_DELAYS: 9,
+	SEVERE_DELAYS: 8,
+	PART_SUSPENDED: 7,
+	SUSPENDED: 6,
+	PLANNED_CLOSURE: 5,
+	PART_WORKS: 4,
+	SPECIAL_SERVICE: 3,
+	REDUCED_SERVICE: 2,
+	BUS_SERVICE: 1,
+	CLOSED: 0,
+	ISSUES: 11,
+	NO_STEP_FREE: 12,
+	CHANGE_OF_FREQ: 13,
+	DIVERTED: 14,
+	NOT_RUNNING: 15,
+	RAIL_SUSP: 16,
+	INFORMATION: 17,
+	SPECIAL_CLOSING: 20,
+} as const;
+
+const SEVERE = new Set<number>([
+	TFL_SEVERITY.CLOSED,
+	TFL_SEVERITY.BUS_SERVICE,
+	TFL_SEVERITY.REDUCED_SERVICE,
+	TFL_SEVERITY.SPECIAL_SERVICE,
+	TFL_SEVERITY.PART_WORKS,
+	TFL_SEVERITY.PLANNED_CLOSURE,
+	TFL_SEVERITY.SUSPENDED,
+	TFL_SEVERITY.RAIL_SUSP,
+	TFL_SEVERITY.SPECIAL_CLOSING,
+]);
+const DEGRADED = new Set<number>([
+	TFL_SEVERITY.PART_SUSPENDED,
+	TFL_SEVERITY.SEVERE_DELAYS,
+	TFL_SEVERITY.MINOR_DELAYS,
+	TFL_SEVERITY.ISSUES,
+	TFL_SEVERITY.NO_STEP_FREE,
+	TFL_SEVERITY.CHANGE_OF_FREQ,
+	TFL_SEVERITY.DIVERTED,
+	TFL_SEVERITY.NOT_RUNNING,
+	TFL_SEVERITY.INFORMATION,
+]);
+const GOOD = new Set<number>([
+	TFL_SEVERITY.GOOD_SERVICE,
+	TFL_SEVERITY.PART_CLOSURE,
+]);
+
+function pulse(lines: LineStatus[]): Pulse {
+	const tube = lines.filter((l) => l.mode === "tube");
+	const goodTube = tube.filter((l) => GOOD.has(l.status_severity)).length;
+	const goodAll = lines.filter((l) => GOOD.has(l.status_severity)).length;
+
+	let severe = 0;
+	let degraded = 0;
+	let good = 0;
+	for (const l of lines) {
+		if (SEVERE.has(l.status_severity)) severe += 1;
+		else if (DEGRADED.has(l.status_severity)) degraded += 1;
+		else if (GOOD.has(l.status_severity)) good += 1;
+	}
+
+	return {
+		tube: { good: goodTube, total: tube.length },
+		all: { good: goodAll, total: lines.length },
+		bySeverity: { severe, degraded, good },
+	};
+}
+
+export function NetworkPulseTile({ lines }: NetworkPulseTileProps) {
+	const p = pulse(lines);
+	const allPct =
+		p.all.total > 0 ? Math.round((p.all.good / p.all.total) * 1000) / 10 : 0;
+
+	return (
+		<Card className="flex items-center gap-6 px-4 py-3">
+			<div>
+				<div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+					Network pulse
+				</div>
+				<div className="mt-1 text-2xl font-bold">
+					{p.tube.good} of {p.tube.total}
+					<span className="ml-2 text-sm font-medium text-muted-foreground">
+						Tube lines
+					</span>
+				</div>
+				<div className="text-xs text-emerald-600 dark:text-emerald-500">
+					running good service
+				</div>
+			</div>
+
+			<div className="flex flex-1 items-center gap-3">
+				<Dot
+					label="severe"
+					count={p.bySeverity.severe}
+					className="bg-red-600"
+				/>
+				<Dot
+					label="degraded"
+					count={p.bySeverity.degraded}
+					className="bg-amber-500"
+				/>
+				<Dot
+					label="good"
+					count={p.bySeverity.good}
+					className="bg-emerald-600"
+				/>
+			</div>
+
+			<div className="text-right text-[11px] text-muted-foreground">
+				Across all modes:
+				<br />
+				<b className="text-foreground">
+					{p.all.good} of {p.all.total} lines · {allPct}%
+				</b>
+			</div>
+		</Card>
+	);
+}
+
+function Dot({
+	label,
+	count,
+	className,
+}: {
+	label: string;
+	count: number;
+	className: string;
+}) {
+	return (
+		<div
+			className="flex flex-col items-center"
+			role="img"
+			aria-label={`${label} lines: ${count}`}
+		>
+			<span className={`size-3.5 rounded-full ${className}`} />
+			<span className="mt-1 text-[10px] font-medium">{count}</span>
+		</div>
+	);
+}

--- a/web/components/dashboard/network-status-card.tsx
+++ b/web/components/dashboard/network-status-card.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { StatusBadge } from "@/components/status-badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { LineStatus } from "@/lib/api/status-live";
+import { modeLabel } from "@/lib/labels";
+
+const STORAGE_KEY = "tfl-monitor:last-mode";
+
+interface NetworkStatusCardProps {
+	lines: LineStatus[];
+	lastUpdated: Date | null;
+}
+
+type TabId =
+	| "tube"
+	| "elizabeth-line"
+	| "overground"
+	| "dlr"
+	| "tram-river-cable"
+	| "bus";
+
+const TAB_ORDER: { id: TabId; label: string; modes: LineStatus["mode"][] }[] = [
+	{ id: "tube", label: "Tube", modes: ["tube"] },
+	{ id: "elizabeth-line", label: "Elizabeth line", modes: ["elizabeth-line"] },
+	{ id: "overground", label: "Overground", modes: ["overground"] },
+	{ id: "dlr", label: "DLR", modes: ["dlr"] },
+	{
+		id: "tram-river-cable",
+		label: "Tram · River · Cable",
+		modes: ["tram", "river-bus", "cable-car", "national-rail"],
+	},
+	{ id: "bus", label: "Bus", modes: ["bus"] },
+];
+
+const VALID_TABS = new Set<TabId>(TAB_ORDER.map((t) => t.id));
+
+function readStoredTab(): TabId {
+	if (typeof window === "undefined") return "tube";
+	const stored = window.localStorage.getItem(STORAGE_KEY);
+	return stored && VALID_TABS.has(stored as TabId) ? (stored as TabId) : "tube";
+}
+
+const RELATIVE_FORMATTER = new Intl.RelativeTimeFormat("en", {
+	numeric: "auto",
+});
+
+function formatLastUpdated(d: Date | null): string {
+	if (!d) return "never";
+	const seconds = Math.round((d.getTime() - Date.now()) / 1000);
+	return RELATIVE_FORMATTER.format(seconds, "second");
+}
+
+function useTicker(intervalMs: number): void {
+	const [, setTick] = useState(0);
+	useEffect(() => {
+		const id = setInterval(() => setTick((n) => n + 1), intervalMs);
+		return () => clearInterval(id);
+	}, [intervalMs]);
+}
+
+export function NetworkStatusCard({
+	lines,
+	lastUpdated,
+}: NetworkStatusCardProps) {
+	const [tab, setTab] = useState<TabId>("tube");
+
+	useEffect(() => {
+		setTab(readStoredTab());
+	}, []);
+
+	useTicker(1_000);
+
+	const active = useMemo(
+		() => TAB_ORDER.find((t) => t.id === tab) ?? TAB_ORDER[0],
+		[tab],
+	);
+	const filtered = useMemo(
+		() => lines.filter((l) => active.modes.includes(l.mode)),
+		[lines, active],
+	);
+
+	function changeTab(next: string) {
+		const id = next as TabId;
+		if (!VALID_TABS.has(id)) return;
+		setTab(id);
+		try {
+			window.localStorage.setItem(STORAGE_KEY, id);
+		} catch {
+			// localStorage may be unavailable in private mode; non-fatal.
+		}
+	}
+
+	const listLabel = `${active.label} lines`;
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Network status</CardTitle>
+				<CardDescription>
+					Updated {formatLastUpdated(lastUpdated)} · auto-refresh 30 s
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<Tabs value={tab} onValueChange={changeTab}>
+					<TabsList className="mb-3">
+						{TAB_ORDER.map((t) => (
+							<TabsTrigger key={t.id} value={t.id}>
+								{t.label}
+							</TabsTrigger>
+						))}
+					</TabsList>
+				</Tabs>
+
+				{filtered.length === 0 ? (
+					<p className="text-sm text-muted-foreground">
+						No lines reported for {active.label}.
+					</p>
+				) : (
+					<ul
+						aria-label={listLabel}
+						className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3"
+					>
+						{filtered.map((line) => (
+							<li
+								key={line.line_id}
+								className="rounded border-l-4 border-emerald-600 bg-card p-2"
+								data-testid={`line-${line.line_id}`}
+							>
+								<div className="flex items-baseline justify-between gap-2">
+									<span className="text-sm font-semibold">
+										{line.line_name}
+									</span>
+									<span className="text-[10px] text-muted-foreground">
+										{modeLabel(line.mode)}
+									</span>
+								</div>
+								<div className="mt-1">
+									<StatusBadge
+										severity={line.status_severity}
+										description={line.status_severity_description}
+									/>
+								</div>
+							</li>
+						))}
+					</ul>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/web/components/dashboard/network-status-card.tsx
+++ b/web/components/dashboard/network-status-card.tsx
@@ -46,8 +46,14 @@ const VALID_TABS = new Set<TabId>(TAB_ORDER.map((t) => t.id));
 
 function readStoredTab(): TabId {
 	if (typeof window === "undefined") return "tube";
-	const stored = window.localStorage.getItem(STORAGE_KEY);
-	return stored && VALID_TABS.has(stored as TabId) ? (stored as TabId) : "tube";
+	try {
+		const stored = window.localStorage.getItem(STORAGE_KEY);
+		return stored && VALID_TABS.has(stored as TabId)
+			? (stored as TabId)
+			: "tube";
+	} catch {
+		return "tube";
+	}
 }
 
 const RELATIVE_FORMATTER = new Intl.RelativeTimeFormat("en", {
@@ -72,11 +78,7 @@ export function NetworkStatusCard({
 	lines,
 	lastUpdated,
 }: NetworkStatusCardProps) {
-	const [tab, setTab] = useState<TabId>("tube");
-
-	useEffect(() => {
-		setTab(readStoredTab());
-	}, []);
+	const [tab, setTab] = useState<TabId>(readStoredTab);
 
 	useTicker(1_000);
 

--- a/web/package.json
+++ b/web/package.json
@@ -29,6 +29,7 @@
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
+		"@testing-library/user-event": "^14.6.1",
 		"@types/node": "^20",
 		"@types/react": "^19",
 		"@types/react-dom": "^19",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^20
         version: 20.19.39
@@ -1600,6 +1603,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
@@ -4898,6 +4907,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@ts-morph/common@0.27.0':
     dependencies:

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
 	},
 	test: {
 		environment: "jsdom",
+		environmentOptions: {
+			jsdom: {
+				url: "http://localhost/",
+			},
+		},
 		globals: true,
 		setupFiles: ["./vitest.setup.ts"],
 		include: ["**/*.{test,spec}.{ts,tsx}"],

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,1 +1,60 @@
 import "@testing-library/jest-dom/vitest";
+
+// Node 22+ ships a native `localStorage` that requires a `--localstorage-file`
+// flag, which jsdom 29 picks up under Node and fails on. Stub an in-memory
+// implementation so component tests can exercise persistence logic.
+function createMemoryStorage(): Storage {
+	const store = new Map<string, string>();
+	return {
+		get length(): number {
+			return store.size;
+		},
+		clear(): void {
+			store.clear();
+		},
+		getItem(key: string): string | null {
+			return store.has(key) ? (store.get(key) as string) : null;
+		},
+		setItem(key: string, value: string): void {
+			store.set(key, String(value));
+		},
+		removeItem(key: string): void {
+			store.delete(key);
+		},
+		key(index: number): string | null {
+			return Array.from(store.keys())[index] ?? null;
+		},
+	};
+}
+
+// jsdom 29 omits `matchMedia`; vaul (drawer primitive) calls it on mount.
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+	Object.defineProperty(window, "matchMedia", {
+		configurable: true,
+		writable: true,
+		value: (query: string): MediaQueryList => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: () => {},
+			removeListener: () => {},
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			dispatchEvent: () => false,
+		}),
+	});
+}
+
+for (const name of ["localStorage", "sessionStorage"] as const) {
+	const storage = createMemoryStorage();
+	Object.defineProperty(globalThis, name, {
+		configurable: true,
+		value: storage,
+	});
+	if (typeof window !== "undefined") {
+		Object.defineProperty(window, name, {
+			configurable: true,
+			value: storage,
+		});
+	}
+}


### PR DESCRIPTION
## Summary

PR-2 of the 3-PR TM-E5 split (PR-1: #51 hook + labels + primitives; PR-3: page rewrite + redirects). Adds the six dashboard surfaces consumed by the upcoming one-pager:

- `<NetworkPulseTile>` — pure derivation from `LineStatus[]` to Tube fraction + RGB severity tally + cross-mode total.
- `<HappeningNowCard>` — filters `RealTime`/`Incident` disruptions, sorts by `last_update` DESC, surfaces `closure_text` in a destructive `<Alert>`.
- `<ComingUpCard>` — filters `PlannedWork`, sorts by `created` ASC, caps at 5.
- `<NetworkStatusCard>` — mode tabs (Tube / Elizabeth / Overground / DLR / Tram·River·Cable / Bus) with `localStorage` persistence (`tfl-monitor:last-mode`) and a 1 s ticker so the relative timestamp stays live between auto-refresh polls.
- `<ChatPanel>` — sticky aside on `lg+`, FAB-triggered Drawer on `<lg`, mounts the existing `<ChatView />` in both surfaces.
- `<AboutSheet>` — header Sheet content with pipeline summary + GitHub link.

Surface: `web/` only.

## Test infra

- `@testing-library/user-event` added as dev dep.
- `vitest.config.ts` pins jsdom URL to `http://localhost/` so storage / origin checks behave.
- `vitest.setup.ts` stubs in-memory `localStorage` + `sessionStorage` (Node 25 ships a native `localStorage` that requires `--localstorage-file`, jsdom 29 cannot override it) and stubs `matchMedia` for vaul.

## Plan divergence

Tests / impl use the real `Disruption` schema (`disruption_id`, required `closure_text`) rather than the `id` / nullable shape sketched in the plan. Components compile against `contracts/openapi.yaml`.

## Test plan

- [x] `pnpm --dir web lint` — clean (54 files)
- [x] `pnpm --dir web test` — 86 / 86 passing (15 files)
- [x] `uv run task lint` — clean
- [x] `uv run task test` — 237 passed, 1 skipped
- [ ] Manual verification deferred to PR-3 (cards are unused until the page rewrite wires them).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * About section with project info and GitHub link
  * Chat panel for asking the agent about transit conditions
  * Network Pulse tile with service overview and severity indicators
  * Network Status card with mode filters and detailed line status
  * Disruption cards showing current incidents and upcoming planned work

* **Tests**
  * Extensive test coverage and test-environment improvements for dashboard components

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/53)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->