### PR TITLE
feat: TM-E4 PR-3 port dashboard components

### DIFF
--- a/.claude/napkin.md
+++ b/.claude/napkin.md
@@ -46,6 +46,10 @@ recurring guidance only — not a session log.
    Override only on explicit team-lead green-light, e.g. to unblock a `required_review_thread_resolution: true` policy when the rejected thread is the last blocker. Even then, post the audit reply first, get the green-light, then resolve — never the other way round.
    Do instead: after replying with rationale, leave the resolve to the author. Track unresolved count via `reviewThreads.nodes[] | select(.isResolved == false)` so you know whether the PR is merge-blocked.
 
+9. **[2026-05-13] Codex (`chatgpt-codex-connector[bot]`) reviews each PR in vacuum — expect P1 flags on intentional intermediate states in stacked PRs**
+   On PR #57 (TM-E4 Phase 2: strip Tailwind/shadcn), Codex flagged the deliberate `app/page.tsx` stub as a P1 "functional regression that breaks production behavior". The stub is required by the TM-E4 spec because Phase 2 deletes the components `page.tsx` imports; Phase 5 rewrites the page with the new composition. Codex has no view of the multi-phase plan and reads each commit as a standalone artifact. CodeRabbit + Gemini both returned "no actionable comments" on the same PR, confirming the finding is Codex-specific reasoning, not consensus.
+   Do instead: when assessing Codex P1/P2 findings on a stacked-PR phase, cross-reference the spec phase before fixing. If the flag points at intentional WIP/regression documented in the PR body and spec §5 phase plan, mark as "skip — intentional intermediate state" in the `/review-pr` summary with a one-line spec citation. Do NOT respond on the thread (Codex is bot-driven, no human reads the rationale); the PR-level audit comment is enough. The other reviewers will silently re-evaluate on the next phase's PR and the regression will be self-resolved when Phase N rewrites the stub.
+
 ## Shell & Command Reliability
 
 1. **[2026-04-26] Branch protection lives in rulesets, not classic API**

