### PR TITLE
fix(web): stretch conversation pane height

### DIFF
--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -53,13 +53,14 @@
   flex-direction: column;
   gap: var(--space-4);
   min-width: 0;
+  min-height: 0;
 }
 
 .tfl-right-col .tfl-chat-stack {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  flex: 1 1 auto;
+  flex: 1 1 0;
   min-height: 0;
 }
 .tfl-right-col .tfl-chat-stack .tfl-chat-card { flex: 1 1 auto; min-height: 0; }

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -59,6 +59,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+  flex: 1 1 auto;
   min-height: 0;
 }
 .tfl-right-col .tfl-chat-stack .tfl-chat-card { flex: 1 1 auto; min-height: 0; }
@@ -159,7 +160,7 @@
   padding: var(--space-4) var(--space-5) var(--space-7);
   display: grid; grid-template-columns: 1fr 1fr;
   gap: var(--space-4);
-  align-items: start;
+  align-items: stretch;
 }
 
 .tfl-card {


### PR DESCRIPTION
Right column now stretches alongside left column (align-items: stretch on .tfl-grid) and .tfl-chat-stack claims remaining vertical space (flex: 1 1 auto). Transcript card grows; dark composer stays compact. Matches design canvas reference.