### PR TITLE
fix(ingestion): wire SASL/SSL config for Redpanda Cloud auth

### DIFF
--- a/src/ingestion/consumers/kafka.py
+++ b/src/ingestion/consumers/kafka.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import contextlib
 from collections.abc import AsyncIterator, Callable, Iterable
 from types import TracebackType
-from typing import Self, cast
+from typing import Any, Self, cast
 
 import logfire
 from aiokafka import AIOKafkaConsumer
@@ -46,6 +46,7 @@ class KafkaEventConsumer:
         client_id: str = _DEFAULT_CLIENT_ID,
         auto_offset_reset: str = "earliest",
         consumer_factory: Callable[..., AIOKafkaConsumer] | None = None,
+        aiokafka_extra_config: dict[str, Any] | None = None,
     ) -> None:
         if not topic:
             raise ValueError("topic must be a non-empty string")
@@ -59,6 +60,11 @@ class KafkaEventConsumer:
         self._client_id = client_id
         self._auto_offset_reset = auto_offset_reset
         self._consumer_factory = consumer_factory or AIOKafkaConsumer
+        # aiokafka_extra_config carries security_protocol / SASL / SSL
+        # kwargs (built by ingestion.kafka_config.build_aiokafka_security_config)
+        # so the same wrapper drives both the plaintext local Redpanda and
+        # the SASL_SSL Redpanda Cloud cluster without two code paths.
+        self._aiokafka_extra_config = aiokafka_extra_config or {}
         self._consumer: AIOKafkaConsumer | None = None
 
     async def __aenter__(self) -> Self:
@@ -69,6 +75,7 @@ class KafkaEventConsumer:
             group_id=self._group_id,
             auto_offset_reset=self._auto_offset_reset,
             enable_auto_commit=False,
+            **self._aiokafka_extra_config,
         )
         self._consumer = consumer
         with logfire.span("kafka.consumer.start", topic=self._topic, group_id=self._group_id):

--- a/src/ingestion/kafka_config.py
+++ b/src/ingestion/kafka_config.py
@@ -49,7 +49,10 @@ def build_aiokafka_security_config() -> dict[str, Any]:
             ``KAFKA_SASL_MECHANISM`` / ``KAFKA_SASL_USERNAME`` /
             ``KAFKA_SASL_PASSWORD`` is missing.
     """
-    protocol = os.environ.get("KAFKA_SECURITY_PROTOCOL", "").upper()
+    # `.strip()` tolerates accidental leading / trailing whitespace introduced
+    # by hand-edited `.env` files; `.upper()` lets operators set the protocol
+    # in either case without surprising the supported-set check below.
+    protocol = os.environ.get("KAFKA_SECURITY_PROTOCOL", "").strip().upper()
     if protocol in _PLAINTEXT_PROTOCOLS:
         return {}
 
@@ -65,7 +68,10 @@ def build_aiokafka_security_config() -> dict[str, Any]:
     config: dict[str, Any] = {"security_protocol": protocol}
 
     if protocol in _SASL_PROTOCOLS:
-        mechanism = os.environ.get("KAFKA_SASL_MECHANISM", "")
+        # Strip whitespace and uppercase the mechanism for the same reason as
+        # the protocol — Kafka mechanisms (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512,
+        # GSSAPI, OAUTHBEARER) are uppercase by convention.
+        mechanism = os.environ.get("KAFKA_SASL_MECHANISM", "").strip().upper()
         username = os.environ.get("KAFKA_SASL_USERNAME", "")
         password = os.environ.get("KAFKA_SASL_PASSWORD", "")
         missing = [

--- a/src/ingestion/kafka_config.py
+++ b/src/ingestion/kafka_config.py
@@ -30,6 +30,7 @@ __all__ = ["build_aiokafka_security_config"]
 _PLAINTEXT_PROTOCOLS = frozenset({"", "PLAINTEXT"})
 _SASL_PROTOCOLS = frozenset({"SASL_PLAINTEXT", "SASL_SSL"})
 _TLS_PROTOCOLS = frozenset({"SSL", "SASL_SSL"})
+_SUPPORTED_PROTOCOLS = frozenset({"PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"})
 
 
 def build_aiokafka_security_config() -> dict[str, Any]:
@@ -43,13 +44,23 @@ def build_aiokafka_security_config() -> dict[str, Any]:
         protocol uses TLS).
 
     Raises:
-        SystemExit: When ``KAFKA_SECURITY_PROTOCOL`` requests SASL but
-            any of ``KAFKA_SASL_MECHANISM`` / ``KAFKA_SASL_USERNAME`` /
+        SystemExit: When ``KAFKA_SECURITY_PROTOCOL`` is set to an
+            unsupported value, or when SASL is requested but any of
+            ``KAFKA_SASL_MECHANISM`` / ``KAFKA_SASL_USERNAME`` /
             ``KAFKA_SASL_PASSWORD`` is missing.
     """
     protocol = os.environ.get("KAFKA_SECURITY_PROTOCOL", "").upper()
     if protocol in _PLAINTEXT_PROTOCOLS:
         return {}
