### PR TITLE
chore: TM-E5 done, refresh current-wp pointer

### DIFF
--- a/.claude/current-wp.md
+++ b/.claude/current-wp.md
@@ -3,5 +3,5 @@
 | WP | Status | Notes |
 |---|---|---|
 | TM-D5 | Done ✅ 2026-05-08 | LangGraph agent (SQL + RAG) shipped, PR #44 merged |
-| TM-E5 | In progress | Design spec + 17-task implementation plan committed (PR #48). Code not started. |
+| TM-E5 | Done ✅ 2026-05-12 | One-pager dashboard + chat. Three sub-PRs merged: #51 (hook + labels + primitives), #53 (6 cards + chat panel + about sheet), #54 (page rewrite + redirects + legacy deletion + AbortSignal/ApiError fixes). |
 | TM-A5 | Blocked | Research + plan committed (PR #49). Blocked on Section 8 confirmation gate (AWS deploy decision). |


### PR DESCRIPTION
Marks TM-E5 done in `.claude/current-wp.md` after PRs #51, #53, #54 all squash-merged into main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project tracking documentation to reflect completion of dashboard and chat features.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/55)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->