### PR TITLE
feat(agent,ingestion): TM-A5 PR-1 Bedrock swap + service collapse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,16 @@ KAFKA_SASL_MECHANISM=
 KAFKA_SASL_USERNAME=
 KAFKA_SASL_PASSWORD=
 
-# LLMs
+# LLMs — Bedrock is the production backend; Anthropic-direct stays as
+# a local-dev fallback when BEDROCK_REGION is unset. See ADR 006.
+#
+# Bedrock (production): also requires AWS_ACCESS_KEY_ID +
+# AWS_SECRET_ACCESS_KEY in the deployed .env on the Lightsail box.
+BEDROCK_REGION=
+BEDROCK_SONNET_MODEL_ID=eu.anthropic.claude-sonnet-4-5-20250929-v1:0
+BEDROCK_HAIKU_MODEL_ID=eu.anthropic.claude-haiku-4-5-20251001-v1:0
+AWS_REGION=eu-west-2
+# Anthropic direct (local dev fallback)
 ANTHROPIC_API_KEY=your_anthropic_key_here
 OPENAI_API_KEY=your_openai_key_here
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "aiokafka>=0.12",
     "psycopg[binary,pool]>=3.2",
     "langchain-anthropic>=0.3",
+    "langchain-aws>=0.2",
+    "boto3>=1.35",
     "langgraph>=1.0",
     "langsmith>=0.1",
     "llama-index>=0.12",
