### PR TITLE
chore: TM-E4 phase 5 done, refresh current-wp + ignore .vscode

### DIFF
--- a/.claude/current-wp.md
+++ b/.claude/current-wp.md
@@ -5,4 +5,4 @@
 | TM-D5 | Done ✅ 2026-05-08 | LangGraph agent (SQL + RAG) shipped, PR #44 merged |
 | TM-E5 | Done ✅ 2026-05-12 | One-pager dashboard + chat. Three sub-PRs merged: #51 (hook + labels + primitives), #53 (6 cards + chat panel + about sheet), #54 (page rewrite + redirects + legacy deletion + AbortSignal/ApiError fixes). |
 | TM-A5 | Blocked | Research + plan committed (PR #49). Blocked on Section 8 confirmation gate (AWS deploy decision). |
-| TM-E4 | Active | Frontend migration to claude.design system + Vercel deploy. Spec: `.claude/specs/TM-E4-spec.md`. Phases 1–6, stacked PRs. Phase 1 (tokens + assets + fonts) in progress. |
+| TM-E4 | Active | Frontend migration to claude.design system + Vercel deploy. Spec: `.claude/specs/TM-E4-spec.md`. Phases 1–6 stacked PRs. Phase 1 ✅ #56, Phase 2 ✅ #57, Phase 3 ✅ #58, Phase 4 ✅ #59, Phase 5 ✅ #60. Phase 6 (verification + Vercel deploy) pending. |

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 .superpowers/
+.vscode/
 
 # dbt
 dbt/target/


### PR DESCRIPTION
## Summary
- Refreshes `.claude/current-wp.md` so the TM-E4 row reflects the merged stack — Phase 1 (#56) → Phase 5 (#60) — and pins Phase 6 (verification + Vercel deploy) as the only remaining surface.
- Adds `.vscode/` to `.gitignore` so per-user editor workspace settings stop appearing as untracked between sessions.

Cleanup commit only — no code changes, no test surface.

## Test plan
- [x] `git diff --cached` shows only the two intended changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal work package status documentation.
  * Updated development environment configuration to exclude editor settings from version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/61)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->