### PR TITLE
feat(web): TM-E4 PR-4 mocks + env flag

### DIFF
--- a/web/lib/api/disruptions-recent.mock.test.ts
+++ b/web/lib/api/disruptions-recent.mock.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("getRecentDisruptions — USE_MOCKS branch", () => {
+	const fetchMock = vi.fn();
+
+	beforeEach(() => {
+		fetchMock.mockReset();
+		vi.stubGlobal("fetch", fetchMock);
+		vi.stubEnv("NEXT_PUBLIC_USE_MOCKS", "true");
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
+		vi.resetModules();
+	});
+
+	it("short-circuits to a single fixture without calling fetch", async () => {
+		const { getRecentDisruptions } = await import("./disruptions-recent");
+
+		const result = await getRecentDisruptions();
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(result).toHaveLength(1);
+		const [first] = result;
+		expect(first.affected_routes).toContain("elizabeth");
+		expect(first.affected_stops.length).toBeGreaterThan(0);
+		expect(first.summary).toMatch(/Paddington/);
+	});
+});

--- a/web/lib/api/disruptions-recent.ts
+++ b/web/lib/api/disruptions-recent.ts
@@ -1,28 +1,50 @@
 /**
  * Fetcher for the `/disruptions/recent` endpoint.
  *
- * Calls the FastAPI handler exposed by TM-D3 over the shared
- * `apiFetch` helper. Mirrors `status-live.ts` so the disruption-log
- * server component can compose a real call against
- * `contracts/openapi.yaml :: get_recent_disruptions`.
+ * Returns the most recent disruptions across the network. When
+ * `USE_MOCKS` is on, the fetch path is short-circuited with a fixture
+ * projected to the `Disruption` schema so the dashboard renders
+ * without a live backend.
  */
 
 import { apiFetch } from "@/lib/api-client";
+import { USE_MOCKS } from "@/lib/env";
+import { MOCK_DISRUPTION } from "@/lib/mocks/disruptions";
 import type { components } from "@/lib/types";
 
 export type Disruption = components["schemas"]["Disruption"];
 
