### PR TITLE
feat(infra): extend deploy.sh retry budget + dump logs on failure

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,6 +29,14 @@ COMPOSE_FILE="${APP_DIR}/infra/docker-compose.prod.yml"
 HEALTHCHECK_URL="${HEALTHCHECK_URL:-https://tfl-monitor-api.humbertolomeu.com/health}"
 API_CONTAINER="tfl-monitor-api-1"
 API_SERVICE="${API_SERVICE:-api}"
+# Budget for the internal healthcheck loop. 12 × 5s ≈ 60s — sized for the worst
+# observed Lightsail cold-start. A separate cold-start optimisation is in
+# progress; this budget remains the safety net.
+MAX_ATTEMPTS=12
+
+dump_api_logs() {
+  docker compose -f "${COMPOSE_FILE}" logs --tail=200 "${API_SERVICE}" >&2 || true
+}
 
 cd "${APP_DIR}"
 
@@ -52,22 +60,19 @@ if ! grep -qx "${API_SERVICE}" <<<"${running_services}"; then
   echo "Running services:" >&2
   echo "${running_services:-<none>}" >&2
   docker compose -f "${COMPOSE_FILE}" ps >&2 || true
-  docker compose -f "${COMPOSE_FILE}" logs --tail=200 "${API_SERVICE}" >&2 || true
+  dump_api_logs
   exit 1
 fi
 
 echo "[$(date -Iseconds)] internal healthcheck (docker exec ${API_CONTAINER})"
-# Budget of 12 attempts × 5s sleep ≈ 60s, sized for the worst observed Lightsail
-# cold-start. Bucket A is reducing that; this loop is the upper bound, not the
-# expected wait.
-for attempt in $(seq 1 12); do
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
   if docker exec "${API_CONTAINER}" curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
     echo "[$(date -Iseconds)] container healthy"
     break
   fi
-  if [[ ${attempt} -eq 12 ]]; then
-    echo "ERROR: ${API_CONTAINER} did not respond to /health after 12 attempts" >&2
-    docker compose -f "${COMPOSE_FILE}" logs --tail=200 "${API_SERVICE}" >&2 || true
+  if [[ ${attempt} -eq ${MAX_ATTEMPTS} ]]; then
+    echo "ERROR: ${API_CONTAINER} did not respond to /health after ${MAX_ATTEMPTS} attempts" >&2
+    dump_api_logs
     exit 1
   fi
   sleep 5
@@ -83,5 +88,5 @@ for attempt in 1 2 3; do
 done
 
 echo "WARN: container is healthy but ${HEALTHCHECK_URL} is unreachable — check DNS / Caddy" >&2
-docker compose -f "${COMPOSE_FILE}" logs --tail=200 "${API_SERVICE}" >&2 || true
+dump_api_logs
 exit 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -52,17 +52,22 @@ if ! grep -qx "${API_SERVICE}" <<<"${running_services}"; then
   echo "Running services:" >&2
   echo "${running_services:-<none>}" >&2
   docker compose -f "${COMPOSE_FILE}" ps >&2 || true
+  docker compose -f "${COMPOSE_FILE}" logs --tail=200 "${API_SERVICE}" >&2 || true
   exit 1
 fi
 
 echo "[$(date -Iseconds)] internal healthcheck (docker exec ${API_CONTAINER})"
-for attempt in 1 2 3 4 5; do
+# Budget of 12 attempts × 5s sleep ≈ 60s, sized for the worst observed Lightsail
+# cold-start. Bucket A is reducing that; this loop is the upper bound, not the
+# expected wait.
+for attempt in $(seq 1 12); do
   if docker exec "${API_CONTAINER}" curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
     echo "[$(date -Iseconds)] container healthy"
     break
   fi
-  if [[ ${attempt} -eq 5 ]]; then
-    echo "ERROR: ${API_CONTAINER} did not respond to /health after 5 attempts" >&2
+  if [[ ${attempt} -eq 12 ]]; then
+    echo "ERROR: ${API_CONTAINER} did not respond to /health after 12 attempts" >&2
+    docker compose -f "${COMPOSE_FILE}" logs --tail=200 "${API_SERVICE}" >&2 || true
     exit 1
   fi
   sleep 5
@@ -78,4 +83,5 @@ for attempt in 1 2 3; do
 done
 
 echo "WARN: container is healthy but ${HEALTHCHECK_URL} is unreachable — check DNS / Caddy" >&2
+docker compose -f "${COMPOSE_FILE}" logs --tail=200 "${API_SERVICE}" >&2 || true
 exit 1


### PR DESCRIPTION
## Summary
- Extend the internal healthcheck loop from 5×5s (~25s) to 12×5s (~60s) so deploys do not flake on cold starts on the Lightsail box.
- On every `exit 1` path in `scripts/deploy.sh`, dump `docker compose logs --tail=200 ${API_SERVICE}` to stderr so the failure reason is visible directly in the GHA Deploy run output (instead of needing a manual SSH).
- Three failure sites covered: the post-`docker compose up` "service not running" assertion added by PR #86, the internal `docker exec ... /health` loop, and the external-URL `WARN:` exit.

## Why 12 attempts
- Cold-start on the shared Lightsail box has been observed at 60–90s end-to-end (image pull warm, app boot + ingestion warm-up). PR #86 raised the lower-bound checks (post-up assertion, `pipefail`) but left the retry budget untouched.
- 12 attempts × 5s ≈ 60s — covers the typical worst case and still exits early via the `break` on first success, so successful deploys are not slowed.
- Bucket A is reducing the cold-start root cause separately; once that lands, this budget remains a safety net (early `break` means no wasted time on healthy deploys).

## Test plan
- [x] `bash -n scripts/deploy.sh` — passes locally.
- [ ] CI lint + test jobs green on this branch.
- [ ] Next Deploy workflow run shows the new "12 attempts" message in the success log and, if it ever fails, surfaces the `docker compose logs --tail=200` block.
- [ ] If the external healthcheck ever WARNs, the log dump now appears immediately before the `exit 1` so the GHA run captures it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced deployment diagnostics with improved logging visibility during health verification failures
  * Increased health check retry attempts for more resilient deployment processes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->