+
+    # Validate upfront so a typo (e.g. ``SALS_SSL``) fails with a clear
+    # configuration error rather than a generic aiokafka bootstrap failure
+    # several layers deeper.
+    if protocol not in _SUPPORTED_PROTOCOLS:
+        supported = ", ".join(sorted(_SUPPORTED_PROTOCOLS))
+        raise SystemExit(
+            f"KAFKA_SECURITY_PROTOCOL={protocol!r} is not supported; expected one of: {supported}"
+        )
 
     config: dict[str, Any] = {"security_protocol": protocol}
 

--- a/src/ingestion/kafka_config.py
+++ b/src/ingestion/kafka_config.py
@@ -1,0 +1,78 @@
+"""Build ``aiokafka`` security keyword arguments from environment variables.
+
+Reads ``KAFKA_SECURITY_PROTOCOL`` / ``KAFKA_SASL_MECHANISM`` /
+``KAFKA_SASL_USERNAME`` / ``KAFKA_SASL_PASSWORD`` and returns a dict that
+is forwarded as ``**kwargs`` to ``AIOKafkaProducer`` and
+``AIOKafkaConsumer`` constructors.
+
+Local dev (plaintext Redpanda inside ``docker-compose.yml``) keeps
+working with no extra environment configuration: when
+``KAFKA_SECURITY_PROTOCOL`` is unset or ``PLAINTEXT`` the function
+returns an empty dict so the wrappers fall back to ``aiokafka``
+defaults.
+
+Production (Redpanda Cloud Serverless, SASL/SCRAM over TLS) needs the
+full set: ``KAFKA_SECURITY_PROTOCOL=SASL_SSL`` +
+``KAFKA_SASL_MECHANISM=SCRAM-SHA-256`` + ``KAFKA_SASL_USERNAME`` +
+``KAFKA_SASL_PASSWORD``. Missing values fail loudly with
+``SystemExit`` rather than silently falling back to a plaintext
+connection that the cloud broker would reject anyway.
+"""
+
+from __future__ import annotations
+
+import os
+import ssl
+from typing import Any
+
+__all__ = ["build_aiokafka_security_config"]
+
+_PLAINTEXT_PROTOCOLS = frozenset({"", "PLAINTEXT"})
+_SASL_PROTOCOLS = frozenset({"SASL_PLAINTEXT", "SASL_SSL"})
+_TLS_PROTOCOLS = frozenset({"SSL", "SASL_SSL"})
+
+
+def build_aiokafka_security_config() -> dict[str, Any]:
+    """Return aiokafka ``security_protocol`` / SASL / SSL kwargs from env.
+
+    Returns:
+        Empty dict when ``KAFKA_SECURITY_PROTOCOL`` is unset or
+        ``PLAINTEXT``. Otherwise a dict with ``security_protocol`` plus
+        the SASL credentials (when the protocol uses SASL) and an
+        ``ssl_context`` built from the system CA bundle (when the
+        protocol uses TLS).
+
+    Raises:
+        SystemExit: When ``KAFKA_SECURITY_PROTOCOL`` requests SASL but
+            any of ``KAFKA_SASL_MECHANISM`` / ``KAFKA_SASL_USERNAME`` /
+            ``KAFKA_SASL_PASSWORD`` is missing.
+    """
+    protocol = os.environ.get("KAFKA_SECURITY_PROTOCOL", "").upper()
+    if protocol in _PLAINTEXT_PROTOCOLS:
+        return {}
+
+    config: dict[str, Any] = {"security_protocol": protocol}
+
+    if protocol in _SASL_PROTOCOLS:
+        mechanism = os.environ.get("KAFKA_SASL_MECHANISM", "")
+        username = os.environ.get("KAFKA_SASL_USERNAME", "")
+        password = os.environ.get("KAFKA_SASL_PASSWORD", "")
+        missing = [
+            name
+            for name, value in (
+                ("KAFKA_SASL_MECHANISM", mechanism),
+                ("KAFKA_SASL_USERNAME", username),
+                ("KAFKA_SASL_PASSWORD", password),
+            )
+            if not value
+        ]
+        if missing:
+            raise SystemExit(f"KAFKA_SECURITY_PROTOCOL={protocol} requires {' + '.join(missing)}")
+        config["sasl_mechanism"] = mechanism
+        config["sasl_plain_username"] = username
+        config["sasl_plain_password"] = password
+
+    if protocol in _TLS_PROTOCOLS:
+        config["ssl_context"] = ssl.create_default_context()
+
+    return config