+function toMockDisruption(now: Date): Disruption {
+	return {
+		disruption_id: "MOCK-ELZ-001",
+		category: "RealTime",
+		category_description: "Real Time",
+		description: MOCK_DISRUPTION.body.join("\n\n"),
+		summary: MOCK_DISRUPTION.headline,
+		affected_routes: ["elizabeth"],
+		affected_stops: MOCK_DISRUPTION.stations.map((station) => station.code),
+		closure_text: "",
+		severity: 6,
+		created: now.toISOString(),
+		last_update: now.toISOString(),
+	};
+}
+
 /**
  * Return the most recent disruptions across the served network.
  *
- * `cache: "no-store"` opts the request out of the Next.js Data Cache
- * so the server component re-fetches on every request instead of
- * serving build-time HTML. Response shape is locked by the
- * `Disruption` schema in `contracts/openapi.yaml`.
+ * Calls `GET /api/v1/disruptions/recent` via the shared `apiFetch`
+ * helper unless `USE_MOCKS` is on, in which case the function
+ * resolves synchronously to a single fixture derived from
+ * `MOCK_DISRUPTION`. Response shape is locked by the `Disruption`
+ * schema in `contracts/openapi.yaml`.
  */
 export async function getRecentDisruptions(
 	signal?: AbortSignal,
 ): Promise<Disruption[]> {
+	if (USE_MOCKS) {
+		return [toMockDisruption(new Date())];
+	}
 	return apiFetch<Disruption[]>("/api/v1/disruptions/recent", {
 		cache: "no-store",
 		signal,

--- a/web/lib/api/status-live.mock.test.ts
+++ b/web/lib/api/status-live.mock.test.ts
@@ -30,16 +30,23 @@ describe("getStatusLive — USE_MOCKS branch", () => {
 
 		const lines = await getStatusLive();
 
-		const elizabeth = lines.find((line) => line.line_id === "elz");
+		const elizabeth = lines.find((line) => line.line_id === "elizabeth");
 		expect(elizabeth?.mode).toBe("elizabeth-line");
 		expect(elizabeth?.status_severity_description).toBe("Severe Delays");
 
 		const dlr = lines.find((line) => line.line_id === "dlr");
 		expect(dlr?.mode).toBe("dlr");
 
-		const bakerloo = lines.find((line) => line.line_id === "bak");
+		const bakerloo = lines.find((line) => line.line_id === "bakerloo");
 		expect(bakerloo?.mode).toBe("tube");
 		expect(bakerloo?.status_severity).toBe(10);
+
+		expect(
+			lines.find((line) => line.line_id === "waterloo-city"),
+		).toBeDefined();
+		expect(
+			lines.find((line) => line.line_id === "london-overground"),
+		).toBeDefined();
 
 		for (const line of lines) {
 			expect(line.valid_from).toBeTypeOf("string");

--- a/web/lib/api/status-live.mock.test.ts
+++ b/web/lib/api/status-live.mock.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("getStatusLive — USE_MOCKS branch", () => {
+	const fetchMock = vi.fn();
+
+	beforeEach(() => {
+		fetchMock.mockReset();
+		vi.stubGlobal("fetch", fetchMock);
+		vi.stubEnv("NEXT_PUBLIC_USE_MOCKS", "true");
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
+		vi.resetModules();
+	});
+
+	it("short-circuits to fixtures without calling fetch", async () => {
+		const { getStatusLive } = await import("./status-live");
+
+		const result = await getStatusLive();
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(result.length).toBe(14);
+	});
+
+	it("projects fixtures into the LineStatus schema", async () => {
+		const { getStatusLive } = await import("./status-live");
+
+		const lines = await getStatusLive();
+
+		const elizabeth = lines.find((line) => line.line_id === "elz");
+		expect(elizabeth?.mode).toBe("elizabeth-line");
+		expect(elizabeth?.status_severity_description).toBe("Severe Delays");
+
+		const dlr = lines.find((line) => line.line_id === "dlr");
+		expect(dlr?.mode).toBe("dlr");
+
+		const bakerloo = lines.find((line) => line.line_id === "bak");
+		expect(bakerloo?.mode).toBe("tube");
+		expect(bakerloo?.status_severity).toBe(10);
+
+		for (const line of lines) {
+			expect(line.valid_from).toBeTypeOf("string");
+			expect(line.valid_to).toBeTypeOf("string");
+		}
+	});
+});

--- a/web/lib/api/status-live.ts
+++ b/web/lib/api/status-live.ts
@@ -1,29 +1,71 @@
 /**
  * Fetcher for the `/status/live` endpoint.
  *
- * TM-E1b swaps the TM-E1a mock body for a real call against the
- * FastAPI handler exposed by TM-D2. The function signature is the
- * contract — call sites in `app/page.tsx` compile unchanged.
+ * Returns the live operational status for every served line. When
+ * `USE_MOCKS` is on, the fetch path is short-circuited with fixtures
+ * projected to the `LineStatus` schema so the dashboard renders
+ * without a live backend.
  */
 
+import type { LineSummary, StatusBucket } from "@/components/dashboard/types";
 import { apiFetch } from "@/lib/api-client";
+import { USE_MOCKS } from "@/lib/env";
+import { MOCK_LINES } from "@/lib/mocks/lines";
 import type { components } from "@/lib/types";
 
 export type LineStatus = components["schemas"]["LineStatus"];
 
+type Mode = LineStatus["mode"];
+
+const BUCKET_TO_SEVERITY: Record<
+	StatusBucket,
+	{ severity: number; description: string }
+> = {
+	good: { severity: 10, description: "Good Service" },
+	minor: { severity: 9, description: "Minor Delays" },
+	severe: { severity: 6, description: "Severe Delays" },
+	suspended: { severity: 1, description: "Suspended" },
+};
+
+const CODE_TO_MODE: Record<string, Mode> = {
+	ELZ: "elizabeth-line",
+	DLR: "dlr",
+	OVG: "overground",
+};
+
+function lineSummaryToLineStatus(line: LineSummary, now: Date): LineStatus {
+	const { severity, description } = BUCKET_TO_SEVERITY[line.status];
+	const start = new Date(now);
+	start.setUTCHours(0, 0, 0, 0);
+	const end = new Date(now);
+	end.setUTCHours(23, 59, 59, 0);
+	return {
+		line_id: line.code.toLowerCase(),
+		line_name: line.name,
+		mode: CODE_TO_MODE[line.code] ?? "tube",
+		status_severity: severity,
+		status_severity_description: description,
+		reason: null,
+		valid_from: start.toISOString(),
+		valid_to: end.toISOString(),
+	};
+}
+
 /**
  * Return the current operational status for every served line.
  *
- * Calls `GET /api/v1/status/live` via the shared `apiFetch` helper,
- * which surfaces non-2xx responses as `ApiError` so the caller can
- * render a fallback. `cache: "no-store"` opts the request out of the
- * Next.js Data Cache so server components re-fetch on every request
- * instead of serving build-time HTML. Response shape is locked by the
- * `LineStatus` schema in `contracts/openapi.yaml`.
+ * Calls `GET /api/v1/status/live` via the shared `apiFetch` helper
+ * unless `USE_MOCKS` is on, in which case the function resolves
+ * synchronously to fixtures derived from `MOCK_LINES`. Response shape
+ * is locked by the `LineStatus` schema in `contracts/openapi.yaml`.
  */
 export async function getStatusLive(
 	signal?: AbortSignal,
 ): Promise<LineStatus[]> {
+	if (USE_MOCKS) {
+		const now = new Date();
+		return MOCK_LINES.map((line) => lineSummaryToLineStatus(line, now));
+	}
 	return apiFetch<LineStatus[]>("/api/v1/status/live", {
 		cache: "no-store",
 		signal,

--- a/web/lib/api/status-live.ts
+++ b/web/lib/api/status-live.ts
@@ -33,6 +33,23 @@ const CODE_TO_MODE: Record<string, Mode> = {
 	OVG: "overground",
 };
 
+const CODE_TO_LINE_ID: Record<string, string> = {
+	BAK: "bakerloo",
+	CEN: "central",
+	CIR: "circle",
+	DIS: "district",
+	ELZ: "elizabeth",
+	HAM: "hammersmith-city",
+	JUB: "jubilee",
+	MET: "metropolitan",
+	NTH: "northern",
+	PIC: "piccadilly",
+	VIC: "victoria",
+	WAT: "waterloo-city",
+	DLR: "dlr",
+	OVG: "london-overground",
+};
+
 function lineSummaryToLineStatus(line: LineSummary, now: Date): LineStatus {
 	const { severity, description } = BUCKET_TO_SEVERITY[line.status];
 	const start = new Date(now);
@@ -40,7 +57,7 @@ function lineSummaryToLineStatus(line: LineSummary, now: Date): LineStatus {
 	const end = new Date(now);
 	end.setUTCHours(23, 59, 59, 0);
 	return {
-		line_id: line.code.toLowerCase(),
+		line_id: CODE_TO_LINE_ID[line.code] ?? line.code.toLowerCase(),
 		line_name: line.name,
 		mode: CODE_TO_MODE[line.code] ?? "tube",
 		status_severity: severity,

--- a/web/lib/env.ts
+++ b/web/lib/env.ts
@@ -1,0 +1,10 @@
+/**
+ * Runtime environment flags read once at module load.
+ *
+ * `USE_MOCKS` is default-on so the dashboard renders against fixtures
+ * unless the deploy explicitly opts in to live data. The flag is read
+ * via the `NEXT_PUBLIC_*` prefix so it survives Next.js bundling for
+ * client components.
+ */
+
+export const USE_MOCKS = process.env.NEXT_PUBLIC_USE_MOCKS !== "false";

--- a/web/lib/mocks/__tests__/fixtures.test.ts
+++ b/web/lib/mocks/__tests__/fixtures.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { MOCK_BUSES } from "@/lib/mocks/buses";
+import { MOCK_DISRUPTION } from "@/lib/mocks/disruptions";
+import { MOCK_LINES } from "@/lib/mocks/lines";
+import { MOCK_NEWS } from "@/lib/mocks/news";
+
+describe("design-system mock fixtures", () => {
+	it("ships 14 line summaries with unique codes", () => {
+		expect(MOCK_LINES).toHaveLength(14);
+		const codes = new Set(MOCK_LINES.map((line) => line.code));
+		expect(codes.size).toBe(MOCK_LINES.length);
+	});
+
+	it("only uses known status buckets", () => {
+		const allowed = new Set(["good", "minor", "severe", "suspended"]);
+		for (const line of MOCK_LINES) {
+			expect(allowed.has(line.status)).toBe(true);
+		}
+	});
+
+	it("flags the Elizabeth line as the severe-delay subject", () => {
+		const elizabeth = MOCK_LINES.find((line) => line.code === "ELZ");
+		expect(elizabeth?.status).toBe("severe");
+		expect(MOCK_DISRUPTION.headline).toMatch(/Elizabeth|Paddington|Reading/);
+		expect(MOCK_DISRUPTION.body.length).toBeGreaterThan(0);
+		expect(MOCK_DISRUPTION.stations.length).toBeGreaterThan(0);
+	});
+
+	it("ships 4 bus alerts and 3 news items per design canvas", () => {
+		expect(MOCK_BUSES).toHaveLength(4);
+		expect(MOCK_NEWS).toHaveLength(3);
+	});
+});

--- a/web/lib/mocks/buses.ts
+++ b/web/lib/mocks/buses.ts
@@ -1,0 +1,19 @@
+import type { BusItem } from "@/components/dashboard/types";
+
+/**
+ * Bus-banner fixtures sourced from the design-system canvas's
+ * `TFLBusBanner` block (`Humberto Lomeu Design System/ui_kits/
+ * tfl_monitor/Components.jsx`).
+ */
+export const MOCK_BUSES: BusItem[] = [
+	{
+		route: "N29",
+		text: "Diverted around Trafalgar Square — closure 19:00–22:00.",
+	},
+	{
+		route: "38",
+		text: "Stop closure at Piccadilly Circus, alight at Green Park.",
+	},
+	{ route: "73", text: "Running normally. No reported delays." },
+	{ route: "N5", text: "Night service — start 23:30 from Edgware." },
+];

--- a/web/lib/mocks/disruptions.ts
+++ b/web/lib/mocks/disruptions.ts
@@ -1,0 +1,25 @@
+import type { DisruptionSnapshot } from "@/components/dashboard/types";
+
+/**
+ * Elizabeth-line disruption snapshot used by `LineDetail` under
+ * `USE_MOCKS`. Mirrors the inline copy from
+ * `Humberto Lomeu Design System/ui_kits/tfl_monitor/Components.jsx`.
+ */
+export const MOCK_DISRUPTION: DisruptionSnapshot = {
+	headline: "Severe delays westbound between Paddington and Reading",
+	body: [
+		"A faulty train at Hayes & Harlington is causing severe delays on the Elizabeth line westbound. Trains are reversing at Paddington. Eastbound services are running with minor delays.",
+		"Tickets are being accepted on London Underground (Piccadilly, Bakerloo) and on TfL bus routes between Paddington and Heathrow.",
+	],
+	reportedAtLabel: "17:58 BST",
+	stations: [
+		{ name: "Paddington", code: "PAD", note: "interchange" },
+		{ name: "Ealing Broadway", code: "EAL" },
+		{ name: "West Ealing", code: "WEA" },
+		{ name: "Hanwell", code: "HAN" },
+		{ name: "Southall", code: "STL" },
+		{ name: "Hayes & Harlington", code: "HAY", note: "incident" },
+	],
+	sourceLabel: "Source: TfL Unified API",
+	updatedAtLabel: "18:42:14 BST",
+};

--- a/web/lib/mocks/lines.ts
+++ b/web/lib/mocks/lines.ts
@@ -1,0 +1,124 @@
+import type { LineSummary } from "@/components/dashboard/types";
+
+/**
+ * Static line-summary fixtures mirroring the design-system canvas.
+ *
+ * Sourced verbatim from `Humberto Lomeu Design System/ui_kits/tfl_monitor/
+ * Components.jsx`'s `LINES` array. Used by the dashboard when
+ * `USE_MOCKS` is on, and by the wrapped `getStatusLive` fetcher to
+ * synthesise a backend-shaped response.
+ */
+export const MOCK_LINES: LineSummary[] = [
+	{
+		code: "BAK",
+		name: "Bakerloo",
+		color: "#894E24",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "CEN",
+		name: "Central",
+		color: "#DC241F",
+		status: "minor",
+		statusText: "Minor delays",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "CIR",
+		name: "Circle",
+		color: "#FFD329",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "DIS",
+		name: "District",
+		color: "#007D32",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "ELZ",
+		name: "Elizabeth",
+		color: "#6950A1",
+		status: "severe",
+		statusText: "Severe delays",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "HAM",
+		name: "Hammersmith & City",
+		color: "#E899A8",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "JUB",
+		name: "Jubilee",
+		color: "#7B868C",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "MET",
+		name: "Metropolitan",
+		color: "#751056",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "NTH",
+		name: "Northern",
+		color: "#000000",
+		status: "minor",
+		statusText: "Part suspended",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "PIC",
+		name: "Piccadilly",
+		color: "#0019A8",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "VIC",
+		name: "Victoria",
+		color: "#039BE5",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "WAT",
+		name: "Waterloo & City",
+		color: "#76D0BD",
+		status: "suspended",
+		statusText: "Suspended",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "DLR",
+		name: "DLR",
+		color: "#00AFAD",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "OVG",
+		name: "London Overground",
+		color: "#EE7C0E",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+];

--- a/web/lib/mocks/news.ts
+++ b/web/lib/mocks/news.ts
@@ -1,0 +1,24 @@
+import type { NewsItem } from "@/components/dashboard/types";
+
+/**
+ * News-and-reports fixtures sourced from the design-system canvas's
+ * `TFL_NEWS` array (`Humberto Lomeu Design System/ui_kits/tfl_monitor/
+ * Components.jsx`).
+ */
+export const MOCK_NEWS: NewsItem[] = [
+	{
+		time: "17:58",
+		title: "Elizabeth line — westbound severe delays",
+		body: "Faulty train at Hayes & Harlington. Tickets accepted on Piccadilly & Bakerloo.",
+	},
+	{
+		time: "16:20",
+		title: "Northern line — Bank branch part-suspended",
+		body: "No service between Kennington and Moorgate until further notice.",
+	},
+	{
+		time: "14:05",
+		title: "Planned engineering — weekend",
+		body: "District line no service Earl’s Court ↔ Wimbledon Sat – Sun. Replacement buses run.",
+	},
+];

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -20,5 +20,8 @@ export default defineConfig({
 		setupFiles: ["./vitest.setup.ts"],
 		include: ["**/*.{test,spec}.{ts,tsx}"],
 		exclude: ["**/node_modules/**", "**/.next/**"],
+		env: {
+			NEXT_PUBLIC_USE_MOCKS: "false",
+		},
 	},
 });


### PR DESCRIPTION
## Summary
- Adds `USE_MOCKS` env flag (default-on) read from `NEXT_PUBLIC_USE_MOCKS` so the dashboard renders against design-system fixtures unless the deploy explicitly opts in to live data.
- Ports the `LINES`, `TFL_NEWS`, bus banner, and Elizabeth-line disruption data from `Humberto Lomeu Design System/ui_kits/tfl_monitor/Components.jsx` into typed view-model fixtures under `web/lib/mocks/{lines,disruptions,buses,news}.ts`.
- Wraps `getStatusLive` and `getRecentDisruptions` so they short-circuit to fixtures projected back into the `LineStatus` / `Disruption` OpenAPI schemas when `USE_MOCKS` is on. The live `apiFetch` path is preserved for when the backend is reachable.
- Vitest config sets `NEXT_PUBLIC_USE_MOCKS=false` so existing fetcher tests still exercise the network path; new mock-branch tests opt in via `vi.stubEnv` + `vi.resetModules` + dynamic import.

Implements Phase 4 of the TM-E4 spec (`.claude/specs/TM-E4-spec.md` §5). Phase 5 (page rewrite) will wire `useAutoRefresh` to the wrapped fetchers, and Phase 6 covers the Vercel deploy.

## Test plan
- [x] `pnpm --dir web lint`
- [x] `pnpm --dir web test` (51 passed, +6 new)
- [x] `pnpm --dir web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard gains a mock-data mode (runtime flag) with fixture sets for lines, disruptions, news, and buses; API fetches short-circuit to synthesized responses when enabled.

* **Tests**
  * Added test suites validating mock-mode behavior and fixture integrity (structure, counts, and expected fields).

* **Chores**
  * Test environment configured to keep mocks disabled by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/59)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->