--- a/web/components/dashboard/__tests__/bus-banner.test.tsx
+++ b/web/components/dashboard/__tests__/bus-banner.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+
+import { BusBanner } from "../bus-banner";
+
+describe("BusBanner", () => {
+	it("renders every bus cell and the route count", () => {
+		render(
+			<BusBanner
+				buses={[
+					{ route: "N29", text: "Diverted around Trafalgar Square." },
+					{ route: "38", text: "Stop closure at Piccadilly Circus." },
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("N29")).toBeInTheDocument();
+		expect(screen.getByText("38")).toBeInTheDocument();
+		expect(screen.getByText(/2 routes flagged/)).toBeInTheDocument();
+	});
+});

--- a/web/components/dashboard/__tests__/chat-panel.test.tsx
+++ b/web/components/dashboard/__tests__/chat-panel.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { ChatPanel } from "../chat-panel";
+
+describe("ChatPanel", () => {
+	it("appends a user message on send and clears the input", async () => {
+		const onSend = vi.fn();
+		render(
+			<ChatPanel
+				initialMessages={[{ who: "bot", text: "Welcome to TfL Monitor" }]}
+				onSend={onSend}
+			/>,
+		);
+
+		expect(screen.getByText("Welcome to TfL Monitor")).toBeInTheDocument();
+
+		const textarea = screen.getByRole("textbox");
+		await userEvent.type(textarea, "What is the next train to Uxbridge?");
+		await userEvent.click(screen.getByRole("button", { name: /send/i }));
+
+		expect(
+			screen.getByText("What is the next train to Uxbridge?"),
+		).toBeInTheDocument();
+		expect(textarea).toHaveValue("");
+		expect(onSend).toHaveBeenCalledWith("What is the next train to Uxbridge?");
+	});
+
+	it("populates the textarea when a quick prompt chip is clicked", async () => {
+		render(<ChatPanel />);
+
+		const chip = screen.getByRole("button", { name: /next train/i });
+		await userEvent.click(chip);
+
+		expect(screen.getByRole("textbox")).toHaveValue(
+			"Next train Baker Street → Uxbridge",
+		);
+	});
+});

--- a/web/components/dashboard/__tests__/line-detail.test.tsx
+++ b/web/components/dashboard/__tests__/line-detail.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+
+import { LineDetail } from "../line-detail";
+import type { DisruptionSnapshot, LineSummary } from "../types";
+
+const LINE: LineSummary = {
+	code: "ELZ",
+	name: "Elizabeth",
+	color: "#6950A1",
+	status: "severe",
+	statusText: "Severe delays",
+	updatedLabel: "updated 2m ago",
+};
+
+const DISRUPTION: DisruptionSnapshot = {
+	headline: "Severe delays westbound between Paddington and Reading",
+	body: ["A faulty train at Hayes & Harlington is causing severe delays."],
+	reportedAtLabel: "17:58 BST",
+	stations: [{ name: "Paddington", code: "PAD", note: "interchange" }],
+	sourceLabel: "Source: TfL Unified API",
+	updatedAtLabel: "18:42:14 BST",
+};
+
+describe("LineDetail", () => {
+	it("renders the line header and disruption details", () => {
+		render(<LineDetail line={LINE} disruption={DISRUPTION} />);
+
+		expect(
+			screen.getByRole("heading", { name: /elizabeth line/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				/Severe delays westbound between Paddington and Reading/,
+			),
+		).toBeInTheDocument();
+		expect(screen.getByText("Affected stations")).toBeInTheDocument();
+		expect(screen.getByText(/PAD · interchange/)).toBeInTheDocument();
+	});
+
+	it("renders a fallback when no disruption is provided", () => {
+		render(<LineDetail line={LINE} />);
+
+		expect(
+			screen.getByText(/No active disruption reported/i),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Affected stations")).not.toBeInTheDocument();
+	});
+});

--- a/web/components/dashboard/__tests__/line-grid.test.tsx
+++ b/web/components/dashboard/__tests__/line-grid.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { LineGrid } from "../line-grid";
+import type { LineSummary } from "../types";
+
+const SAMPLE_LINES: LineSummary[] = [
+	{
+		code: "ELZ",
+		name: "Elizabeth",
+		color: "#6950A1",
+		status: "severe",
+		statusText: "Severe delays",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "VIC",
+		name: "Victoria",
+		color: "#039BE5",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 1m ago",
+	},
+];
+
+describe("LineGrid", () => {
+	it("renders each line and reports selection clicks", async () => {
+		const onSelect = vi.fn();
+		render(
+			<LineGrid lines={SAMPLE_LINES} selected="ELZ" onSelect={onSelect} />,
+		);
+
+		expect(screen.getByText("Elizabeth")).toBeInTheDocument();
+		expect(screen.getByText("Victoria")).toBeInTheDocument();
+		expect(screen.getAllByText(/Severe delays/)[0]).toBeInTheDocument();
+
+		const victoria = screen.getByText("Victoria").closest('[role="button"]');
+		expect(victoria).not.toBeNull();
+		if (victoria) {
+			await userEvent.click(victoria);
+		}
+		expect(onSelect).toHaveBeenCalledWith("VIC");
+	});
+});

--- a/web/components/dashboard/__tests__/news-reports.test.tsx
+++ b/web/components/dashboard/__tests__/news-reports.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+
+import { NewsReports } from "../news-reports";
+
+describe("NewsReports", () => {
+	it("renders supplied items and pads empty slots up to the slot count", () => {
+		render(
+			<NewsReports
+				items={[
+					{
+						time: "17:58",
+						title: "Elizabeth line — westbound severe delays",
+						body: "Faulty train at Hayes & Harlington.",
+					},
+				]}
+			/>,
+		);
+
+		expect(
+			screen.getByText(/Elizabeth line — westbound severe delays/),
+		).toBeInTheDocument();
+		expect(screen.getByText(/1 today/)).toBeInTheDocument();
+		expect(screen.getAllByText(/No further updates/)).toHaveLength(2);
+	});
+});

--- a/web/components/dashboard/__tests__/news-reports.test.tsx
+++ b/web/components/dashboard/__tests__/news-reports.test.tsx
@@ -22,4 +22,17 @@ describe("NewsReports", () => {
 		expect(screen.getByText(/1 today/)).toBeInTheDocument();
 		expect(screen.getAllByText(/No further updates/)).toHaveLength(2);
 	});
+
+	it("reports the full item count in the meta label even when slots truncate", () => {
+		const items = Array.from({ length: 5 }, (_, i) => ({
+			time: `0${i}:00`,
+			title: `Report ${i}`,
+			body: `Body ${i}`,
+		}));
+
+		render(<NewsReports items={items} slotCount={3} />);
+
+		expect(screen.getByText(/5 today/)).toBeInTheDocument();
+		expect(screen.queryByText(/3 today/)).not.toBeInTheDocument();
+	});
 });

--- a/web/components/dashboard/__tests__/page-head.test.tsx
+++ b/web/components/dashboard/__tests__/page-head.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+
+import { PageHead } from "../page-head";
+
+describe("PageHead", () => {
+	it("renders title and meta line", () => {
+		render(
+			<PageHead
+				lineCount={15}
+				lastRefreshedLabel="18:42:14 BST"
+				refreshIntervalSeconds={30}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: /london transport — at a glance/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				/15 lines · last refreshed 18:42:14 BST · auto-refresh every 30s/,
+			),
+		).toBeInTheDocument();
+	});
+});

--- a/web/components/dashboard/__tests__/top-nav.test.tsx
+++ b/web/components/dashboard/__tests__/top-nav.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+
+import { TopNav } from "../top-nav";
+
+describe("TopNav", () => {
+	it("renders brand, repo link, and status summary segments", () => {
+		render(
+			<TopNav
+				summary={{ good: 11, minor: 2, severe: 1, suspended: 1 }}
+				clockLabel="18:42 BST · live"
+			/>,
+		);
+
+		expect(screen.getByText("TfL Monitor")).toBeInTheDocument();
+		expect(screen.getByText(/11 good/)).toBeInTheDocument();
+		expect(screen.getByText(/2 minor/)).toBeInTheDocument();
+		expect(screen.getByText(/1 severe/)).toBeInTheDocument();
+		expect(screen.getByText(/1 suspended/)).toBeInTheDocument();
+		expect(screen.getByText("18:42 BST · live")).toBeInTheDocument();
+
+		const link = screen.getByRole("link", { name: /github repo/i });
+		expect(link).toHaveAttribute(
+			"href",
+			"https://github.com/humbertolomeu/tfl-monitor",
+		);
+	});
+});

--- a/web/components/dashboard/bus-banner.tsx
+++ b/web/components/dashboard/bus-banner.tsx
@@ -1,0 +1,24 @@
+import type { BusItem } from "./types";
+
+export interface BusBannerProps {
+	buses: BusItem[];
+}
+
+export function BusBanner({ buses }: BusBannerProps) {
+	return (
+		<section className="tfl-card tfl-bus">
+			<div className="tfl-card-h">
+				<h4>Buses worth knowing about</h4>
+				<span className="meta">{buses.length} routes flagged</span>
+			</div>
+			<div className="tfl-bus-row">
+				{buses.map((bus) => (
+					<div key={bus.route} className="tfl-bus-cell">
+						<span className="tfl-bus-route">{bus.route}</span>
+						<span className="tfl-bus-text">{bus.text}</span>
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/web/components/dashboard/chat-panel.tsx
+++ b/web/components/dashboard/chat-panel.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+
+import { AUDIO_PATH, Icon, SEND_PATH } from "./icons";
+import type { ChatMessage } from "./types";
+
+export interface QuickPrompt {
+	label: string;
+	value: string;
+}
+
+export interface ChatPanelProps {
+	initialMessages?: ChatMessage[];
+	placeholder?: string;
+	quickPrompts?: QuickPrompt[];
+	onSend?: (message: string) => void;
+}
+
+interface RenderableMessage extends ChatMessage {
+	id: string;
+}
+
+const DEFAULT_PLACEHOLDER =
+	"what is the next train leaving Baker Street to Uxbridge?";
+
+const DEFAULT_QUICK_PROMPTS: QuickPrompt[] = [
+	{ label: "Next train", value: "Next train Baker Street → Uxbridge" },
+	{ label: "Why delayed?", value: "Why is the Elizabeth line delayed?" },
+	{
+		label: "Ticket acceptance",
+		value: "Tickets accepted on which lines?",
+	},
+];
+
+export function ChatPanel({
+	initialMessages = [],
+	placeholder = DEFAULT_PLACEHOLDER,
+	quickPrompts = DEFAULT_QUICK_PROMPTS,
+	onSend,
+}: ChatPanelProps) {
+	const sessionId = useId();
+	const [value, setValue] = useState("");
+	const [messages, setMessages] = useState<RenderableMessage[]>(() =>
+		initialMessages.map((message, index) => ({
+			...message,
+			id: `${sessionId}-seed-${index}`,
+		})),
+	);
+	const nextLocalId = useRef(0);
+	const transcriptRef = useRef<HTMLDivElement | null>(null);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: scroll-to-bottom must re-run whenever the transcript grows, even though the effect body only touches the ref.
+	useEffect(() => {
+		const node = transcriptRef.current;
+		if (node) {
+			node.scrollTop = node.scrollHeight;
+		}
+	}, [messages]);
+
+	const send = () => {
+		const trimmed = value.trim();
+		if (!trimmed) return;
+		const id = `${sessionId}-local-${nextLocalId.current++}`;
+		setMessages((current) => [...current, { id, who: "user", text: trimmed }]);
+		setValue("");
+		onSend?.(trimmed);
+	};
+
+	return (
+		<div className="tfl-chat-stack">
+			<section className="tfl-card tfl-chat-card">
+				<div className="tfl-chat-card-h">
+					<h4>Ask the Monitor</h4>
+					<span className="meta">GPT · context · TfL</span>
+				</div>
+				<div
+					className="tfl-chat-transcript"
+					ref={transcriptRef}
+					aria-live="polite"
+				>
+					{messages.map((message) => (
+						<div key={message.id} className={`tfl-msg tfl-msg-${message.who}`}>
+							{message.who === "bot" && (
+								<span className="tfl-msg-avatar" aria-hidden />
+							)}
+							<span className="tfl-msg-bubble">{message.text}</span>
+						</div>
+					))}
+				</div>
+			</section>
+			<div className="tfl-chatbox">
+				<textarea
+					className="tfl-chatbox-ta"
+					placeholder={placeholder}
+					value={value}
+					onChange={(e) => setValue(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" && !e.shiftKey) {
+							e.preventDefault();
+							send();
+						}
+					}}
+					rows={2}
+				/>
+				<div className="tfl-chatbox-row">
+					<div className="tfl-chatbox-l">
+						{quickPrompts.map((prompt) => (
+							<button
+								key={prompt.label}
+								type="button"
+								className="tfl-chip-sm"
+								onClick={() => setValue(prompt.value)}
+							>
+								{prompt.label}
+							</button>
+						))}
+					</div>
+					<div className="tfl-chatbox-r">
+						<button
+							type="button"
+							className="tfl-chat-iconbtn"
+							aria-label="Voice"
+						>
+							<Icon d={AUDIO_PATH} size={16} />
+						</button>
+						<button
+							type="button"
+							className="tfl-chatbox-send"
+							aria-label="Send"
+							onClick={send}
+						>
+							<Icon d={SEND_PATH} size={16} />
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/web/components/dashboard/chat-panel.tsx
+++ b/web/components/dashboard/chat-panel.tsx
@@ -96,7 +96,11 @@ export function ChatPanel({
 					value={value}
 					onChange={(e) => setValue(e.target.value)}
 					onKeyDown={(e) => {
-						if (e.key === "Enter" && !e.shiftKey) {
+						if (
+							e.key === "Enter" &&
+							!e.shiftKey &&
+							!e.nativeEvent.isComposing
+						) {
 							e.preventDefault();
 							send();
 						}

--- a/web/components/dashboard/icons.tsx
+++ b/web/components/dashboard/icons.tsx
@@ -1,0 +1,40 @@
+/**
+ * Inline SVG icon used across the dashboard surface.
+ *
+ * Path strings are exported as constants so callers reference them by
+ * name. The renderer splits multi-subpath strings on every leading `M`
+ * so the upstream design-system path data round-trips unchanged.
+ */
+
+export const GITHUB_PATH =
+	"M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 1.5 5 1.5 5 1.5c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 8.5c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4M9 18c-4.51 2-5-2-7-2";
+
+export const SEND_PATH = "M12 19V5 M5 12 l7-7 7 7";
+
+export const AUDIO_PATH = "M2 10v3 M6 6v11 M10 3v18 M14 8v7 M18 5v13 M22 10v3";
+
+export interface IconProps {
+	d: string;
+	size?: number;
+}
+
+export function Icon({ d, size = 16 }: IconProps) {
+	const parts = d.split(/(?=M)/).filter(Boolean);
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			{parts.map((p) => (
+				<path key={p} d={p} />
+			))}
+		</svg>
+	);
+}

--- a/web/components/dashboard/line-detail.tsx
+++ b/web/components/dashboard/line-detail.tsx
@@ -25,8 +25,9 @@ export function LineDetail({ line, disruption }: LineDetailProps) {
 				<>
 					<div className="tfl-disruption">
 						<div className="summary">{disruption.headline}</div>
-						{disruption.body.map((paragraph) => (
-							<p key={paragraph}>{paragraph}</p>
+						{disruption.body.map((paragraph, index) => (
+							// biome-ignore lint/suspicious/noArrayIndexKey: disruption body is a static prop with stable ordering; the index disambiguates duplicate paragraph strings that React would otherwise collide on.
+							<p key={`${index}-${paragraph}`}>{paragraph}</p>
 						))}
 					</div>
 					{disruption.stations.length > 0 && (

--- a/web/components/dashboard/line-detail.tsx
+++ b/web/components/dashboard/line-detail.tsx
@@ -1,0 +1,60 @@
+import type { DisruptionSnapshot, LineSummary } from "./types";
+
+export interface LineDetailProps {
+	line: LineSummary;
+	disruption?: DisruptionSnapshot;
+}
+
+export function LineDetail({ line, disruption }: LineDetailProps) {
+	return (
+		<section className="tfl-card">
+			<div className="tfl-detail-h">
+				<span
+					className="tfl-detail-stripe"
+					style={{ background: line.color }}
+				/>
+				<div>
+					<h2 className="tfl-detail-name">{line.name} line</h2>
+					<div className="tfl-detail-sub">
+						{line.code} · {line.statusText}
+						{disruption ? ` · reported ${disruption.reportedAtLabel}` : ""}
+					</div>
+				</div>
+			</div>
+			{disruption ? (
+				<>
+					<div className="tfl-disruption">
+						<div className="summary">{disruption.headline}</div>
+						{disruption.body.map((paragraph) => (
+							<p key={paragraph}>{paragraph}</p>
+						))}
+					</div>
+					{disruption.stations.length > 0 && (
+						<div className="tfl-stations">
+							<h5>Affected stations</h5>
+							<ul>
+								{disruption.stations.map((station) => (
+									<li key={station.code}>
+										{station.name}{" "}
+										<span className="code">
+											{station.code}
+											{station.note ? ` · ${station.note}` : ""}
+										</span>
+									</li>
+								))}
+							</ul>
+						</div>
+					)}
+					<div className="tfl-detail-foot">
+						<span>{disruption.sourceLabel}</span>
+						<span>Updated {disruption.updatedAtLabel}</span>
+					</div>
+				</>
+			) : (
+				<div className="tfl-disruption">
+					<p>No active disruption reported for this line.</p>
+				</div>
+			)}
+		</section>
+	);
+}

--- a/web/components/dashboard/line-grid.tsx
+++ b/web/components/dashboard/line-grid.tsx
@@ -1,0 +1,63 @@
+// biome-ignore-all lint/a11y/useSemanticElements: <div role="button"> preserves the upstream design-system CSS that styles every `.tfl-line` row; switching to <button> would inherit user-agent defaults the CSS does not reset, and keyboard activation is wired explicitly below.
+"use client";
+
+import type { KeyboardEvent } from "react";
+
+import type { LineSummary } from "./types";
+
+export interface LineGridProps {
+	lines: LineSummary[];
+	selected?: string;
+	onSelect: (code: string) => void;
+}
+
+function activateOnEnterOrSpace(
+	event: KeyboardEvent<HTMLDivElement>,
+	handler: () => void,
+) {
+	if (event.key === "Enter" || event.key === " ") {
+		event.preventDefault();
+		handler();
+	}
+}
+
+export function LineGrid({ lines, selected, onSelect }: LineGridProps) {
+	return (
+		<section className="tfl-card">
+			<div className="tfl-card-h">
+				<h4>Tube, Overground, DLR &amp; Elizabeth</h4>
+				<span className="meta">tap a line</span>
+			</div>
+			<div className="tfl-line-list">
+				{lines.map((l) => {
+					const isActive = selected === l.code;
+					const activate = () => onSelect(l.code);
+					return (
+						<div
+							key={l.code}
+							role="button"
+							tabIndex={0}
+							className={`tfl-line${isActive ? " active" : ""}`}
+							onClick={activate}
+							onKeyDown={(e) => activateOnEnterOrSpace(e, activate)}
+							aria-pressed={isActive}
+						>
+							<span
+								className="tfl-line-stripe"
+								style={{ background: l.color }}
+							/>
+							<div className="tfl-line-name-wrap">
+								<span className="tfl-line-name">{l.name}</span>
+								<span className="tfl-line-updated">{l.updatedLabel}</span>
+							</div>
+							<span className={`tfl-line-status tfl-${l.status}`}>
+								<span className="dot" />
+								{l.statusText}
+							</span>
+						</div>
+					);
+				})}
+			</div>
+		</section>
+	);
+}

--- a/web/components/dashboard/news-reports.tsx
+++ b/web/components/dashboard/news-reports.tsx
@@ -1,0 +1,44 @@
+import type { NewsItem } from "./types";
+
+export interface NewsReportsProps {
+	items: NewsItem[];
+	slotCount?: number;
+}
+
+export function NewsReports({ items, slotCount = 3 }: NewsReportsProps) {
+	const filled = items.slice(0, slotCount);
+	const empties = Math.max(0, slotCount - filled.length);
+	const slots: (NewsItem | null)[] = [
+		...filled,
+		...Array.from({ length: empties }, () => null),
+	];
+
+	return (
+		<section className="tfl-card tfl-news">
+			<div className="tfl-card-h">
+				<h4>News &amp; reports from TfL</h4>
+				<span className="meta">{filled.length} today</span>
+			</div>
+			<ul className="tfl-news-list">
+				{slots.map((slot, index) => {
+					const key = slot ? `${slot.time}-${slot.title}` : `empty-${index}`;
+					return (
+						<li key={key} className={slot ? "" : "is-empty"}>
+							<span className="tfl-news-time">{slot ? slot.time : ""}</span>
+							<div>
+								{slot ? (
+									<>
+										<div className="tfl-news-title">{slot.title}</div>
+										<div className="tfl-news-body">{slot.body}</div>
+									</>
+								) : (
+									<div className="tfl-news-placeholder">No further updates</div>
+								)}
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+		</section>
+	);
+}

--- a/web/components/dashboard/news-reports.tsx
+++ b/web/components/dashboard/news-reports.tsx
@@ -17,11 +17,13 @@ export function NewsReports({ items, slotCount = 3 }: NewsReportsProps) {
 		<section className="tfl-card tfl-news">
 			<div className="tfl-card-h">
 				<h4>News &amp; reports from TfL</h4>
-				<span className="meta">{filled.length} today</span>
+				<span className="meta">{items.length} today</span>
 			</div>
 			<ul className="tfl-news-list">
 				{slots.map((slot, index) => {
-					const key = slot ? `${slot.time}-${slot.title}` : `empty-${index}`;
+					const key = slot
+						? `${slot.time}-${slot.title}-${index}`
+						: `empty-${index}`;
 					return (
 						<li key={key} className={slot ? "" : "is-empty"}>
 							<span className="tfl-news-time">{slot ? slot.time : ""}</span>

--- a/web/components/dashboard/page-head.tsx
+++ b/web/components/dashboard/page-head.tsx
@@ -1,0 +1,21 @@
+export interface PageHeadProps {
+	lineCount: number;
+	lastRefreshedLabel: string;
+	refreshIntervalSeconds: number;
+}
+
+export function PageHead({
+	lineCount,
+	lastRefreshedLabel,
+	refreshIntervalSeconds,
+}: PageHeadProps) {
+	return (
+		<header className="tfl-pageh">
+			<h1>London transport — at a glance</h1>
+			<span className="meta">
+				{lineCount} lines · last refreshed {lastRefreshedLabel} · auto-refresh
+				every {refreshIntervalSeconds}s
+			</span>
+		</header>
+	);
+}

--- a/web/components/dashboard/top-nav.tsx
+++ b/web/components/dashboard/top-nav.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { GITHUB_PATH, Icon } from "./icons";
+import type { StatusSummaryCounts } from "./types";
+
+export interface TopNavProps {
+	summary: StatusSummaryCounts;
+	clockLabel: string;
+	repoUrl?: string;
+}
+
+const REPO_URL_DEFAULT = "https://github.com/humbertolomeu/tfl-monitor";
+
+export function TopNav({
+	summary,
+	clockLabel,
+	repoUrl = REPO_URL_DEFAULT,
+}: TopNavProps) {
+	return (
+		<nav className="tfl-nav">
+			<div className="tfl-nav-side tfl-nav-left">
+				<div className="tfl-brand">TfL Monitor</div>
+				<span className="tfl-nav-divider" />
+				<a
+					className="tfl-nav-iconbtn"
+					href={repoUrl}
+					aria-label="GitHub repo"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<Icon d={GITHUB_PATH} size={15} />
+				</a>
+			</div>
+			<div className="tfl-nav-side tfl-nav-right">
+				<div className="tfl-nav-sep">
+					<span className="tfl-nav-sep-line" />
+					<span className="tfl-nav-sep-label">Status</span>
+				</div>
+				<div className="tfl-nav-summary">
+					<span className="seg">
+						<span className="pill" style={{ background: "var(--success)" }} />
+						{summary.good} good
+					</span>
+					<span className="seg">
+						<span className="pill" style={{ background: "var(--warning)" }} />
+						{summary.minor} minor
+					</span>
+					<span className="seg">
+						<span className="pill" style={{ background: "var(--danger)" }} />
+						{summary.severe} severe
+					</span>
+					<span className="seg">
+						<span
+							className="pill"
+							style={{ background: "var(--ink-primary)" }}
+						/>
+						{summary.suspended} suspended
+					</span>
+					<span className="clock">{clockLabel}</span>
+				</div>
+			</div>
+		</nav>
+	);
+}

--- a/web/components/dashboard/types.ts
+++ b/web/components/dashboard/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared shapes consumed by dashboard components.
+ *
+ * The shapes intentionally diverge from the auto-generated OpenAPI types
+ * in `web/lib/types.ts`: components consume a denormalised view-model
+ * (status bucket + display colour) rather than the raw backend payload,
+ * so the same components can be hydrated by mocks or by a real fetcher
+ * adapter without leaking server-side concerns.
+ */
+
+export type StatusBucket = "good" | "minor" | "severe" | "suspended";
+
+export interface LineSummary {
+	code: string;
+	name: string;
+	color: string;
+	status: StatusBucket;
+	statusText: string;
+	updatedLabel: string;
+}
+
+export interface StatusSummaryCounts {
+	good: number;
+	minor: number;
+	severe: number;
+	suspended: number;
+}
+
+export interface DisruptionStation {
+	name: string;
+	code: string;
+	note?: string;
+}
+
+export interface DisruptionSnapshot {
+	headline: string;
+	body: string[];
+	reportedAtLabel: string;
+	stations: DisruptionStation[];
+	sourceLabel: string;
+	updatedAtLabel: string;
+}
+
+export interface BusItem {
+	route: string;
+	text: string;
+}
+
+export interface NewsItem {
+	time: string;
+	title: string;
+	body: string;
+}
+
+export interface ChatMessage {
+	who: "user" | "bot";
+	text: string;
+}


### PR DESCRIPTION
## Summary
- Port the seven design-system components from `Humberto Lomeu Design System/ui_kits/tfl_monitor/Components.jsx` into typed React 19 modules under `web/components/dashboard/`.
- Add `icons.tsx` (Icon + path constants) and component-level `types.ts` for shared view-model shapes (`LineSummary`, `DisruptionSnapshot`, `BusItem`, `NewsItem`, `ChatMessage`, `StatusSummaryCounts`).
- Smoke tests per component (mount + key interaction assertions) under `web/components/dashboard/__tests__/`.

## Scope
- `app/page.tsx` intentionally unchanged in this phase — still the Phase 2 stub. Page rewrite + composition lands in Phase 5 per spec §5.
- No backend wiring; `ChatPanel` keeps local-only transcript state until Phase 5 wires the SSE stream.
- CSS class names preserved verbatim (`tfl-card`, `tfl-line`, `tfl-msg`, `tfl-news-list`, …) so the design-system stylesheet applies unchanged.

## Verification
- `pnpm --dir web lint` — clean (Biome).
- `pnpm --dir web test` — 43 passed across 13 files.
- `pnpm --dir web build` — Next 16 / Turbopack succeeds.

## Test plan
- [ ] Phase 5 PR composes these components in `app/page.tsx` and adds the page-level integration test.
- [ ] Manual smoke once Phase 5 lands.

Refs TM-E4. Next: Phase 4 (mocks + env) and Phase 5 (page rewrite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dashboard UI: line status grid, detailed line view, bus banner, news feed, chat panel with quick prompts, and top navigation with live status and clock.

* **Tests**
  * Added comprehensive component tests covering BusBanner, ChatPanel, LineDetail, LineGrid, NewsReports, PageHead, and TopNav.

* **Documentation**
  * Added a high-priority runbook item detailing how to handle automated review findings for stacked PRs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/58)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->