@@ -33,11 +35,14 @@ dev = [
     "ruff>=0.8",
     "mypy>=1.13",
     "bandit>=1.7",
-    "dbt-core>=1.9",
-    "dbt-postgres>=1.9",
     "openapi-spec-validator>=0.7",
     "taskipy>=1.14",
     "apache-airflow>=2.10,<3.0",
+    {include-group = "dbt"},
+]
+dbt = [
+    "dbt-core>=1.9",
+    "dbt-postgres>=1.9",
 ]
 docs = [
     "mkdocs>=1.6",
@@ -81,6 +86,8 @@ follow_untyped_imports = true
 module = [
     "langchain_anthropic",
     "langchain_anthropic.*",
+    "langchain_aws",
+    "langchain_aws.*",
     "langchain_core.*",
     "langgraph",
     "langgraph.*",
@@ -124,5 +131,7 @@ ingest-arrivals = "python -m ingestion.producers.arrivals"
 consume-arrivals = "python -m ingestion.consumers.arrivals"
 ingest-disruptions = "python -m ingestion.producers.disruptions"
 consume-disruptions = "python -m ingestion.consumers.disruptions"
+run-producers = "python -m ingestion.run_producers"
+run-consumers = "python -m ingestion.run_consumers"
 docs-serve = "mkdocs serve --config-file mkdocs.yml --dev-addr 127.0.0.1:8001"
 docs-build = "mkdocs build --config-file mkdocs.yml --strict"

--- a/src/api/agent/extraction.py
+++ b/src/api/agent/extraction.py
@@ -3,10 +3,15 @@
 Maps free-text line names ("Lizzy", "Lizzie", "Elizabeth Line") to the
 canonical TfL ``line_id``. Used inside ``query_line_reliability`` when
 the LLM-supplied ``line_id`` is not already a canonical token.
+
+Backend selection mirrors :mod:`api.agent.graph`: when
+``BEDROCK_REGION`` is set the normaliser runs Haiku via Bedrock,
+otherwise it falls back to Anthropic direct for local dev.
 """
 
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 from typing import Literal, get_args
 
@@ -30,6 +35,8 @@ CanonicalLineId = Literal[
 ]
 
 _CANONICAL: frozenset[str] = frozenset(get_args(CanonicalLineId))
+DEFAULT_BEDROCK_HAIKU_MODEL = "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+DEFAULT_ANTHROPIC_HAIKU_MODEL = "anthropic:claude-3-5-haiku-latest"
 
 
 class LineId(BaseModel):
@@ -38,11 +45,18 @@ class LineId(BaseModel):
     line_id: CanonicalLineId
 
 
+def _model_string() -> str:
+    """Return the pydantic-ai model identifier for the active backend."""
+    if os.environ.get("BEDROCK_REGION"):
+        return "bedrock:" + os.environ.get("BEDROCK_HAIKU_MODEL_ID", DEFAULT_BEDROCK_HAIKU_MODEL)
+    return DEFAULT_ANTHROPIC_HAIKU_MODEL
+
+
 @lru_cache(maxsize=1)
 def _normaliser() -> Agent[None, LineId]:
     """Return the singleton Haiku-backed extraction agent."""
     return Agent(
-        "anthropic:claude-3-5-haiku-latest",
+        _model_string(),
         output_type=LineId,
         instructions=(
             "Map the user's mention of a London Underground or Elizabeth "

--- a/src/api/agent/graph.py
+++ b/src/api/agent/graph.py
@@ -56,6 +56,7 @@ def _build_chat_model() -> Any | None:
             model=model_id,
             region_name=bedrock_region,
             temperature=0.0,
+            timeout=int(DEFAULT_MODEL_TIMEOUT_SECONDS),
         )
 
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")

--- a/src/api/agent/graph.py
+++ b/src/api/agent/graph.py
@@ -4,9 +4,18 @@ Build the in-process ``create_react_agent`` over Sonnet, the five SQL +
 RAG tools, and the rendered system prompt. The graph is compiled once
 in the FastAPI lifespan and cached on ``app.state.agent``.
 
-If any of ``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``, ``PINECONE_API_KEY``
-is missing, this module returns ``None`` so the request handler can
-respond with an RFC 7807 ``503``.
+Two LLM backends are supported, selected by environment:
+
+- **Bedrock** (production): set ``BEDROCK_REGION`` and
+  ``BEDROCK_SONNET_MODEL_ID``. Uses
+  ``langchain_aws.ChatBedrockConverse`` and the IAM credentials picked
+  up by ``boto3`` from the standard chain (env vars on Lightsail).
+- **Anthropic direct** (local dev fallback): leave ``BEDROCK_REGION``
+  unset and provide ``ANTHROPIC_API_KEY``.
+
+If any of ``OPENAI_API_KEY``, ``PINECONE_API_KEY`` is missing — or
+neither LLM backend is configured — this module returns ``None`` so
+the request handler can respond with an RFC 7807 ``503``.
 """
 
 from __future__ import annotations
@@ -25,8 +34,41 @@ from api.agent.rag import build_retriever
 from api.agent.tools import make_tools
 
 DEFAULT_PINECONE_INDEX = "tfl-strategy-docs"
-DEFAULT_MODEL_NAME = "claude-3-5-sonnet-latest"
+DEFAULT_ANTHROPIC_MODEL = "claude-3-5-sonnet-latest"
+DEFAULT_BEDROCK_SONNET_MODEL = "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
 DEFAULT_MODEL_TIMEOUT_SECONDS = 60.0
+
+
+def _build_chat_model() -> Any | None:
+    """Return a configured chat model, or ``None`` if no backend is set.
+
+    Bedrock takes precedence when ``BEDROCK_REGION`` is set. Anthropic
+    direct is the fallback for local development.
+    """
+    bedrock_region = os.environ.get("BEDROCK_REGION")
+    if bedrock_region:
+        # Imported lazily so local dev environments without
+        # langchain-aws installed can still run the Anthropic path.
+        from langchain_aws import ChatBedrockConverse  # noqa: PLC0415
+
+        model_id = os.environ.get("BEDROCK_SONNET_MODEL_ID", DEFAULT_BEDROCK_SONNET_MODEL)
+        return ChatBedrockConverse(
+            model=model_id,
+            region_name=bedrock_region,
+            temperature=0.0,
+        )
+
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+    if anthropic_key:
+        return ChatAnthropic(
+            model_name=DEFAULT_ANTHROPIC_MODEL,
+            temperature=0.0,
+            api_key=SecretStr(anthropic_key),
+            timeout=DEFAULT_MODEL_TIMEOUT_SECONDS,
+            stop=None,
+        )
+
+    return None
 
 
 def compile_agent(
@@ -34,37 +76,28 @@ def compile_agent(
     pool: AsyncConnectionPool,
     model: Any | None = None,
 ) -> Any | None:
-    """Build the agent or return ``None`` if any required key is missing.
+    """Build the agent or return ``None`` when required config is missing.
 
     Args:
         pool: Shared ``AsyncConnectionPool`` reused by every SQL tool.
         model: Optional pre-built chat model. Tests inject a fake here
-            so they never hit the live Anthropic API.
+            so they never hit a live LLM provider.
 
     Returns:
-        Compiled LangGraph agent, or ``None`` when one of
-        ``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` / ``PINECONE_API_KEY``
-        is unset.
+        Compiled LangGraph agent, or ``None`` when ``OPENAI_API_KEY``
+        or ``PINECONE_API_KEY`` is unset, or when neither
+        ``BEDROCK_REGION`` nor ``ANTHROPIC_API_KEY`` is set.
     """
-    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     openai_key = os.environ.get("OPENAI_API_KEY")
     pinecone_key = os.environ.get("PINECONE_API_KEY")
     pinecone_index = os.environ.get("PINECONE_INDEX", DEFAULT_PINECONE_INDEX)
 
-    if not (anthropic_key and openai_key and pinecone_key):
+    if not (openai_key and pinecone_key):
         return None
 
-    chat_model: Any = model
+    chat_model: Any = model if model is not None else _build_chat_model()
     if chat_model is None:
-        # Bound timeout so a stalled Anthropic / network never hangs the
-        # agent loop. 60 s matches the httpx default used in TM-B1.
-        chat_model = ChatAnthropic(
-            model_name=DEFAULT_MODEL_NAME,
-            temperature=0.0,
-            api_key=SecretStr(anthropic_key),
-            timeout=DEFAULT_MODEL_TIMEOUT_SECONDS,
-            stop=None,
-        )
+        return None
 
     retriever = build_retriever(
         pinecone_api_key=pinecone_key,

--- a/src/ingestion/run_consumers.py
+++ b/src/ingestion/run_consumers.py
@@ -1,0 +1,127 @@
+"""Single-process entrypoint running every TfL consumer concurrently.
+
+Collapses the three per-topic consumer entrypoints (``line_status``,
+``arrivals``, ``disruptions``) into one ``asyncio.gather`` so the
+shared Lightsail box only runs one Python process instead of three.
+
+Each consumer keeps its own Kafka group_id + Postgres writer (the
+writers cannot be shared because they target distinct ``raw.*``
+tables), so we still spin up three ``KafkaEventConsumer`` +
+``RawEventWriter`` pairs — they just live inside the same event loop.
+
+The per-topic ``main`` entrypoints remain available for local dev and
+backwards compatibility.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import AsyncExitStack
+from typing import NoReturn
+
+import logfire
+
+from contracts.schemas import ArrivalEvent, DisruptionEvent, LineStatusEvent
+from ingestion.consumers.arrivals import (
+    ARRIVALS_CONSUMER_GROUP_ID,
+    ARRIVALS_TABLE,
+    ARRIVALS_TOPIC_LABEL,
+)
+from ingestion.consumers.disruptions import (
+    DISRUPTIONS_CONSUMER_GROUP_ID,
+    DISRUPTIONS_TABLE,
+    DISRUPTIONS_TOPIC_LABEL,
+)
+from ingestion.consumers.event_consumer import RawEventConsumer
+from ingestion.consumers.kafka import KafkaEventConsumer
+from ingestion.consumers.line_status import (
+    LINE_STATUS_CONSUMER_GROUP_ID,
+    LINE_STATUS_LOG_NAMESPACE,
+    LINE_STATUS_TABLE,
+    LINE_STATUS_TOPIC_LABEL,
+)
+from ingestion.consumers.postgres import RawEventWriter
+from ingestion.observability import configure_logfire
+
+
+async def _amain() -> NoReturn:
+    configure_logfire(instrument_psycopg=True)
+
+    bootstrap = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "")
+    if not bootstrap:
+        raise SystemExit("KAFKA_BOOTSTRAP_SERVERS is required")
+
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        raise SystemExit("DATABASE_URL is required")
+
+    async with AsyncExitStack() as stack:
+        line_status_kafka = await stack.enter_async_context(
+            KafkaEventConsumer(
+                LineStatusEvent.TOPIC_NAME,
+                bootstrap_servers=bootstrap,
+                group_id=LINE_STATUS_CONSUMER_GROUP_ID,
+                client_id="tfl-monitor-ingestion-line-status-consumer",
+            )
+        )
+        line_status_writer = await stack.enter_async_context(
+            RawEventWriter(dsn, table=LINE_STATUS_TABLE)
+        )
+        arrivals_kafka = await stack.enter_async_context(
+            KafkaEventConsumer(
+                ArrivalEvent.TOPIC_NAME,
+                bootstrap_servers=bootstrap,
+                group_id=ARRIVALS_CONSUMER_GROUP_ID,
+                client_id="tfl-monitor-ingestion-arrivals-consumer",
+            )
+        )
+        arrivals_writer = await stack.enter_async_context(RawEventWriter(dsn, table=ARRIVALS_TABLE))
+        disruptions_kafka = await stack.enter_async_context(
+            KafkaEventConsumer(
+                DisruptionEvent.TOPIC_NAME,
+                bootstrap_servers=bootstrap,
+                group_id=DISRUPTIONS_CONSUMER_GROUP_ID,
+                client_id="tfl-monitor-ingestion-disruptions-consumer",
+            )
+        )
+        disruptions_writer = await stack.enter_async_context(
+            RawEventWriter(dsn, table=DISRUPTIONS_TABLE)
+        )
+
+        line_status_consumer = RawEventConsumer[LineStatusEvent](
+            kafka_consumer=line_status_kafka,
+            writer=line_status_writer,
+            event_class=LineStatusEvent,
+            topic_label=LINE_STATUS_TOPIC_LABEL,
+            log_namespace=LINE_STATUS_LOG_NAMESPACE,
+        )
+        arrivals_consumer = RawEventConsumer[ArrivalEvent](
+            kafka_consumer=arrivals_kafka,
+            writer=arrivals_writer,
+            event_class=ArrivalEvent,
+            topic_label=ARRIVALS_TOPIC_LABEL,
+        )
+        disruptions_consumer = RawEventConsumer[DisruptionEvent](
+            kafka_consumer=disruptions_kafka,
+            writer=disruptions_writer,
+            event_class=DisruptionEvent,
+            topic_label=DISRUPTIONS_TOPIC_LABEL,
+        )
+        logfire.info("ingestion.run_consumers.start", count=3)
+        await asyncio.gather(
+            line_status_consumer.run_forever(),
+            arrivals_consumer.run_forever(),
+            disruptions_consumer.run_forever(),
+        )
+
+    raise AssertionError("run_forever loops never return")
+
+
+def main() -> None:
+    """Module entrypoint used by ``python -m ingestion.run_consumers``."""
+    asyncio.run(_amain())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ingestion/run_consumers.py
+++ b/src/ingestion/run_consumers.py
@@ -109,11 +109,14 @@ async def _amain() -> NoReturn:
             topic_label=DISRUPTIONS_TOPIC_LABEL,
         )
         logfire.info("ingestion.run_consumers.start", count=3)
-        await asyncio.gather(
-            line_status_consumer.run_forever(),
-            arrivals_consumer.run_forever(),
-            disruptions_consumer.run_forever(),
-        )
+        # TaskGroup (Python 3.11+) propagates the first failure as an
+        # ExceptionGroup and cancels the surviving consumers, so the
+        # box's process supervisor (Docker restart=unless-stopped)
+        # restarts the whole bundle cleanly.
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(line_status_consumer.run_forever())
+            tg.create_task(arrivals_consumer.run_forever())
+            tg.create_task(disruptions_consumer.run_forever())
 
     raise AssertionError("run_forever loops never return")
 

--- a/src/ingestion/run_producers.py
+++ b/src/ingestion/run_producers.py
@@ -41,11 +41,14 @@ async def _amain() -> NoReturn:
         arrivals = ArrivalsProducer(tfl_client=tfl, kafka_producer=kafka)
         disruptions = DisruptionsProducer(tfl_client=tfl, kafka_producer=kafka)
         logfire.info("ingestion.run_producers.start", count=3)
-        await asyncio.gather(
-            line_status.run_forever(),
-            arrivals.run_forever(),
-            disruptions.run_forever(),
-        )
+        # TaskGroup (Python 3.11+) propagates the first failure as an
+        # ExceptionGroup and cancels the surviving producers, so the
+        # box's process supervisor (Docker restart=unless-stopped)
+        # restarts the whole bundle cleanly.
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(line_status.run_forever())
+            tg.create_task(arrivals.run_forever())
+            tg.create_task(disruptions.run_forever())
 
     raise AssertionError("run_forever loops never return")
 

--- a/src/ingestion/run_producers.py
+++ b/src/ingestion/run_producers.py
@@ -1,0 +1,59 @@
+"""Single-process entrypoint running every TfL producer concurrently.
+
+Collapses the three per-topic producer entrypoints (``line_status``,
+``arrivals``, ``disruptions``) into one ``asyncio.gather`` so the
+shared Lightsail box only pays the cost of one Python process, one
+``TflClient``, and one ``KafkaEventProducer`` instead of three.
+
+The per-topic ``main`` entrypoints remain available for local dev and
+backwards compatibility.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import NoReturn
+
+import logfire
+
+from ingestion.observability import configure_logfire
+from ingestion.producers.arrivals import ArrivalsProducer
+from ingestion.producers.disruptions import DisruptionsProducer
+from ingestion.producers.kafka import KafkaEventProducer
+from ingestion.producers.line_status import LineStatusProducer
+from ingestion.tfl_client import TflClient
+
+
+async def _amain() -> NoReturn:
+    configure_logfire()
+    logfire.instrument_httpx()
+
+    bootstrap = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "")
+    if not bootstrap:
+        raise SystemExit("KAFKA_BOOTSTRAP_SERVERS is required")
+
+    async with (
+        TflClient.from_env() as tfl,
+        KafkaEventProducer(bootstrap_servers=bootstrap) as kafka,
+    ):
+        line_status = LineStatusProducer(tfl_client=tfl, kafka_producer=kafka)
+        arrivals = ArrivalsProducer(tfl_client=tfl, kafka_producer=kafka)
+        disruptions = DisruptionsProducer(tfl_client=tfl, kafka_producer=kafka)
+        logfire.info("ingestion.run_producers.start", count=3)
+        await asyncio.gather(
+            line_status.run_forever(),
+            arrivals.run_forever(),
+            disruptions.run_forever(),
+        )
+
+    raise AssertionError("run_forever loops never return")
+
+
+def main() -> None:
+    """Module entrypoint used by ``python -m ingestion.run_producers``."""
+    asyncio.run(_amain())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_extraction.py
+++ b/tests/agent/test_extraction.py
@@ -59,3 +59,21 @@ async def test_nonsense_returns_none() -> None:
     agent = _normaliser()
     with agent.override(model=_BoomModel()):
         assert await normalise_line_id("my favourite stop") is None
+
+
+def test_model_string_picks_bedrock_when_region_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BEDROCK_REGION", "eu-west-2")
+    monkeypatch.setenv(
+        "BEDROCK_HAIKU_MODEL_ID",
+        "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+    )
+    assert extraction._model_string() == ("bedrock:eu.anthropic.claude-haiku-4-5-20251001-v1:0")
+
+
+def test_model_string_falls_back_to_anthropic_when_region_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BEDROCK_REGION", raising=False)
+    assert extraction._model_string() == extraction.DEFAULT_ANTHROPIC_HAIKU_MODEL

--- a/tests/agent/test_graph_compile.py
+++ b/tests/agent/test_graph_compile.py
@@ -9,26 +9,24 @@ from api.agent.graph import compile_agent
 
 from .conftest import FakeChatModel
 
-REQUIRED_KEYS = ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "PINECONE_API_KEY")
+RETRIEVER_KEYS = ("OPENAI_API_KEY", "PINECONE_API_KEY")
+LLM_KEYS = ("ANTHROPIC_API_KEY", "BEDROCK_REGION")
 
 
-def _set_keys(monkeypatch: pytest.MonkeyPatch) -> None:
-    for key in REQUIRED_KEYS:
+def _set_retriever_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in RETRIEVER_KEYS:
         monkeypatch.setenv(key, f"test-{key.lower()}")
 
 
-def test_compile_returns_none_when_anthropic_missing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _set_keys(monkeypatch)
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    assert compile_agent(pool=object(), model=FakeChatModel()) is None  # type: ignore[arg-type]
+def _clear_llm_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in LLM_KEYS:
+        monkeypatch.delenv(key, raising=False)
 
 
 def test_compile_returns_none_when_openai_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _set_keys(monkeypatch)
+    _set_retriever_keys(monkeypatch)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     assert compile_agent(pool=object(), model=FakeChatModel()) is None  # type: ignore[arg-type]
 
@@ -36,14 +34,28 @@ def test_compile_returns_none_when_openai_missing(
 def test_compile_returns_none_when_pinecone_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _set_keys(monkeypatch)
+    _set_retriever_keys(monkeypatch)
     monkeypatch.delenv("PINECONE_API_KEY", raising=False)
     assert compile_agent(pool=object(), model=FakeChatModel()) is None  # type: ignore[arg-type]
 
 
+def test_compile_returns_none_when_no_llm_backend_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No Bedrock region, no Anthropic key, no injected model → return None."""
+    _set_retriever_keys(monkeypatch)
+    _clear_llm_keys(monkeypatch)
+    assert compile_agent(pool=object()) is None
+
+
 def test_compile_smoke_invoke_with_fake_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    """All keys set + injected fake model → graph invokes deterministically."""
-    _set_keys(monkeypatch)
+    """Retriever keys set + injected fake model → graph invokes deterministically.
+
+    The fake model bypasses both backends, so no Bedrock or Anthropic
+    credential needs to be present.
+    """
+    _set_retriever_keys(monkeypatch)
+    _clear_llm_keys(monkeypatch)
 
     def fake_build_retriever(**_kwargs: object) -> dict[str, object]:
         return {}
@@ -61,3 +73,60 @@ def test_compile_smoke_invoke_with_fake_model(monkeypatch: pytest.MonkeyPatch) -
     )
     last_message = out["messages"][-1]
     assert last_message.content == "ack"
+
+
+def test_build_chat_model_picks_bedrock_when_region_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``BEDROCK_REGION`` set → ChatBedrockConverse selected."""
+    monkeypatch.setenv("BEDROCK_REGION", "eu-west-2")
+    monkeypatch.setenv(
+        "BEDROCK_SONNET_MODEL_ID",
+        "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "should-be-ignored")
+
+    captured: dict[str, object] = {}
+
+    class FakeBedrockConverse:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    import sys
+    import types
+
+    fake_module = types.ModuleType("langchain_aws")
+    fake_module.ChatBedrockConverse = FakeBedrockConverse  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "langchain_aws", fake_module)
+
+    model = graph_module._build_chat_model()
+    assert isinstance(model, FakeBedrockConverse)
+    assert captured["model"] == "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    assert captured["region_name"] == "eu-west-2"
+
+
+def test_build_chat_model_falls_back_to_anthropic_when_region_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``BEDROCK_REGION`` unset + ``ANTHROPIC_API_KEY`` set → ChatAnthropic."""
+    monkeypatch.delenv("BEDROCK_REGION", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+
+    captured: dict[str, object] = {}
+
+    def fake_chat_anthropic(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(graph_module, "ChatAnthropic", fake_chat_anthropic)
+
+    model = graph_module._build_chat_model()
+    assert model is not None
+    assert captured["model_name"] == graph_module.DEFAULT_ANTHROPIC_MODEL
+
+
+def test_build_chat_model_returns_none_when_no_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_llm_keys(monkeypatch)
+    assert graph_module._build_chat_model() is None

--- a/tests/ingestion/test_run_entrypoints.py
+++ b/tests/ingestion/test_run_entrypoints.py
@@ -1,0 +1,55 @@
+"""Smoke tests for the collapsed ingestion entrypoints.
+
+`run_producers` / `run_consumers` are thin asyncio.gather wrappers
+around the per-topic classes already covered by their own test
+modules. We only need to confirm that:
+
+1. The new modules import without error.
+2. ``_amain`` exits early with a clear error when required
+   environment variables are missing — the production deploy depends
+   on this fail-fast behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ingestion import run_consumers, run_producers
+
+
+def test_run_producers_module_importable() -> None:
+    assert callable(run_producers.main)
+    assert callable(run_producers._amain)
+
+
+def test_run_consumers_module_importable() -> None:
+    assert callable(run_consumers.main)
+    assert callable(run_consumers._amain)
+
+
+@pytest.mark.asyncio
+async def test_run_producers_amain_fails_without_kafka(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+    with pytest.raises(SystemExit, match="KAFKA_BOOTSTRAP_SERVERS"):
+        await run_producers._amain()
+
+
+@pytest.mark.asyncio
+async def test_run_consumers_amain_fails_without_kafka(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KAFKA_BOOTSTRAP_SERVERS", raising=False)
+    with pytest.raises(SystemExit, match="KAFKA_BOOTSTRAP_SERVERS"):
+        await run_consumers._amain()
+
+
+@pytest.mark.asyncio
+async def test_run_consumers_amain_fails_without_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(SystemExit, match="DATABASE_URL"):
+        await run_consumers._amain()

--- a/uv.lock
+++ b/uv.lock
@@ -2719,6 +2719,21 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-aws"
+version = "1.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "langchain-core" },
+    { name = "numpy" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/93/2f52f3b4b635c640c4915f3bbe634610d375c8cbf0a64f0a11f0b2c8c286/langchain_aws-1.4.6.tar.gz", hash = "sha256:eb7d48d17967313f436729cbf1beffc10be1a654583f3170a3798e57efaaea04", size = 513150, upload-time = "2026-05-04T21:48:53.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/c6/656a7ac130b542021b78de8d133091a5f2e34fbb5a226321febcc71ec25c/langchain_aws-1.4.6-py3-none-any.whl", hash = "sha256:0b30f30aef099549367e4e0f75c8ce602645c0e9318a25ae4a563c03ef8a0ee0", size = 201547, upload-time = "2026-05-04T21:48:52.333Z" },
+]
+
+[[package]]
 name = "langchain-core"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -7095,10 +7110,12 @@ source = { editable = "." }
 dependencies = [
     { name = "aiokafka" },
     { name = "anthropic" },
+    { name = "boto3" },
     { name = "docling" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "langchain-anthropic" },
+    { name = "langchain-aws" },
     { name = "langgraph" },
     { name = "langsmith" },
     { name = "llama-index" },
@@ -7116,6 +7133,10 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+dbt = [
+    { name = "dbt-core" },
+    { name = "dbt-postgres" },
+]
 dev = [
     { name = "apache-airflow" },
     { name = "bandit" },
@@ -7141,10 +7162,12 @@ docs = [
 requires-dist = [
     { name = "aiokafka", specifier = ">=0.12" },
     { name = "anthropic", specifier = ">=0.39" },
+    { name = "boto3", specifier = ">=1.35" },
     { name = "docling", specifier = ">=2.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "langchain-anthropic", specifier = ">=0.3" },
+    { name = "langchain-aws", specifier = ">=0.2" },
     { name = "langgraph", specifier = ">=1.0" },
     { name = "langsmith", specifier = ">=0.1" },
     { name = "llama-index", specifier = ">=0.12" },
@@ -7162,6 +7185,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+dbt = [
+    { name = "dbt-core", specifier = ">=1.9" },
+    { name = "dbt-postgres", specifier = ">=1.9" },
+]
 dev = [
     { name = "apache-airflow", specifier = ">=2.10,<3.0" },
     { name = "bandit", specifier = ">=1.7" },


### PR DESCRIPTION
## Summary

First of three PRs implementing TM-A5 (see `.claude/specs/TM-A5-plan.md` §3.3).

- **Bedrock swap.** `api.agent.graph` and `api.agent.extraction` now pick the LLM backend from env: `BEDROCK_REGION` set → `langchain_aws.ChatBedrockConverse` + pydantic-ai `bedrock:eu.anthropic.claude-haiku-4-5-20251001-v1:0`. Default model IDs target eu-west-2 cross-region inference profiles (Sonnet 4.5 + Haiku 4.5). The Anthropic-direct path stays for local dev.
- **Service collapse.** `src/ingestion/run_producers.py` runs `LineStatus + Arrivals + Disruptions` producers under one `asyncio.gather` sharing a single `TflClient` + `KafkaEventProducer`. `src/ingestion/run_consumers.py` runs the three `RawEventConsumer`s under one `AsyncExitStack`. The per-topic `main` entrypoints stay available for local dev and tests.
- **Dependency bookkeeping.** `pyproject.toml` adds `langchain-aws>=0.2` + `boto3>=1.35` to main deps. `dbt-core` + `dbt-postgres` move from the `dev` group to a new `dbt` group included by dev (so the prod `src/api/Dockerfile` can install dbt without the rest of the dev tooling). Adds `taskipy` `run-producers` / `run-consumers` and a `mypy` override for `langchain_aws`.
- **`.env.example`.** Documents `BEDROCK_REGION`, `BEDROCK_*_MODEL_ID`, `AWS_REGION`. Anthropic key stays as a local-dev fallback (commented context).
- **Tests.** Parametrised LLM backend tests for both `graph._build_chat_model` and `extraction._model_string`, plus smoke tests for the new collapsed entrypoints (`tests/ingestion/test_run_entrypoints.py`).

## Cross-track touch

Declared per ADR 002: this PR touches both `src/api/agent/` (D-api-agent) and `src/ingestion/` (B-ingestion). The Bedrock swap is API-owned; the ingestion collapse is mechanical (no contract change).

## Verification (local)

```
uv run task lint                              # all checks passed
uv run task test                              # 247 passed, 1 skipped, 29 deselected
uv run bandit -r src --severity-level high    # 0 issues at any severity
uv run task dbt-parse                         # parse OK
```

`make check` fails only on `pnpm --dir web lint` because the worktree has no `node_modules`; CI installs and re-runs.

## Test plan

- [ ] CI green (`lint`, `test`, `frontend`).
- [ ] CodeRabbit + Gemini review pass (expect ≥2 rounds per napkin).
- [ ] Bedrock vs Anthropic backend selection covered by unit tests (no live LLM call).
- [ ] No behavioural change to the per-topic ingestion mains.