--- a/src/ingestion/producers/kafka.py
+++ b/src/ingestion/producers/kafka.py
@@ -42,12 +42,18 @@ class KafkaEventProducer:
         *,
         client_id: str = _DEFAULT_CLIENT_ID,
         producer_factory: Callable[..., AIOKafkaProducer] | None = None,
+        aiokafka_extra_config: dict[str, Any] | None = None,
     ) -> None:
         if not bootstrap_servers:
             raise ValueError("bootstrap_servers must be a non-empty string")
         self._bootstrap_servers = bootstrap_servers
         self._client_id = client_id
         self._producer_factory = producer_factory or AIOKafkaProducer
+        # aiokafka_extra_config carries security_protocol / SASL / SSL
+        # kwargs (built by ingestion.kafka_config.build_aiokafka_security_config)
+        # so the same wrapper drives both the plaintext local Redpanda and
+        # the SASL_SSL Redpanda Cloud cluster without two code paths.
+        self._aiokafka_extra_config = aiokafka_extra_config or {}
         self._producer: AIOKafkaProducer | None = None
 
     async def __aenter__(self) -> Self:
@@ -57,6 +63,7 @@ class KafkaEventProducer:
             enable_idempotence=True,
             acks="all",
             linger_ms=_DEFAULT_LINGER_MS,
+            **self._aiokafka_extra_config,
         )
         await self._producer.start()  # type: ignore[no-untyped-call]
         return self

--- a/src/ingestion/run_consumers.py
+++ b/src/ingestion/run_consumers.py
@@ -42,6 +42,7 @@ from ingestion.consumers.line_status import (
     LINE_STATUS_TOPIC_LABEL,
 )
 from ingestion.consumers.postgres import RawEventWriter
+from ingestion.kafka_config import build_aiokafka_security_config
 from ingestion.observability import configure_logfire
 
 
@@ -56,6 +57,9 @@ async def _amain() -> NoReturn:
     if not dsn:
         raise SystemExit("DATABASE_URL is required")
 
