### PR TITLE
feat(web): TM-E4 PR-5 page rewrite + adapters

### DIFF
--- a/web/app/__tests__/page.test.tsx
+++ b/web/app/__tests__/page.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Disruption } from "@/lib/api/disruptions-recent";
+import type { LineStatus } from "@/lib/api/status-live";
+
+const SAMPLE_LINES: LineStatus[] = [
+	{
+		line_id: "elizabeth",
+		line_name: "Elizabeth line",
+		mode: "elizabeth-line",
+		status_severity: 6,
+		status_severity_description: "Severe Delays",
+		reason: null,
+		valid_from: "2026-05-13T05:00:00Z",
+		valid_to: "2026-05-13T23:59:00Z",
+	},
+	{
+		line_id: "victoria",
+		line_name: "Victoria",
+		mode: "tube",
+		status_severity: 10,
+		status_severity_description: "Good Service",
+		reason: null,
+		valid_from: "2026-05-13T05:00:00Z",
+		valid_to: "2026-05-13T23:59:00Z",
+	},
+	{
+		line_id: "piccadilly",
+		line_name: "Piccadilly",
+		mode: "tube",
+		status_severity: 9,
+		status_severity_description: "Minor Delays",
+		reason: null,
+		valid_from: "2026-05-13T05:00:00Z",
+		valid_to: "2026-05-13T23:59:00Z",
+	},
+];
+
+const SAMPLE_DISRUPTION: Disruption = {
+	disruption_id: "ELZ-001",
+	category: "RealTime",
+	category_description: "Real Time",
+	description: "Severe delays westbound between Paddington and Reading.",
+	summary: "Severe delays westbound",
+	affected_routes: ["elizabeth"],
+	affected_stops: ["910GPADTON"],
+	closure_text: "",
+	severity: 6,
+	created: "2026-05-13T16:58:00Z",
+	last_update: "2026-05-13T17:42:00Z",
+};
+
+vi.mock("@/lib/api/status-live", async () => {
+	const actual = await vi.importActual<typeof import("@/lib/api/status-live")>(
+		"@/lib/api/status-live",
+	);
+	return {
+		...actual,
+		getStatusLive: vi.fn(async () => SAMPLE_LINES),
+	};
+});
+
+vi.mock("@/lib/api/disruptions-recent", async () => {
+	const actual = await vi.importActual<
+		typeof import("@/lib/api/disruptions-recent")
+	>("@/lib/api/disruptions-recent");
+	return {
+		...actual,
+		getRecentDisruptions: vi.fn(async () => [SAMPLE_DISRUPTION]),
+	};
+});
+
+describe("HomePage", () => {
+	beforeEach(() => {
+		Object.defineProperty(document, "visibilityState", {
+			configurable: true,
+			value: "visible",
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders the dashboard composition once mocked fetchers resolve", async () => {
+		const { default: HomePage } = await import("../page");
+		render(<HomePage />);
+
+		expect(
+			await screen.findByText(/Tube, Overground, DLR/),
+		).toBeInTheDocument();
+
+		expect(await screen.findByText("Elizabeth line line")).toBeInTheDocument();
+
+		expect(
+			await screen.findByText("London transport — at a glance"),
+		).toBeInTheDocument();
+
+		const goodPill = await screen.findByText(/1 good/);
+		expect(goodPill).toBeInTheDocument();
+		expect(screen.getByText(/1 severe/)).toBeInTheDocument();
+		expect(screen.getByText(/1 minor/)).toBeInTheDocument();
+	});
+
+	it("renders the news-and-reports + bus banner cards from mocks", async () => {
+		const { default: HomePage } = await import("../page");
+		render(<HomePage />);
+
+		expect(
+			await screen.findByText(/News & reports from TfL/),
+		).toBeInTheDocument();
+		expect(screen.getByText(/Buses worth knowing about/)).toBeInTheDocument();
+	});
+});

--- a/web/app/__tests__/page.test.tsx
+++ b/web/app/__tests__/page.test.tsx
@@ -91,7 +91,7 @@ describe("HomePage", () => {
 			await screen.findByText(/Tube, Overground, DLR/),
 		).toBeInTheDocument();
 
-		expect(await screen.findByText("Elizabeth line line")).toBeInTheDocument();
+		expect(await screen.findByText("Elizabeth line")).toBeInTheDocument();
 
 		expect(
 			await screen.findByText("London transport — at a glance"),

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -30,19 +30,20 @@ function formatLondonClock(date: Date | null): string {
 		hour: "2-digit",
 		minute: "2-digit",
 		timeZone: "Europe/London",
+		timeZoneName: "short",
 	});
-	return `${time} BST · live`;
+	return `${time} · live`;
 }
 
 function formatRefreshedLabel(date: Date | null): string {
 	if (!date) return "awaiting first refresh";
-	const time = date.toLocaleTimeString("en-GB", {
+	return date.toLocaleTimeString("en-GB", {
 		hour: "2-digit",
 		minute: "2-digit",
 		second: "2-digit",
 		timeZone: "Europe/London",
+		timeZoneName: "short",
 	});
-	return `${time} BST`;
 }
 
 export default function HomePage() {
@@ -58,7 +59,13 @@ export default function HomePage() {
 	const [selectedCode, setSelectedCode] = useState<string | null>(null);
 
 	useEffect(() => {
-		if (selectedCode || lineSummaries.length === 0) return;
+		if (lineSummaries.length === 0) return;
+		if (
+			selectedCode &&
+			lineSummaries.some((line) => line.code === selectedCode)
+		) {
+			return;
+		}
 		const preferred =
 			lineSummaries.find((line) => line.status === "severe") ??
 			lineSummaries[0];

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,8 +1,109 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { BusBanner } from "@/components/dashboard/bus-banner";
+import { ChatPanel } from "@/components/dashboard/chat-panel";
+import { LineDetail } from "@/components/dashboard/line-detail";
+import { LineGrid } from "@/components/dashboard/line-grid";
+import { NewsReports } from "@/components/dashboard/news-reports";
+import { PageHead } from "@/components/dashboard/page-head";
+import { TopNav } from "@/components/dashboard/top-nav";
+import { getRecentDisruptions } from "@/lib/api/disruptions-recent";
+import { getStatusLive } from "@/lib/api/status-live";
+import {
+	disruptionForLine,
+	disruptionToSnapshot,
+	lineStatusesToSummaries,
+	summarizeCounts,
+} from "@/lib/dashboard/adapt";
+import { useAutoRefresh } from "@/lib/hooks/use-auto-refresh";
+import { MOCK_BUSES } from "@/lib/mocks/buses";
+import { MOCK_NEWS } from "@/lib/mocks/news";
+
+const REFRESH_INTERVAL_MS = 30_000;
+const REPO_URL = "https://github.com/humbertolomeu/tfl-monitor";
+
+function formatLondonClock(date: Date | null): string {
+	if (!date) return "—";
+	const time = date.toLocaleTimeString("en-GB", {
+		hour: "2-digit",
+		minute: "2-digit",
+		timeZone: "Europe/London",
+	});
+	return `${time} BST · live`;
+}
+
+function formatRefreshedLabel(date: Date | null): string {
+	if (!date) return "awaiting first refresh";
+	const time = date.toLocaleTimeString("en-GB", {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		timeZone: "Europe/London",
+	});
+	return `${time} BST`;
+}
+
 export default function HomePage() {
+	const status = useAutoRefresh(getStatusLive, REFRESH_INTERVAL_MS);
+	const disruptions = useAutoRefresh(getRecentDisruptions, REFRESH_INTERVAL_MS);
+
+	const lineSummaries = useMemo(
+		() => (status.data ? lineStatusesToSummaries(status.data) : []),
+		[status.data],
+	);
+	const counts = useMemo(() => summarizeCounts(lineSummaries), [lineSummaries]);
+
+	const [selectedCode, setSelectedCode] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (selectedCode || lineSummaries.length === 0) return;
+		const preferred =
+			lineSummaries.find((line) => line.status === "severe") ??
+			lineSummaries[0];
+		setSelectedCode(preferred.code);
+	}, [selectedCode, lineSummaries]);
+
+	const selectedLine = useMemo(
+		() => lineSummaries.find((line) => line.code === selectedCode) ?? null,
+		[lineSummaries, selectedCode],
+	);
+
+	const selectedDisruption = useMemo(() => {
+		if (!selectedLine || !disruptions.data) return undefined;
+		const match = disruptionForLine(disruptions.data, selectedLine);
+		return match ? disruptionToSnapshot(match) : undefined;
+	}, [disruptions.data, selectedLine]);
+
+	const clockLabel = formatLondonClock(status.lastUpdated);
+	const refreshedLabel = formatRefreshedLabel(status.lastUpdated);
+
 	return (
-		<main>
-			<h1>tfl-monitor</h1>
-			<p>Dashboard under reconstruction — see TM-E4.</p>
-		</main>
+		<>
+			<TopNav summary={counts} clockLabel={clockLabel} repoUrl={REPO_URL} />
+			<main className="tfl-grid">
+				<PageHead
+					lineCount={lineSummaries.length}
+					lastRefreshedLabel={refreshedLabel}
+					refreshIntervalSeconds={REFRESH_INTERVAL_MS / 1000}
+				/>
+				<div className="tfl-left-col">
+					<LineGrid
+						lines={lineSummaries}
+						selected={selectedCode ?? undefined}
+						onSelect={setSelectedCode}
+					/>
+					<BusBanner buses={MOCK_BUSES} />
+					<NewsReports items={MOCK_NEWS} />
+				</div>
+				<div className="tfl-right-col">
+					{selectedLine ? (
+						<LineDetail line={selectedLine} disruption={selectedDisruption} />
+					) : null}
+					<ChatPanel />
+				</div>
+			</main>
+		</>
 	);
 }

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -59,9 +59,27 @@ describe("lineStatusesToSummaries", () => {
 		});
 		expect(elizabeth).toMatchObject({
 			code: "ELZ",
+			name: "Elizabeth",
 			color: "#6950A1",
 			status: "severe",
 		});
+	});
+
+	it("strips trailing ' line' so downstream components don't duplicate it", () => {
+		const summaries = lineStatusesToSummaries([
+			{
+				...SAMPLE_LINES[0],
+				line_id: "elizabeth",
+				line_name: "Elizabeth line",
+			},
+			{
+				...SAMPLE_LINES[0],
+				line_id: "waterloo-city",
+				line_name: "Waterloo & City",
+			},
+		]);
+		expect(summaries[0].name).toBe("Elizabeth");
+		expect(summaries[1].name).toBe("Waterloo & City");
 	});
 
 	it("falls back to a neutral meta when the line id is unknown", () => {
@@ -118,7 +136,7 @@ describe("disruptionForLine + disruptionToSnapshot", () => {
 			{ name: "940GZZLUHBN", code: "940GZZLUHBN" },
 		]);
 		expect(snapshot.sourceLabel).toBe("Source: TfL Unified API");
-		expect(snapshot.reportedAtLabel).toMatch(/BST$/);
-		expect(snapshot.updatedAtLabel).toMatch(/BST$/);
+		expect(snapshot.reportedAtLabel).toMatch(/\d{2}:\d{2}/);
+		expect(snapshot.updatedAtLabel).toMatch(/\d{2}:\d{2}/);
 	});
 });

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import type { Disruption } from "@/lib/api/disruptions-recent";
+import type { LineStatus } from "@/lib/api/status-live";
+import {
+	disruptionForLine,
+	disruptionToSnapshot,
+	lineStatusesToSummaries,
+	severityToBucket,
+	summarizeCounts,
+} from "@/lib/dashboard/adapt";
+
+const SAMPLE_LINES: LineStatus[] = [
+	{
+		line_id: "victoria",
+		line_name: "Victoria",
+		mode: "tube",
+		status_severity: 10,
+		status_severity_description: "Good Service",
+		reason: null,
+		valid_from: "2026-05-13T05:00:00Z",
+		valid_to: "2026-05-13T23:59:00Z",
+	},
+	{
+		line_id: "elizabeth",
+		line_name: "Elizabeth line",
+		mode: "elizabeth-line",
+		status_severity: 6,
+		status_severity_description: "Severe Delays",
+		reason: null,
+		valid_from: "2026-05-13T05:00:00Z",
+		valid_to: "2026-05-13T23:59:00Z",
+	},
+];
+
+describe("severityToBucket", () => {
+	it("maps every observed severity to one of the four buckets", () => {
+		expect(severityToBucket(10)).toBe("good");
+		expect(severityToBucket(20)).toBe("good");
+		expect(severityToBucket(9)).toBe("minor");
+		expect(severityToBucket(7)).toBe("minor");
+		expect(severityToBucket(6)).toBe("severe");
+		expect(severityToBucket(4)).toBe("severe");
+		expect(severityToBucket(1)).toBe("suspended");
+		expect(severityToBucket(0)).toBe("suspended");
+	});
+});
+
+describe("lineStatusesToSummaries", () => {
+	it("joins backend ids with the dashboard registry", () => {
+		const [victoria, elizabeth] = lineStatusesToSummaries(SAMPLE_LINES);
+
+		expect(victoria).toMatchObject({
+			code: "VIC",
+			name: "Victoria",
+			color: "#039BE5",
+			status: "good",
+			statusText: "Good Service",
+		});
+		expect(elizabeth).toMatchObject({
+			code: "ELZ",
+			color: "#6950A1",
+			status: "severe",
+		});
+	});
+
+	it("falls back to a neutral meta when the line id is unknown", () => {
+		const summaries = lineStatusesToSummaries([
+			{
+				...SAMPLE_LINES[0],
+				line_id: "totally-new-line",
+				line_name: "Mystery",
+			},
+		]);
+		expect(summaries[0]).toMatchObject({ code: "TFL", color: "#5A6A77" });
+	});
+});
+
+describe("summarizeCounts", () => {
+	it("aggregates per-bucket totals", () => {
+		const summaries = lineStatusesToSummaries(SAMPLE_LINES);
+		expect(summarizeCounts(summaries)).toEqual({
+			good: 1,
+			minor: 0,
+			severe: 1,
+			suspended: 0,
+		});
+	});
+});
+
+describe("disruptionForLine + disruptionToSnapshot", () => {
+	const disruption: Disruption = {
+		disruption_id: "test-1",
+		category: "RealTime",
+		category_description: "Real Time",
+		description: "Para 1.\n\nPara 2.",
+		summary: "Severe delays westbound",
+		affected_routes: ["elizabeth"],
+		affected_stops: ["940GZZLUHBN"],
+		closure_text: "",
+		severity: 6,
+		created: "2026-05-13T16:58:00Z",
+		last_update: "2026-05-13T17:42:00Z",
+	};
+
+	it("resolves selected line via canonical id", () => {
+		const [, elizabeth] = lineStatusesToSummaries(SAMPLE_LINES);
+		expect(disruptionForLine([disruption], elizabeth)).toBe(disruption);
+		const [victoria] = lineStatusesToSummaries(SAMPLE_LINES);
+		expect(disruptionForLine([disruption], victoria)).toBeUndefined();
+	});
+
+	it("projects backend payload onto the snapshot view-model", () => {
+		const snapshot = disruptionToSnapshot(disruption);
+		expect(snapshot.headline).toBe("Severe delays westbound");
+		expect(snapshot.body).toEqual(["Para 1.", "Para 2."]);
+		expect(snapshot.stations).toEqual([
+			{ name: "940GZZLUHBN", code: "940GZZLUHBN" },
+		]);
+		expect(snapshot.sourceLabel).toBe("Source: TfL Unified API");
+		expect(snapshot.reportedAtLabel).toMatch(/BST$/);
+		expect(snapshot.updatedAtLabel).toMatch(/BST$/);
+	});
+});

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -82,15 +82,52 @@ describe("lineStatusesToSummaries", () => {
 		expect(summaries[1].name).toBe("Waterloo & City");
 	});
 
-	it("falls back to a neutral meta when the line id is unknown", () => {
+	it("prefixes unknown line ids so unrelated rows don't collide on a shared fallback code", () => {
 		const summaries = lineStatusesToSummaries([
 			{
 				...SAMPLE_LINES[0],
 				line_id: "totally-new-line",
 				line_name: "Mystery",
 			},
+			{
+				...SAMPLE_LINES[0],
+				line_id: "another-new-line",
+				line_name: "Other",
+			},
 		]);
-		expect(summaries[0]).toMatchObject({ code: "TFL", color: "#5A6A77" });
+		expect(summaries[0]).toMatchObject({
+			code: "UNK:totally-new-line",
+			color: "#5A6A77",
+		});
+		expect(summaries[1]).toMatchObject({
+			code: "UNK:another-new-line",
+			color: "#5A6A77",
+		});
+		expect(summaries[0].code).not.toBe(summaries[1].code);
+	});
+
+	it("resolves disruptions for unknown lines via the UNK: prefix", () => {
+		const summaries = lineStatusesToSummaries([
+			{
+				...SAMPLE_LINES[0],
+				line_id: "mystery-line",
+				line_name: "Mystery",
+			},
+		]);
+		const disruption: Disruption = {
+			disruption_id: "MYST-001",
+			category: "RealTime",
+			category_description: "Real Time",
+			description: "Mystery delays",
+			summary: "Mystery delays",
+			affected_routes: ["mystery-line"],
+			affected_stops: [],
+			closure_text: "",
+			severity: 6,
+			created: "2026-05-13T16:58:00Z",
+			last_update: "2026-05-13T17:42:00Z",
+		};
+		expect(disruptionForLine([disruption], summaries[0])).toBe(disruption);
 	});
 });
 

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -41,7 +41,8 @@ const LINE_META_BY_ID: Record<string, LineMeta> = {
 	"london-overground": { code: "OVG", color: "#EE7C0E" },
 };
 
-const FALLBACK_META: LineMeta = { code: "TFL", color: "#5A6A77" };
+const UNKNOWN_CODE_PREFIX = "UNK:";
+const FALLBACK_COLOR = "#5A6A77";
 
 const LINE_ID_BY_CODE: Record<string, string> = Object.fromEntries(
 	Object.entries(LINE_META_BY_ID).map(([id, { code }]) => [code, id]),
@@ -64,7 +65,17 @@ export function severityToBucket(severity: number): StatusBucket {
 }
 
 function metaFor(lineId: string): LineMeta {
-	return LINE_META_BY_ID[lineId] ?? FALLBACK_META;
+	const known = LINE_META_BY_ID[lineId];
+	if (known) return known;
+	return { code: `${UNKNOWN_CODE_PREFIX}${lineId}`, color: FALLBACK_COLOR };
+}
+
+function lineIdForCode(code: string): string | undefined {
+	const known = LINE_ID_BY_CODE[code];
+	if (known) return known;
+	return code.startsWith(UNKNOWN_CODE_PREFIX)
+		? code.slice(UNKNOWN_CODE_PREFIX.length)
+		: undefined;
 }
 
 /**
@@ -126,7 +137,7 @@ export function disruptionForLine(
 	disruptions: Disruption[],
 	summary: LineSummary,
 ): Disruption | undefined {
-	const lineId = LINE_ID_BY_CODE[summary.code];
+	const lineId = lineIdForCode(summary.code);
 	if (!lineId) return undefined;
 	return disruptions.find((d) => d.affected_routes.includes(lineId));
 }

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -43,6 +43,14 @@ const LINE_META_BY_ID: Record<string, LineMeta> = {
 
 const FALLBACK_META: LineMeta = { code: "TFL", color: "#5A6A77" };
 
+const LINE_ID_BY_CODE: Record<string, string> = Object.fromEntries(
+	Object.entries(LINE_META_BY_ID).map(([id, { code }]) => [code, id]),
+);
+
+function stripTrailingLine(name: string): string {
+	return name.replace(/\s*line$/i, "").trim();
+}
+
 /**
  * Project a TfL `status_severity` integer onto the four display
  * buckets the dashboard uses. Mirrors the inverse of
@@ -69,7 +77,7 @@ export function lineStatusesToSummaries(lines: LineStatus[]): LineSummary[] {
 		const meta = metaFor(line.line_id);
 		return {
 			code: meta.code,
-			name: line.line_name,
+			name: stripTrailingLine(line.line_name),
 			color: meta.color,
 			status: severityToBucket(line.status_severity),
 			statusText: line.status_severity_description,
@@ -100,6 +108,7 @@ function formatLondonTime(iso: string): string {
 			hour: "2-digit",
 			minute: "2-digit",
 			timeZone: "Europe/London",
+			timeZoneName: "short",
 		});
 	} catch {
 		return iso;
@@ -117,9 +126,7 @@ export function disruptionForLine(
 	disruptions: Disruption[],
 	summary: LineSummary,
 ): Disruption | undefined {
-	const lineId = Object.keys(LINE_META_BY_ID).find(
-		(id) => LINE_META_BY_ID[id].code === summary.code,
-	);
+	const lineId = LINE_ID_BY_CODE[summary.code];
 	if (!lineId) return undefined;
 	return disruptions.find((d) => d.affected_routes.includes(lineId));
 }
@@ -142,9 +149,9 @@ export function disruptionToSnapshot(d: Disruption): DisruptionSnapshot {
 	return {
 		headline: d.summary,
 		body,
-		reportedAtLabel: `${formatLondonTime(d.created)} BST`,
+		reportedAtLabel: formatLondonTime(d.created),
 		stations,
 		sourceLabel: "Source: TfL Unified API",
-		updatedAtLabel: `${formatLondonTime(d.last_update)} BST`,
+		updatedAtLabel: formatLondonTime(d.last_update),
 	};
 }

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -1,0 +1,150 @@
+/**
+ * Adapters that bridge backend payloads (`LineStatus`, `Disruption`)
+ * and the dashboard's view-model shapes (`LineSummary`,
+ * `DisruptionSnapshot`).
+ *
+ * Components in `web/components/dashboard/*` consume denormalised
+ * view-models so the same components can be hydrated by mocks or by
+ * real fetchers. The lookup tables here are the contract that joins
+ * canonical TfL line IDs with the colours and short codes the design
+ * canvas requires.
+ */
+
+import type {
+	DisruptionSnapshot,
+	LineSummary,
+	StatusBucket,
+	StatusSummaryCounts,
+} from "@/components/dashboard/types";
+import type { Disruption } from "@/lib/api/disruptions-recent";
+import type { LineStatus } from "@/lib/api/status-live";
+
+interface LineMeta {
+	code: string;
+	color: string;
+}
+
+const LINE_META_BY_ID: Record<string, LineMeta> = {
+	bakerloo: { code: "BAK", color: "#894E24" },
+	central: { code: "CEN", color: "#DC241F" },
+	circle: { code: "CIR", color: "#FFD329" },
+	district: { code: "DIS", color: "#007D32" },
+	elizabeth: { code: "ELZ", color: "#6950A1" },
+	"hammersmith-city": { code: "HAM", color: "#E899A8" },
+	jubilee: { code: "JUB", color: "#7B868C" },
+	metropolitan: { code: "MET", color: "#751056" },
+	northern: { code: "NTH", color: "#000000" },
+	piccadilly: { code: "PIC", color: "#0019A8" },
+	victoria: { code: "VIC", color: "#039BE5" },
+	"waterloo-city": { code: "WAT", color: "#76D0BD" },
+	dlr: { code: "DLR", color: "#00AFAD" },
+	"london-overground": { code: "OVG", color: "#EE7C0E" },
+};
+
+const FALLBACK_META: LineMeta = { code: "TFL", color: "#5A6A77" };
+
+/**
+ * Project a TfL `status_severity` integer onto the four display
+ * buckets the dashboard uses. Mirrors the inverse of
+ * `BUCKET_TO_SEVERITY` in the mock fetcher.
+ */
+export function severityToBucket(severity: number): StatusBucket {
+	if (severity >= 10) return "good";
+	if (severity >= 7) return "minor";
+	if (severity >= 4) return "severe";
+	return "suspended";
+}
+
+function metaFor(lineId: string): LineMeta {
+	return LINE_META_BY_ID[lineId] ?? FALLBACK_META;
+}
+
+/**
+ * Convert a list of backend `LineStatus` rows into the view-model
+ * shape `LineGrid` and `TopNav` consume. Colour and short code are
+ * looked up from the static line registry.
+ */
+export function lineStatusesToSummaries(lines: LineStatus[]): LineSummary[] {
+	return lines.map((line) => {
+		const meta = metaFor(line.line_id);
+		return {
+			code: meta.code,
+			name: line.line_name,
+			color: meta.color,
+			status: severityToBucket(line.status_severity),
+			statusText: line.status_severity_description,
+			updatedLabel: "updated just now",
+		};
+	});
+}
+
+/**
+ * Aggregate per-bucket counts for the top-nav status summary.
+ */
+export function summarizeCounts(lines: LineSummary[]): StatusSummaryCounts {
+	const counts: StatusSummaryCounts = {
+		good: 0,
+		minor: 0,
+		severe: 0,
+		suspended: 0,
+	};
+	for (const line of lines) {
+		counts[line.status] += 1;
+	}
+	return counts;
+}
+
+function formatLondonTime(iso: string): string {
+	try {
+		return new Date(iso).toLocaleTimeString("en-GB", {
+			hour: "2-digit",
+			minute: "2-digit",
+			timeZone: "Europe/London",
+		});
+	} catch {
+		return iso;
+	}
+}
+
+/**
+ * Locate the disruption that matches a selected line.
+ *
+ * Backend `affected_routes` carries canonical line IDs (`elizabeth`,
+ * `piccadilly`, …), so we resolve the selected line's ID via the
+ * registry and match on that.
+ */
+export function disruptionForLine(
+	disruptions: Disruption[],
+	summary: LineSummary,
+): Disruption | undefined {
+	const lineId = Object.keys(LINE_META_BY_ID).find(
+		(id) => LINE_META_BY_ID[id].code === summary.code,
+	);
+	if (!lineId) return undefined;
+	return disruptions.find((d) => d.affected_routes.includes(lineId));
+}
+
+/**
+ * Project a backend `Disruption` row into the view-model `LineDetail`
+ * consumes. Station names degrade to the raw stop ID when we lack a
+ * richer registry — Phase 5 keeps the projection minimal; richer
+ * naming comes when the disruption stream is wired end-to-end.
+ */
+export function disruptionToSnapshot(d: Disruption): DisruptionSnapshot {
+	const body = d.description
+		.split(/\n{2,}/)
+		.map((paragraph) => paragraph.trim())
+		.filter((paragraph) => paragraph.length > 0);
+	const stations = d.affected_stops.map((stop) => ({
+		name: stop,
+		code: stop,
+	}));
+	return {
+		headline: d.summary,
+		body,
+		reportedAtLabel: `${formatLondonTime(d.created)} BST`,
+		stations,
+		sourceLabel: "Source: TfL Unified API",
+		updatedAtLabel: `${formatLondonTime(d.last_update)} BST`,
+	};
+}


### PR DESCRIPTION
## Summary
- Rewrites `web/app/page.tsx` as a client component that wires `useAutoRefresh` to the Phase-4 wrapped `getStatusLive` and `getRecentDisruptions` fetchers (30-second tick, abort-aware, visibility-gated).
- Composes the dashboard surface per spec §4.1: `TopNav` (with live summary + clock + repo link) over a `tfl-grid` `<main>` that holds `PageHead`, the left column (`LineGrid` + `BusBanner` + `NewsReports`), and the right column (`LineDetail` + `ChatPanel`).
- Adds `web/lib/dashboard/adapt.ts` with the canonical line registry (line_id → short code + colour), `severityToBucket`, `lineStatusesToSummaries`, `summarizeCounts`, `disruptionForLine`, and `disruptionToSnapshot`.
- Auto-selects the first severe-status line so `LineDetail` always has content when fixtures contain a disruption, and reaches into `MOCK_BUSES` / `MOCK_NEWS` directly (no fetchers exist for those yet).

Implements Phase 5 of the TM-E4 spec (`.claude/specs/TM-E4-spec.md` §5). Phase 6 covers the production verification and Vercel deploy.

## Test plan
- [x] `pnpm --dir web lint`
- [x] `pnpm --dir web test` (59 passed, +8 new — 6 adapter cases, 2 page integration cases)
- [x] `pnpm --dir web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard converted to an interactive client page with live auto-refresh, live clock and "last refreshed" labels, aggregated severity counts, selectable line detail view, bus banner, news & reports, and chat panel.
  * Improved handling of disruption and line summaries for more accurate status labels and snapshots.

* **Tests**
  * Added tests covering homepage rendering, severity/count summaries, disruption snapshots, and line-detail behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/60)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->