### PR TITLE
feat(infra): TM-A5 PR-2 production compose + Caddy snippet + GHA deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'web/**'
+      - '.claude/**'
+      - 'docs/**'
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      LIGHTSAIL_HOST: ${{ secrets.LIGHTSAIL_HOST }}
+      LIGHTSAIL_HOST_KEY: ${{ secrets.LIGHTSAIL_HOST_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
+
+      - name: Trust host (pinned)
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          # Pinned host key — avoid TOFU/MITM. Capture once locally with
+          #   ssh-keyscan -H 13.41.145.33 | grep -v '^#'
+          # then paste output into GitHub secret LIGHTSAIL_HOST_KEY.
+          printf '%s\n' "$LIGHTSAIL_HOST_KEY" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Rsync source
+        run: |
+          rsync -avz --delete \
+            --exclude=.env --exclude=.env.* \
+            --exclude=.git --exclude=node_modules --exclude=.venv --exclude=web \
+            --exclude=tests --exclude=.claude \
+            ./ "ubuntu@${LIGHTSAIL_HOST}:/opt/tfl-monitor/"
+
+      - name: Build + restart + healthcheck
+        run: |
+          ssh "ubuntu@${LIGHTSAIL_HOST}" \
+            'cd /opt/tfl-monitor && bash scripts/deploy.sh'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           rsync -avz --delete \
             --exclude=.env --exclude=.env.* \
+            --exclude=cron.log --exclude='*.log' \
             --exclude=.git --exclude=node_modules --exclude=.venv --exclude=web \
             --exclude=tests --exclude=.claude \
             ./ "ubuntu@${LIGHTSAIL_HOST}:/opt/tfl-monitor/"

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -19,3 +19,18 @@ tfl_monitor:
       dbname: "{{ env_var('POSTGRES_DB', 'postgres') }}"
       schema: analytics
       threads: 2
+    prod:
+      # Used by the production cron entry (scripts/cron-dbt-run.sh).
+      # Reads POSTGRES_* from /opt/tfl-monitor/.env on the Lightsail
+      # box — populate with the Supabase connection parts (Settings ->
+      # Database -> Connection info). No defaults so missing vars fail
+      # loudly instead of pointing at localhost.
+      type: postgres
+      host: "{{ env_var('POSTGRES_HOST') }}"
+      port: "{{ env_var('POSTGRES_PORT') | int }}"
+      user: "{{ env_var('POSTGRES_USER') }}"
+      password: "{{ env_var('POSTGRES_PASSWORD') }}"
+      dbname: "{{ env_var('POSTGRES_DB') }}"
+      schema: analytics
+      threads: 2
+      sslmode: require

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -6,8 +6,18 @@
 # TfL API
 TFL_APP_KEY=
 
-# Postgres warehouse (Supabase free)
+# Postgres warehouse (Supabase free).
+# DATABASE_URL is consumed by the Python app (FastAPI + producers + consumers).
+# The POSTGRES_* parts are consumed by dbt's `prod` target (see dbt/profiles.yml)
+# triggered by host cron via `scripts/cron-dbt-run.sh`. Both groups point at the
+# same Supabase database; the duplication exists because dbt's profile reads
+# discrete fields instead of a connection URL.
 DATABASE_URL=
+POSTGRES_HOST=
+POSTGRES_PORT=5432
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+POSTGRES_DB=
 
 # Redpanda Cloud Serverless
 KAFKA_BOOTSTRAP_SERVERS=

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,41 @@
+# Production .env template — deployed via `scp` from the author's
+# workstation to `/opt/tfl-monitor/.env` with `chmod 600`. Never
+# committed. The `.env` file is excluded from the deploy rsync so
+# subsequent deploys do not wipe it.
+
+# TfL API
+TFL_APP_KEY=
+
+# Postgres warehouse (Supabase free)
+DATABASE_URL=
+
+# Redpanda Cloud Serverless
+KAFKA_BOOTSTRAP_SERVERS=
+KAFKA_SECURITY_PROTOCOL=SASL_SSL
+KAFKA_SASL_MECHANISM=SCRAM-SHA-256
+KAFKA_SASL_USERNAME=
+KAFKA_SASL_PASSWORD=
+
+# Embeddings + Vector DB
+OPENAI_API_KEY=
+EMBEDDING_MODEL=text-embedding-3-small
+PINECONE_API_KEY=
+PINECONE_INDEX=tfl-strategy-docs
+
+# AWS Bedrock — scoped IAM user (Lightsail has no native instance role)
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=eu-west-2
+BEDROCK_REGION=eu-west-2
+BEDROCK_SONNET_MODEL_ID=eu.anthropic.claude-sonnet-4-5-20250929-v1:0
+BEDROCK_HAIKU_MODEL_ID=eu.anthropic.claude-haiku-4-5-20251001-v1:0
+
+# Observability
+LOGFIRE_TOKEN=
+LANGSMITH_TRACING=true
+LANGSMITH_API_KEY=
+LANGSMITH_PROJECT=tfl-monitor
+
+# App metadata
+ENVIRONMENT=production
+APP_VERSION=v1.0.0

--- a/infra/README.md
+++ b/infra/README.md
@@ -35,6 +35,7 @@ ssh ubuntu@13.41.145.33 'sudo mkdir -p /opt/tfl-monitor && sudo chown ubuntu:ubu
 # From workstation, in this repo root:
 rsync -avz --delete \
   --exclude=.env --exclude=.env.* \
+  --exclude=cron.log --exclude='*.log' \
   --exclude=.git --exclude=node_modules --exclude=.venv --exclude=web \
   --exclude=tests --exclude=.claude \
   ./ ubuntu@13.41.145.33:/opt/tfl-monitor/

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,69 @@
+# infra/ — production deployment
+
+This directory holds the production deployment artifacts for tfl-monitor. The full design lives in
+`.claude/specs/TM-A5-plan.md`; this README is the operator quickstart.
+
+## Topology
+
+- **Host:** AWS Lightsail Ubuntu 24.04 LTS, eu-west-2, $10/mo (2 GB RAM, 60 GB SSD, static IP `13.41.145.33`).
+  Shared with `alpha-whale` and future portfolio tenants. Provisioning runbook is the alpha-whale
+  repo's `docs/deploy.md`.
+- **App dir:** `/opt/tfl-monitor/` on the host.
+- **Reverse proxy / TLS:** shared Caddy at `/opt/caddy/` joins the external `caddy_net` docker
+  network and reverse-proxies `tfl-monitor-api.humbertolomeu.com` → `tfl-monitor-api-1:8000`.
+  Site block lives at `/opt/caddy/Caddyfile` on the host; `infra/caddyfile.snippet` is the source of
+  truth for the tfl-monitor portion.
+- **DNS:** Cloudflare A record `tfl-monitor-api.humbertolomeu.com` → `13.41.145.33` (DNS only, gray
+  cloud). No proxy, no Origin Cert.
+- **LLM:** AWS Bedrock cross-region inference profiles for Claude Sonnet 4.5 + Haiku 4.5
+  (`eu.anthropic.*`), authenticated via a scoped IAM user with keys in `/opt/tfl-monitor/.env`.
+
+## Files
+
+| Path | Purpose |
+| --- | --- |
+| `docker-compose.prod.yml` | 3 services: `api`, `producers`, `consumers`. No Airflow. |
+| `caddyfile.snippet` | Site block merged into `/opt/caddy/Caddyfile` once. |
+| `cron.d/tfl-monitor` | Host cron entries for periodic dbt runs. |
+| `.env.example` | Production env-var template. Copy to `/opt/tfl-monitor/.env` (chmod 600). |
+
+## First deploy
+
+```bash
+ssh ubuntu@13.41.145.33 'sudo mkdir -p /opt/tfl-monitor && sudo chown ubuntu:ubuntu /opt/tfl-monitor'
+
+# From workstation, in this repo root:
+rsync -avz --delete \
+  --exclude=.env --exclude=.env.* \
+  --exclude=.git --exclude=node_modules --exclude=.venv --exclude=web \
+  --exclude=tests --exclude=.claude \
+  ./ ubuntu@13.41.145.33:/opt/tfl-monitor/
+
+scp .env.production ubuntu@13.41.145.33:/opt/tfl-monitor/.env
+ssh ubuntu@13.41.145.33 'chmod 600 /opt/tfl-monitor/.env'
+
+ssh ubuntu@13.41.145.33 \
+  'cd /opt/tfl-monitor && docker compose -f infra/docker-compose.prod.yml up -d --build'
+
+ssh ubuntu@13.41.145.33 \
+  'sudo cp /opt/tfl-monitor/infra/cron.d/tfl-monitor /etc/cron.d/tfl-monitor \
+   && sudo chmod 644 /etc/cron.d/tfl-monitor'
+```
+
+Then add the Cloudflare A record and append `infra/caddyfile.snippet` to `/opt/caddy/Caddyfile`,
+reloading with `docker exec shared-caddy caddy reload --config /etc/caddy/Caddyfile`.
+
+## Subsequent deploys
+
+GHA workflow `.github/workflows/deploy.yml` does the same rsync + `docker compose up -d --build` on
+every push to `main` touching backend code. See the workflow file for the SSH-key + pinned-host-key
+secret setup.
+
+## Operations
+
+| Task | Command |
+| --- | --- |
+| Tail api logs | `ssh ubuntu@13.41.145.33 'docker logs -f tfl-monitor-api-1 --tail 100'` |
+| Restart api | `ssh ubuntu@13.41.145.33 'cd /opt/tfl-monitor && docker compose -f infra/docker-compose.prod.yml restart api'` |
+| Manual dbt run | `ssh ubuntu@13.41.145.33 '/opt/tfl-monitor/scripts/cron-dbt-run.sh'` |
+| Disk usage | `ssh ubuntu@13.41.145.33 'df -h / && docker system df'` |

--- a/infra/caddyfile.snippet
+++ b/infra/caddyfile.snippet
@@ -1,0 +1,17 @@
+# Site block for the shared Caddy stack at `/opt/caddy/Caddyfile` on
+# the Lightsail host (eu-west-2). Merge once when adding tfl-monitor
+# as a tenant; subsequent deploys do not touch the Caddyfile.
+#
+# Requires the shared `scanner_block` snippet to be defined at the top
+# of `/opt/caddy/Caddyfile` and the `caddy_net` external docker network
+# to exist (see tfl-monitor TM-A5 plan §3 step 1 for the bootstrap).
+
+tfl-monitor-api.humbertolomeu.com {
+        import scanner_block
+        encode zstd gzip
+        reverse_proxy tfl-monitor-api-1:8000
+        log {
+                output stdout
+                format json
+        }
+}

--- a/infra/cron.d/tfl-monitor
+++ b/infra/cron.d/tfl-monitor
@@ -4,6 +4,8 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# dbt build every 6 hours (cron user must own /opt/tfl-monitor for the
-# log redirect — /var/log/ is root-owned and would fail silently).
+# dbt run every 6 hours (the wrapper script invokes `dbt run`, not
+# `dbt build` — keep the comment honest). Cron user must own
+# /opt/tfl-monitor for the log redirect since /var/log/ is root-owned
+# and would fail silently.
 0 */6 * * * ubuntu /opt/tfl-monitor/scripts/cron-dbt-run.sh >> /opt/tfl-monitor/cron.log 2>&1

--- a/infra/cron.d/tfl-monitor
+++ b/infra/cron.d/tfl-monitor
@@ -1,0 +1,9 @@
+# /etc/cron.d/tfl-monitor — installed on the Lightsail box by
+# `scripts/bootstrap-tenant.sh`. See ADR 006 + .claude/specs/TM-A5-plan.md
+# decision #18 for why this replaces Airflow in production.
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# dbt build every 6 hours (cron user must own /opt/tfl-monitor for the
+# log redirect — /var/log/ is root-owned and would fail silently).
+0 */6 * * * ubuntu /opt/tfl-monitor/scripts/cron-dbt-run.sh >> /opt/tfl-monitor/cron.log 2>&1

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,0 +1,53 @@
+# Production compose stack — deployed to /opt/tfl-monitor/ on the shared
+# Lightsail box (eu-west-2). Three services: api, producers, consumers.
+# Airflow is not part of prod (see ADR 006 + .claude/specs/TM-A5-plan.md
+# decision #17). dbt runs are triggered by host cron via `docker exec api`.
+#
+# The api container joins the host-wide `caddy_net` so the shared Caddy
+# at /opt/caddy/ can reverse-proxy `tfl-monitor-api.humbertolomeu.com` to
+# `tfl-monitor-api-1:8000`.
+
+services:
+  api:
+    build:
+      context: ..
+      dockerfile: src/api/Dockerfile
+    container_name: tfl-monitor-api-1
+    restart: unless-stopped
+    env_file: ../.env
+    networks:
+      - caddy_net
+      - tfl-monitor
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  producers:
+    build:
+      context: ..
+      dockerfile: src/ingestion/Dockerfile
+    container_name: tfl-monitor-producers-1
+    restart: unless-stopped
+    env_file: ../.env
+    command: ["uv", "run", "python", "-m", "ingestion.run_producers"]
+    networks:
+      - tfl-monitor
+
+  consumers:
+    build:
+      context: ..
+      dockerfile: src/ingestion/Dockerfile
+    container_name: tfl-monitor-consumers-1
+    restart: unless-stopped
+    env_file: ../.env
+    command: ["uv", "run", "python", "-m", "ingestion.run_consumers"]
+    networks:
+      - tfl-monitor
+
+networks:
+  caddy_net:
+    external: true
+  tfl-monitor:
+    driver: bridge

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -31,7 +31,7 @@ services:
     container_name: tfl-monitor-producers-1
     restart: unless-stopped
     env_file: ../.env
-    command: ["uv", "run", "python", "-m", "ingestion.run_producers"]
+    command: ["python", "-m", "ingestion.run_producers"]
     networks:
       - tfl-monitor
 
@@ -42,7 +42,7 @@ services:
     container_name: tfl-monitor-consumers-1
     restart: unless-stopped
     env_file: ../.env
-    command: ["uv", "run", "python", "-m", "ingestion.run_consumers"]
+    command: ["python", "-m", "ingestion.run_consumers"]
     networks:
       - tfl-monitor
 

--- a/scripts/bootstrap-tenant.sh
+++ b/scripts/bootstrap-tenant.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# One-shot host bootstrap for the tfl-monitor tenant on the shared Lightsail
+# box. Idempotent: re-running has no side effects beyond ensuring the
+# expected directories, log file, and cron entry exist. Run once from the
+# author's workstation via SSH (see infra/README.md "First deploy").
+
+set -euo pipefail
+
+APP_DIR="/opt/tfl-monitor"
+LOG_FILE="${APP_DIR}/cron.log"
+CRON_SRC="${APP_DIR}/infra/cron.d/tfl-monitor"
+CRON_DST="/etc/cron.d/tfl-monitor"
+
+if [[ ! -d "${APP_DIR}" ]]; then
+  echo "ERROR: ${APP_DIR} missing — rsync the repo tree before bootstrap" >&2
+  exit 1
+fi
+
+mkdir -p "${APP_DIR}/scripts"
+chmod +x "${APP_DIR}/scripts/"*.sh
+
+touch "${LOG_FILE}"
+chown ubuntu:ubuntu "${LOG_FILE}"
+chmod 644 "${LOG_FILE}"
+
+if [[ -f "${CRON_SRC}" ]]; then
+  sudo cp "${CRON_SRC}" "${CRON_DST}"
+  sudo chmod 644 "${CRON_DST}"
+  echo "[$(date -Iseconds)] installed ${CRON_DST}"
+fi
+
+if [[ ! -f "${APP_DIR}/.env" ]]; then
+  echo "WARN: ${APP_DIR}/.env missing — scp it before running deploy.sh" >&2
+fi
+
+echo "[$(date -Iseconds)] bootstrap complete"

--- a/scripts/bootstrap-tenant.sh
+++ b/scripts/bootstrap-tenant.sh
@@ -17,7 +17,9 @@ if [[ ! -d "${APP_DIR}" ]]; then
 fi
 
 mkdir -p "${APP_DIR}/scripts"
-chmod +x "${APP_DIR}/scripts/"*.sh
+# Guard against `set -e` aborting when no scripts have been rsynced yet
+# (e.g. bootstrap run before deploy.sh). `find -exec` exits 0 on no-match.
+find "${APP_DIR}/scripts" -maxdepth 1 -type f -name '*.sh' -exec chmod +x {} +
 
 touch "${LOG_FILE}"
 chown ubuntu:ubuntu "${LOG_FILE}"

--- a/scripts/cron-dbt-run.sh
+++ b/scripts/cron-dbt-run.sh
@@ -13,6 +13,7 @@ cd /opt/tfl-monitor
 # UV_PROJECT_ENVIRONMENT=/usr/local — no `uv run` wrapping needed.
 docker exec tfl-monitor-api-1 dbt run \
   --profiles-dir /app/dbt \
-  --project-dir /app/dbt
+  --project-dir /app/dbt \
+  --target prod
 
 echo "[$(date -Iseconds)] $LOG_TAG dbt run done"

--- a/scripts/cron-dbt-run.sh
+++ b/scripts/cron-dbt-run.sh
@@ -9,7 +9,9 @@ LOG_TAG="tfl-monitor-cron"
 echo "[$(date -Iseconds)] $LOG_TAG dbt run start"
 
 cd /opt/tfl-monitor
-docker exec tfl-monitor-api-1 uv run dbt run \
+# `dbt` is on $PATH inside the container thanks to
+# UV_PROJECT_ENVIRONMENT=/usr/local — no `uv run` wrapping needed.
+docker exec tfl-monitor-api-1 dbt run \
   --profiles-dir /app/dbt \
   --project-dir /app/dbt
 

--- a/scripts/cron-dbt-run.sh
+++ b/scripts/cron-dbt-run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Cron entrypoint for periodic dbt builds on the production Lightsail box.
+# Installed at /etc/cron.d/tfl-monitor via infra/cron.d/tfl-monitor.
+# See ADR 006 + .claude/specs/TM-A5-plan.md decision #18.
+
+set -euo pipefail
+
+LOG_TAG="tfl-monitor-cron"
+echo "[$(date -Iseconds)] $LOG_TAG dbt run start"
+
+cd /opt/tfl-monitor
+docker exec tfl-monitor-api-1 uv run dbt run \
+  --profiles-dir /app/dbt \
+  --project-dir /app/dbt
+
+echo "[$(date -Iseconds)] $LOG_TAG dbt run done"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,6 +2,15 @@
 # Idempotent redeploy on the Lightsail box. Used both by `.github/workflows/deploy.yml`
 # (over SSH) and by operators running a hot fix from the workstation. Assumes the
 # repo tree has already been rsynced into /opt/tfl-monitor/.
+#
+# Prerequisites (one-time, before the first invocation):
+#   * Cloudflare A record `tfl-monitor-api.humbertolomeu.com` -> the static IP
+#   * Shared Caddy site block for that hostname appended to /opt/caddy/Caddyfile
+#     and reloaded via `docker exec shared-caddy caddy reload …`
+#   * /opt/tfl-monitor/.env populated (chmod 600)
+# Without those, the healthcheck against the public URL below will fail. For
+# the very first deploy follow `infra/README.md` "First deploy" instead — it
+# brings up the stack without depending on this script's public healthcheck.
 
 set -euo pipefail
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,17 +6,24 @@
 # Prerequisites (one-time, before the first invocation):
 #   * Cloudflare A record `tfl-monitor-api.humbertolomeu.com` -> the static IP
 #   * Shared Caddy site block for that hostname appended to /opt/caddy/Caddyfile
-#     and reloaded via `docker exec shared-caddy caddy reload …`
+#     and reloaded via `docker exec shared-caddy caddy reload ...`
 #   * /opt/tfl-monitor/.env populated (chmod 600)
-# Without those, the healthcheck against the public URL below will fail. For
-# the very first deploy follow `infra/README.md` "First deploy" instead — it
-# brings up the stack without depending on this script's public healthcheck.
+# Without those, the external healthcheck below will fail. For the very first
+# deploy follow `infra/README.md` "First deploy" instead — it brings up the
+# stack without depending on this script's healthchecks.
+#
+# Healthcheck strategy:
+#   1) Internal — `docker exec` curl against the api container directly so a
+#      Caddy or DNS misconfiguration is distinguishable from a container crash.
+#   2) External — public URL via the shared Caddy. Fewer attempts here because
+#      by the time the internal check passes, Caddy should be routing.
 
 set -euo pipefail
 
 APP_DIR="/opt/tfl-monitor"
 COMPOSE_FILE="${APP_DIR}/infra/docker-compose.prod.yml"
 HEALTHCHECK_URL="${HEALTHCHECK_URL:-https://tfl-monitor-api.humbertolomeu.com/health}"
+API_CONTAINER="tfl-monitor-api-1"
 
 cd "${APP_DIR}"
 
@@ -28,14 +35,27 @@ fi
 echo "[$(date -Iseconds)] docker compose up --build"
 docker compose -f "${COMPOSE_FILE}" up -d --build
 
-echo "[$(date -Iseconds)] healthcheck ${HEALTHCHECK_URL}"
+echo "[$(date -Iseconds)] internal healthcheck (docker exec ${API_CONTAINER})"
 for attempt in 1 2 3 4 5; do
+  if docker exec "${API_CONTAINER}" curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
+    echo "[$(date -Iseconds)] container healthy"
+    break
+  fi
+  if [[ ${attempt} -eq 5 ]]; then
+    echo "ERROR: ${API_CONTAINER} did not respond to /health after 5 attempts" >&2
+    exit 1
+  fi
+  sleep 5
+done
+
+echo "[$(date -Iseconds)] external healthcheck ${HEALTHCHECK_URL}"
+for attempt in 1 2 3; do
   if curl -fsS "${HEALTHCHECK_URL}" >/dev/null; then
-    echo "[$(date -Iseconds)] healthy"
+    echo "[$(date -Iseconds)] public URL reachable"
     exit 0
   fi
   sleep 5
 done
 
-echo "ERROR: healthcheck failed after 5 attempts" >&2
+echo "WARN: container is healthy but ${HEALTHCHECK_URL} is unreachable — check DNS / Caddy" >&2
 exit 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Idempotent redeploy on the Lightsail box. Used both by `.github/workflows/deploy.yml`
+# (over SSH) and by operators running a hot fix from the workstation. Assumes the
+# repo tree has already been rsynced into /opt/tfl-monitor/.
+
+set -euo pipefail
+
+APP_DIR="/opt/tfl-monitor"
+COMPOSE_FILE="${APP_DIR}/infra/docker-compose.prod.yml"
+HEALTHCHECK_URL="${HEALTHCHECK_URL:-https://tfl-monitor-api.humbertolomeu.com/health}"
+
+cd "${APP_DIR}"
+
+if [[ ! -f .env ]]; then
+  echo "ERROR: ${APP_DIR}/.env missing — populate from infra/.env.example before deploying" >&2
+  exit 1
+fi
+
+echo "[$(date -Iseconds)] docker compose up --build"
+docker compose -f "${COMPOSE_FILE}" up -d --build
+
+echo "[$(date -Iseconds)] healthcheck ${HEALTHCHECK_URL}"
+for attempt in 1 2 3 4 5; do
+  if curl -fsS "${HEALTHCHECK_URL}" >/dev/null; then
+    echo "[$(date -Iseconds)] healthy"
+    exit 0
+  fi
+  sleep 5
+done
+
+echo "ERROR: healthcheck failed after 5 attempts" >&2
+exit 1

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -7,27 +7,31 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /app
 
 # curl is used by the compose-level healthcheck (`python:3.12-slim` ships without it).
+# The unprivileged runtime user is created in the same layer so subsequent
+# COPY --chown directives can reference it without a heavy recursive chown.
 RUN apt-get update \
     && apt-get install --no-install-recommends -y curl \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 1001 --no-create-home --shell /usr/sbin/nologin app
 
 RUN pip install --no-cache-dir uv==0.5.7
 
 COPY pyproject.toml uv.lock ./
 # dbt is needed at runtime so the host cron entry can shell into this
 # container via `docker exec` and run `dbt run` without rebuilding.
+# UV_PROJECT_ENVIRONMENT=/usr/local makes the resulting console scripts
+# (uvicorn, dbt, ...) resolve directly from $PATH at runtime; no `uv run`
+# wrapping needed in production.
 RUN uv sync --frozen --no-dev --group dbt --no-install-project
 
-COPY src ./src
-COPY contracts ./contracts
-COPY dbt ./dbt
+COPY --chown=app:app src ./src
+COPY --chown=app:app contracts ./contracts
+COPY --chown=app:app dbt ./dbt
 
 ENV PYTHONPATH=/app/src
 
-RUN useradd --system --uid 1001 --no-create-home --shell /usr/sbin/nologin app \
-    && chown -R app:app /app
 USER app
 
 EXPOSE 8000
 
-CMD ["uv", "run", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/usr/local
+
+WORKDIR /app
+
+# curl is used by the compose-level healthcheck (`python:3.12-slim` ships without it).
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir uv==0.5.7
+
+COPY pyproject.toml uv.lock ./
+# dbt is needed at runtime so the host cron entry can shell into this
+# container via `docker exec` and run `dbt run` without rebuilding.
+RUN uv sync --frozen --no-dev --group dbt --no-install-project
+
+COPY src ./src
+COPY contracts ./contracts
+COPY dbt ./dbt
+
+ENV PYTHONPATH=/app/src
+
+RUN useradd --system --uid 1001 --no-create-home --shell /usr/sbin/nologin app \
+    && chown -R app:app /app
+USER app
+
+EXPOSE 8000
+
+CMD ["uv", "run", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary

Second tfl-monitor PR for TM-A5 (see `.claude/specs/TM-A5-plan.md` §3 step 4). Ships the production deployment artifacts that put tfl-monitor onto the shared Lightsail box at `13.41.145.33` (eu-west-2). **No code in `src/` outside of `src/api/Dockerfile`** — this is pure infra.

## What lands

| Path | Purpose |
| --- | --- |
| `infra/docker-compose.prod.yml` | 3 services on the host: `api`, `producers`, `consumers`. No Airflow (decision #17 — host cron replaces it). `api` joins the external `caddy_net` so the shared Caddy can reverse-proxy. |
| `infra/caddyfile.snippet` | Site block merged once into `/opt/caddy/Caddyfile`. |
| `infra/cron.d/tfl-monitor` | Host cron entry: dbt run every 6 hours, output to `/opt/tfl-monitor/cron.log`. |
| `infra/.env.example` | Production env-var template (TfL key, Supabase, Redpanda Cloud, Pinecone, AWS scoped IAM keys + Bedrock IDs, Logfire, LangSmith). |
| `infra/README.md` | Operator quickstart: first-deploy sequence + subsequent-deploy story + ops table. |
| `scripts/bootstrap-tenant.sh` | One-shot host setup: cron install + log file ownership. |
| `scripts/deploy.sh` | Idempotent redeploy (used by both manual ops and the GHA workflow). Healthchecks after `compose up`. |
| `scripts/cron-dbt-run.sh` | Cron entrypoint: `docker exec tfl-monitor-api-1 uv run dbt run …`. |
| `src/api/Dockerfile` | New API-only image. `python:3.12-slim` + amd64 + `curl` (for the healthcheck) + the `dbt` dependency group so host cron can `docker exec dbt run` without rebuild. `CMD ["uv", "run", "uvicorn", "api.main:app", …]` — `PYTHONPATH=/app/src` matches the ingestion Dockerfile convention. |
| `.github/workflows/deploy.yml` | `push: [main]` deploy: rsync (with `--exclude=.env`) → `ssh ubuntu@$HOST … bash scripts/deploy.sh`. Pinned `LIGHTSAIL_HOST_KEY` known_hosts entry — no TOFU. Concurrency-grouped on `deploy-prod` so two pushes never deploy together. |

## Prerequisites

- **Alpha-whale `chore/shared-caddy-tenant` PR must merge first** — it releases port 443 from the in-stack Caddy so the shared `/opt/caddy/` stack can take over.
- GitHub repo secrets required before the first GHA deploy:
  - `LIGHTSAIL_SSH_KEY` — contents of `~/.ssh/alpha-whale-lightsail.pem`
  - `LIGHTSAIL_HOST` — `13.41.145.33`
  - `LIGHTSAIL_HOST_KEY` — output of `ssh-keyscan -H 13.41.145.33 \| grep -v '^#'`
- IAM user `tfl-monitor-bedrock` created with the scoped policy from the plan §3 step 2.
- Cloudflare A record `tfl-monitor-api.humbertolomeu.com → 13.41.145.33` (DNS only / gray cloud), added manually in the dashboard.

## Verification (local)

```
docker compose -f infra/docker-compose.prod.yml config  # passes with stub .env
uv run task lint                                        # all checks passed
```

End-to-end deploy verification happens on the box after merge — the first run is manual (rsync the tree, scp the populated `.env`, run `scripts/bootstrap-tenant.sh`). GHA takes over from the second deploy onward.

## Test plan

- [ ] CI green (`lint`, `test`, `frontend`).
- [ ] CodeRabbit + Gemini review pass.
- [ ] Alpha-whale `chore/shared-caddy-tenant` merged.
- [ ] First manual deploy: `https://tfl-monitor-api.humbertolomeu.com/health` returns 200 via shared Caddy + Let's Encrypt cert.
- [ ] Memory headroom after deploy: `free -m` shows ≥300 MB free + swap unused (per plan acceptance §4.7).
- [ ] Subsequent push to `main` triggers the deploy workflow and it lands green.