+    # Empty dict on plaintext local Redpanda; SASL_SSL kwargs on Redpanda Cloud.
+    aiokafka_extra_config = build_aiokafka_security_config()
+
     async with AsyncExitStack() as stack:
         line_status_kafka = await stack.enter_async_context(
             KafkaEventConsumer(
@@ -63,6 +67,7 @@ async def _amain() -> NoReturn:
                 bootstrap_servers=bootstrap,
                 group_id=LINE_STATUS_CONSUMER_GROUP_ID,
                 client_id="tfl-monitor-ingestion-line-status-consumer",
+                aiokafka_extra_config=aiokafka_extra_config,
             )
         )
         line_status_writer = await stack.enter_async_context(
@@ -74,6 +79,7 @@ async def _amain() -> NoReturn:
                 bootstrap_servers=bootstrap,
                 group_id=ARRIVALS_CONSUMER_GROUP_ID,
                 client_id="tfl-monitor-ingestion-arrivals-consumer",
+                aiokafka_extra_config=aiokafka_extra_config,
             )
         )
         arrivals_writer = await stack.enter_async_context(RawEventWriter(dsn, table=ARRIVALS_TABLE))
@@ -83,6 +89,7 @@ async def _amain() -> NoReturn:
                 bootstrap_servers=bootstrap,
                 group_id=DISRUPTIONS_CONSUMER_GROUP_ID,
                 client_id="tfl-monitor-ingestion-disruptions-consumer",
+                aiokafka_extra_config=aiokafka_extra_config,
             )
         )
         disruptions_writer = await stack.enter_async_context(

--- a/src/ingestion/run_producers.py
+++ b/src/ingestion/run_producers.py
@@ -17,6 +17,7 @@ from typing import NoReturn
 
 import logfire
 
+from ingestion.kafka_config import build_aiokafka_security_config
 from ingestion.observability import configure_logfire
 from ingestion.producers.arrivals import ArrivalsProducer
 from ingestion.producers.disruptions import DisruptionsProducer
@@ -33,9 +34,15 @@ async def _amain() -> NoReturn:
     if not bootstrap:
         raise SystemExit("KAFKA_BOOTSTRAP_SERVERS is required")
 
+    # Empty dict on plaintext local Redpanda; SASL_SSL kwargs on Redpanda Cloud.
+    aiokafka_extra_config = build_aiokafka_security_config()
+
     async with (
         TflClient.from_env() as tfl,
-        KafkaEventProducer(bootstrap_servers=bootstrap) as kafka,
+        KafkaEventProducer(
+            bootstrap_servers=bootstrap,
+            aiokafka_extra_config=aiokafka_extra_config,
+        ) as kafka,
     ):
         line_status = LineStatusProducer(tfl_client=tfl, kafka_producer=kafka)
         arrivals = ArrivalsProducer(tfl_client=tfl, kafka_producer=kafka)

--- a/tests/ingestion/test_kafka_config.py
+++ b/tests/ingestion/test_kafka_config.py
@@ -97,3 +97,19 @@ def test_raises_when_sasl_credentials_missing(
         build_aiokafka_security_config()
 
     assert missing_var in str(excinfo.value)
+
+
+@pytest.mark.parametrize("typo", ["SALS_SSL", "PLAIN", "TLS", "SASL"])
+def test_raises_when_protocol_unsupported(monkeypatch: pytest.MonkeyPatch, typo: str) -> None:
+    monkeypatch.setenv("KAFKA_SECURITY_PROTOCOL", typo)
+    monkeypatch.setenv("KAFKA_SASL_MECHANISM", "SCRAM-SHA-256")
+    monkeypatch.setenv("KAFKA_SASL_USERNAME", "u")
+    monkeypatch.setenv("KAFKA_SASL_PASSWORD", "p")
+
+    with pytest.raises(SystemExit) as excinfo:
+        build_aiokafka_security_config()
+
+    message = str(excinfo.value)
+    assert typo in message
+    assert "PLAINTEXT" in message
+    assert "SASL_SSL" in message

--- a/tests/ingestion/test_kafka_config.py
+++ b/tests/ingestion/test_kafka_config.py
@@ -1,0 +1,99 @@
+"""Unit tests for ``ingestion.kafka_config.build_aiokafka_security_config``."""
+
+from __future__ import annotations
+
+import ssl
+
+import pytest
+
+from ingestion.kafka_config import build_aiokafka_security_config
+
+
+def test_returns_empty_dict_when_protocol_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KAFKA_SECURITY_PROTOCOL", raising=False)
+    assert build_aiokafka_security_config() == {}
+
+
+def test_returns_empty_dict_when_protocol_plaintext(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT")
+    assert build_aiokafka_security_config() == {}
+
+
+def test_returns_ssl_only_kwargs_when_protocol_ssl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KAFKA_SECURITY_PROTOCOL", "SSL")
+    monkeypatch.delenv("KAFKA_SASL_MECHANISM", raising=False)
+    monkeypatch.delenv("KAFKA_SASL_USERNAME", raising=False)
+    monkeypatch.delenv("KAFKA_SASL_PASSWORD", raising=False)
+
+    config = build_aiokafka_security_config()
+
+    assert config["security_protocol"] == "SSL"
+    assert isinstance(config["ssl_context"], ssl.SSLContext)
+    assert "sasl_mechanism" not in config
+    assert "sasl_plain_username" not in config
+    assert "sasl_plain_password" not in config
+
+
+def test_returns_full_sasl_ssl_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KAFKA_SECURITY_PROTOCOL", "SASL_SSL")
+    monkeypatch.setenv("KAFKA_SASL_MECHANISM", "SCRAM-SHA-256")
+    monkeypatch.setenv("KAFKA_SASL_USERNAME", "redpanda-user")
+    monkeypatch.setenv("KAFKA_SASL_PASSWORD", "redpanda-secret")
+
+    config = build_aiokafka_security_config()
+
+    assert config["security_protocol"] == "SASL_SSL"
+    assert config["sasl_mechanism"] == "SCRAM-SHA-256"
+    assert config["sasl_plain_username"] == "redpanda-user"
+    assert config["sasl_plain_password"] == "redpanda-secret"
+    assert isinstance(config["ssl_context"], ssl.SSLContext)
+
+
+def test_sasl_plaintext_skips_ssl_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KAFKA_SECURITY_PROTOCOL", "SASL_PLAINTEXT")
+    monkeypatch.setenv("KAFKA_SASL_MECHANISM", "SCRAM-SHA-256")
+    monkeypatch.setenv("KAFKA_SASL_USERNAME", "u")
+    monkeypatch.setenv("KAFKA_SASL_PASSWORD", "p")
+
+    config = build_aiokafka_security_config()
+
+    assert config["security_protocol"] == "SASL_PLAINTEXT"
+    assert config["sasl_mechanism"] == "SCRAM-SHA-256"
+    assert config["sasl_plain_username"] == "u"
+    assert config["sasl_plain_password"] == "p"
+    assert "ssl_context" not in config
+
+
+def test_protocol_is_uppercased(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KAFKA_SECURITY_PROTOCOL", "sasl_ssl")
+    monkeypatch.setenv("KAFKA_SASL_MECHANISM", "SCRAM-SHA-256")
+    monkeypatch.setenv("KAFKA_SASL_USERNAME", "u")
+    monkeypatch.setenv("KAFKA_SASL_PASSWORD", "p")
+
+    config = build_aiokafka_security_config()
+
+    assert config["security_protocol"] == "SASL_SSL"
+
+
+@pytest.mark.parametrize(
+    "missing_var",
+    ["KAFKA_SASL_MECHANISM", "KAFKA_SASL_USERNAME", "KAFKA_SASL_PASSWORD"],
+)
+def test_raises_when_sasl_credentials_missing(
+    monkeypatch: pytest.MonkeyPatch, missing_var: str
+) -> None:
+    monkeypatch.setenv("KAFKA_SECURITY_PROTOCOL", "SASL_SSL")
+    for name, value in (
+        ("KAFKA_SASL_MECHANISM", "SCRAM-SHA-256"),
+        ("KAFKA_SASL_USERNAME", "u"),
+        ("KAFKA_SASL_PASSWORD", "p"),
+    ):
+        if name == missing_var:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
+    with pytest.raises(SystemExit) as excinfo:
+        build_aiokafka_security_config()
+
+    assert missing_var in str(excinfo.value)

--- a/tests/ingestion/test_kafka_config.py
+++ b/tests/ingestion/test_kafka_config.py
@@ -113,3 +113,23 @@ def test_raises_when_protocol_unsupported(monkeypatch: pytest.MonkeyPatch, typo:
     assert typo in message
     assert "PLAINTEXT" in message
     assert "SASL_SSL" in message
+
+
+def test_strips_whitespace_from_protocol_and_mechanism(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hand-edited ``.env`` files often introduce stray whitespace.
+
+    Regression guard: a leading newline on ``KAFKA_SECURITY_PROTOCOL`` or
+    trailing spaces on ``KAFKA_SASL_MECHANISM`` must not fail the
+    supported-set check or be forwarded verbatim to aiokafka.
+    """
+    monkeypatch.setenv("KAFKA_SECURITY_PROTOCOL", "  sasl_ssl\n")
+    monkeypatch.setenv("KAFKA_SASL_MECHANISM", "  scram-sha-256\t")
+    monkeypatch.setenv("KAFKA_SASL_USERNAME", "u")
+    monkeypatch.setenv("KAFKA_SASL_PASSWORD", "p")
+
+    config = build_aiokafka_security_config()
+
+    assert config["security_protocol"] == "SASL_SSL"
+    assert config["sasl_mechanism"] == "SCRAM-SHA-256"

--- a/tests/ingestion/test_kafka_consumer.py
+++ b/tests/ingestion/test_kafka_consumer.py
@@ -187,3 +187,63 @@ async def test_seek_records_partition_and_offset() -> None:
         consumer.seek(tp, 42)
 
     assert fake.seeks == [(tp, 42)]
+
+
+async def test_aiokafka_extra_config_kwargs_forwarded_to_factory() -> None:
+    """``aiokafka_extra_config`` keys must reach the underlying constructor.
+
+    Regression test for the production outage where SASL/SSL kwargs were
+    never forwarded, causing every prod consumer to crashloop with
+    ``KafkaConnectionError`` against Redpanda Cloud.
+    """
+    fake = FakeAIOKafkaConsumer()
+    captured: dict[str, Any] = {}
+
+    def _factory(*args: Any, **kwargs: Any) -> AIOKafkaConsumer:
+        captured.update(kwargs)
+        return cast(AIOKafkaConsumer, fake)
+
+    async with KafkaEventConsumer(
+        "line-status",
+        bootstrap_servers="localhost:19092",
+        group_id="g",
+        consumer_factory=_factory,
+        aiokafka_extra_config={
+            "security_protocol": "SASL_SSL",
+            "sasl_mechanism": "SCRAM-SHA-256",
+            "sasl_plain_username": "redpanda-user",
+            "sasl_plain_password": "redpanda-secret",
+        },
+    ):
+        pass
+
+    assert captured["security_protocol"] == "SASL_SSL"
+    assert captured["sasl_mechanism"] == "SCRAM-SHA-256"
+    assert captured["sasl_plain_username"] == "redpanda-user"
+    assert captured["sasl_plain_password"] == "redpanda-secret"
+    # Original kwargs still pass through.
+    assert captured["bootstrap_servers"] == "localhost:19092"
+    assert captured["group_id"] == "g"
+    assert captured["enable_auto_commit"] is False
+
+
+async def test_aiokafka_extra_config_defaults_to_empty_dict() -> None:
+    """No extra config keys when the kwarg is omitted (local plaintext path)."""
+    fake = FakeAIOKafkaConsumer()
+    captured: dict[str, Any] = {}
+
+    def _factory(*args: Any, **kwargs: Any) -> AIOKafkaConsumer:
+        captured.update(kwargs)
+        return cast(AIOKafkaConsumer, fake)
+
+    async with KafkaEventConsumer(
+        "line-status",
+        bootstrap_servers="localhost:19092",
+        group_id="g",
+        consumer_factory=_factory,
+    ):
+        pass
+
+    assert "security_protocol" not in captured
+    assert "sasl_mechanism" not in captured
+    assert "ssl_context" not in captured

--- a/tests/ingestion/test_kafka_producer.py
+++ b/tests/ingestion/test_kafka_producer.py
@@ -181,3 +181,58 @@ async def test_kafka_event_producer_isinstance_of_self_returns_self() -> None:
     async with producer as bound:
         assert isinstance(bound, KafkaEventProducer)
         assert bound is producer
+
+
+async def test_aiokafka_extra_config_kwargs_forwarded_to_factory() -> None:
+    """``aiokafka_extra_config`` keys must reach the underlying constructor.
+
+    Regression test for the production outage where SASL/SSL kwargs were
+    never forwarded, causing every prod producer to crashloop with
+    ``KafkaConnectionError`` against Redpanda Cloud.
+    """
+    fake = _FakeAIOKafkaProducer()
+    captured: dict[str, Any] = {}
+
+    def _factory(**kwargs: Any) -> AIOKafkaProducer:
+        captured.update(kwargs)
+        return cast(AIOKafkaProducer, fake)
+
+    async with KafkaEventProducer(
+        bootstrap_servers="localhost:19092",
+        producer_factory=_factory,
+        aiokafka_extra_config={
+            "security_protocol": "SASL_SSL",
+            "sasl_mechanism": "SCRAM-SHA-256",
+            "sasl_plain_username": "redpanda-user",
+            "sasl_plain_password": "redpanda-secret",
+        },
+    ) as _:
+        pass
+
+    assert captured["security_protocol"] == "SASL_SSL"
+    assert captured["sasl_mechanism"] == "SCRAM-SHA-256"
+    assert captured["sasl_plain_username"] == "redpanda-user"
+    assert captured["sasl_plain_password"] == "redpanda-secret"
+    # Original kwargs still pass through.
+    assert captured["bootstrap_servers"] == "localhost:19092"
+    assert captured["enable_idempotence"] is True
+
+
+async def test_aiokafka_extra_config_defaults_to_empty_dict() -> None:
+    """No extra config keys when the kwarg is omitted (local plaintext path)."""
+    fake = _FakeAIOKafkaProducer()
+    captured: dict[str, Any] = {}
+
+    def _factory(**kwargs: Any) -> AIOKafkaProducer:
+        captured.update(kwargs)
+        return cast(AIOKafkaProducer, fake)
+
+    async with KafkaEventProducer(
+        bootstrap_servers="localhost:19092",
+        producer_factory=_factory,
+    ) as _:
+        pass
+
+    assert "security_protocol" not in captured
+    assert "sasl_mechanism" not in captured
+    assert "ssl_context" not in captured


### PR DESCRIPTION
## Summary

Production producers + consumers have been crashlooping with `aiokafka.errors.KafkaConnectionError: Unable to bootstrap from [('d84dkpp452jt9h43smgg.any.eu-west-2.mpx.prd.cloud.redpanda.com', 9092, …)]` since TM-A5 first deployed. The root cause surfaced only on 2026-05-19 when the first end-to-end deploy actually landed and we were able to read the live container logs.

`KafkaEventProducer.__aenter__` (`src/ingestion/producers/kafka.py:53-60`) and `KafkaEventConsumer.__aenter__` (`src/ingestion/consumers/kafka.py:64-72`) instantiated `AIOKafkaProducer` / `AIOKafkaConsumer` with only `bootstrap_servers` + `client_id` + a handful of idempotence settings. There was no SASL or SSL configuration code path anywhere in the ingestion stack — only a plaintext local Redpanda broker could ever be reached. Redpanda Cloud Serverless mandates SASL/SCRAM-SHA-256 over TLS (port 9092 with SASL_SSL), so the cloud cluster silently refused every bootstrap attempt.

## Change

- **New `src/ingestion/kafka_config.py`** with a single function `build_aiokafka_security_config()` that reads `KAFKA_SECURITY_PROTOCOL` / `KAFKA_SASL_MECHANISM` / `KAFKA_SASL_USERNAME` / `KAFKA_SASL_PASSWORD` and returns the aiokafka kwargs dict — empty when `PLAINTEXT` (default), full kwargs with `ssl_context = ssl.create_default_context()` when `SASL_SSL`. Missing SASL credentials raise `SystemExit` with a list of the missing env-var names rather than silently falling back.
- **`src/ingestion/producers/kafka.py`** and **`src/ingestion/consumers/kafka.py`** gain an optional `aiokafka_extra_config: dict[str, Any] | None = None` constructor kwarg; the dict is spread into the underlying `AIOKafkaProducer` / `AIOKafkaConsumer` constructor.
- **`src/ingestion/run_producers.py`** and **`src/ingestion/run_consumers.py`** call the builder once and forward the dict to every wrapper instance (one producer + three consumers).
- **`infra/.env.example`** already documents the four `KAFKA_*` vars — no change needed.

The same wrapper code path now drives:
- Local dev with `docker-compose.yml` (plaintext Redpanda, no env vars set → builder returns `{}` → wrappers behave exactly as before).
- Production Lightsail with Redpanda Cloud (`KAFKA_SECURITY_PROTOCOL=SASL_SSL` + SASL creds → builder returns full security config → wrappers authenticate over TLS).

No new dependency. No new env var. No new dual code path.

## Test plan

- [x] `uv run pytest tests/ingestion/test_kafka_config.py` — 8 new unit cases covering unset / `PLAINTEXT` / `SSL` / `SASL_PLAINTEXT` / `SASL_SSL` protocols, lower-case `sasl_ssl` upper-casing, and parametrised `SystemExit` on each missing SASL env var.
- [x] `uv run pytest tests/ingestion/test_kafka_producer.py tests/ingestion/test_kafka_consumer.py` — existing 22 cases stay green; the new constructor kwarg is optional and defaults to `None`.
- [x] `uv run task lint` — clean (ruff check + ruff format --check + mypy strict against `src` and `contracts`).
- [ ] After merge + deploy, `docker logs tfl-monitor-producers-1 --since 2m` no longer shows `Unable to bootstrap from …`; first `kafka.publish` span appears within ~30 s for `line-status`, ~30 s for `arrivals`, ~5 min for `disruptions`.
- [ ] `analytics.stg_line_status` row count crosses zero within the first dbt cron tick after deploy.

## Coordination with the rest of the recovery

Reaches green only after **PR #81 (deploy.yml keepalive)** lands so the next GHA `Deploy` can survive buildkit's silent unpack on the ingestion image rebuild. PR #82 (`DISRUPTIONS_SQL ::text cast`) is independent. Topic creation on the Redpanda Cloud cluster (`line-status` / `arrivals` / `disruptions`) was performed manually on 2026-05-19 with `rpk topic create` — no compose changes needed in this PR.

## What this PR does NOT do

- Does **not** add an integration smoke against a real Redpanda Cloud cluster — would require shared cloud credentials in CI.
- Does **not** repeat the same builder in `ingestion.producers.line_status` / `.arrivals` / `.disruptions` (the per-topic CLI entrypoints used for local dev) — those continue to call `KafkaEventProducer(bootstrap_servers=…)` without `aiokafka_extra_config`, matching the local plaintext path they were built for. The prod entrypoint is `run_producers` / `run_consumers`, which is where the builder lives.
- Does **not** touch `enable_idempotence=True` / `acks="all"` — Redpanda Cloud Serverless accepts both today; tuning is deferred until a real metric says otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Kafka security support (PLAINTEXT, SSL/TLS, SASL variants) driven by environment variables
  * Producers and consumers can receive and apply extra Kafka client configuration to support varied deployments

* **Tests**
  * Added comprehensive unit tests for security config parsing and validation
  * Added tests verifying producers/consumers forward extra client configuration correctly

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->