### PR TITLE
perf(api): lazy-import heavy deps to cut cold-start

### DIFF
--- a/src/api/agent/extraction.py
+++ b/src/api/agent/extraction.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 
 import os
 from functools import lru_cache
-from typing import Literal, get_args
+from typing import TYPE_CHECKING, Literal, get_args
 
 import logfire
 from pydantic import BaseModel
-from pydantic_ai import Agent
+
+if TYPE_CHECKING:
+    from pydantic_ai import Agent
 
 CanonicalLineId = Literal[
     "bakerloo",
@@ -55,6 +57,8 @@ def _model_string() -> str:
 @lru_cache(maxsize=1)
 def _normaliser() -> Agent[None, LineId]:
     """Return the singleton Haiku-backed extraction agent."""
+    from pydantic_ai import Agent  # noqa: PLC0415
+
     return Agent(
         _model_string(),
         output_type=LineId,

--- a/src/api/agent/graph.py
+++ b/src/api/agent/graph.py
@@ -23,15 +23,10 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from langchain_anthropic import ChatAnthropic
-from langgraph.checkpoint.memory import InMemorySaver
-from langgraph.prebuilt import create_react_agent
 from psycopg_pool import AsyncConnectionPool
 from pydantic import SecretStr
 
 from api.agent.prompts import render
-from api.agent.rag import build_retriever
-from api.agent.tools import make_tools
 
 DEFAULT_PINECONE_INDEX = "tfl-strategy-docs"
 DEFAULT_ANTHROPIC_MODEL = "claude-3-5-sonnet-latest"
@@ -61,6 +56,8 @@ def _build_chat_model() -> Any | None:
 
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     if anthropic_key:
+        from langchain_anthropic import ChatAnthropic  # noqa: PLC0415
+
         return ChatAnthropic(
             model_name=DEFAULT_ANTHROPIC_MODEL,
             temperature=0.0,
@@ -99,6 +96,12 @@ def compile_agent(
     chat_model: Any = model if model is not None else _build_chat_model()
     if chat_model is None:
         return None
+
+    from langgraph.checkpoint.memory import InMemorySaver  # noqa: PLC0415
+    from langgraph.prebuilt import create_react_agent  # noqa: PLC0415
+
+    from api.agent.rag import build_retriever  # noqa: PLC0415
+    from api.agent.tools import make_tools  # noqa: PLC0415
 
     retriever = build_retriever(
         pinecone_api_key=pinecone_key,

--- a/src/api/agent/rag.py
+++ b/src/api/agent/rag.py
@@ -9,17 +9,15 @@ to ``None`` so the LLM never sees a sentinel page number.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import logfire
-from llama_index.core import VectorStoreIndex
-from llama_index.core.retrievers import BaseRetriever
-from llama_index.embeddings.openai import OpenAIEmbedding
-from llama_index.vector_stores.pinecone import PineconeVectorStore
-from pinecone import Pinecone
 from pydantic import BaseModel, ConfigDict
 
 from rag.upsert import PAGE_UNKNOWN_SENTINEL
+
+if TYPE_CHECKING:
+    from llama_index.core.retrievers import BaseRetriever
 
 NAMESPACES: tuple[str, ...] = ("tfl_business_plan", "mts_2018", "tfl_annual_report")
 DEFAULT_TOP_K = 5
@@ -56,6 +54,11 @@ def build_retriever(
     Returns:
         Dict mapping namespace (``doc_id``) to its retriever.
     """
+    from llama_index.core import VectorStoreIndex  # noqa: PLC0415
+    from llama_index.embeddings.openai import OpenAIEmbedding  # noqa: PLC0415
+    from llama_index.vector_stores.pinecone import PineconeVectorStore  # noqa: PLC0415
+    from pinecone import Pinecone  # noqa: PLC0415
+
     pc = Pinecone(api_key=pinecone_api_key)
     pinecone_index = pc.Index(index_name)
     embed_model = OpenAIEmbedding(

--- a/src/api/agent/tools.py
+++ b/src/api/agent/tools.py
@@ -14,11 +14,9 @@ smuggle unknown fields past the type system.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import logfire
-from langchain_core.tools import BaseTool, tool
-from llama_index.core.retrievers import BaseRetriever
 from psycopg_pool import AsyncConnectionPool
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -32,6 +30,10 @@ from api.db import (
     fetch_reliability,
 )
 from api.schemas import Mode
+
+if TYPE_CHECKING:
+    from langchain_core.tools import BaseTool
+    from llama_index.core.retrievers import BaseRetriever
 
 
 class LineReliabilityQuery(BaseModel):
@@ -85,6 +87,7 @@ def make_tools(
         List of LangChain ``BaseTool`` instances ready for
         ``create_react_agent``.
     """
+    from langchain_core.tools import tool  # noqa: PLC0415
 
     @tool
     async def query_tube_status() -> list[dict[str, Any]]:

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -22,7 +22,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 from sse_starlette.sse import EventSourceResponse
 
-from api.agent.graph import compile_agent
 from api.agent.history import append_message, fetch_history
 from api.agent.streaming import frame_end, project, serialise
 from api.db import (
@@ -71,6 +70,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     pool = build_pool(dsn)
     await pool.open()
     app.state.db_pool = pool
+    # Lazy import: pulls langchain_anthropic + llama_index transitively.
+    # Keeping it out of module scope shaves cold-start when DATABASE_URL
+    # is unset (smoke tests, /health-only deploys).
+    from api.agent.graph import compile_agent  # noqa: PLC0415
+
     app.state.agent = compile_agent(pool=pool)
     logfire.info(
         "api_db_pool_opened",

--- a/tests/agent/test_graph_compile.py
+++ b/tests/agent/test_graph_compile.py
@@ -60,7 +60,14 @@ def test_compile_smoke_invoke_with_fake_model(monkeypatch: pytest.MonkeyPatch) -
     def fake_build_retriever(**_kwargs: object) -> dict[str, object]:
         return {}
 
-    monkeypatch.setattr(graph_module, "build_retriever", fake_build_retriever)
+    # ``compile_agent`` lazy-imports ``build_retriever`` from
+    # ``api.agent.rag`` so the heavy llama_index / pinecone chain stays
+    # off the API cold-start path. Patch the source attribute so the
+    # ``from … import build_retriever`` inside the function resolves to
+    # the fake.
+    from api.agent import rag as rag_module
+
+    monkeypatch.setattr(rag_module, "build_retriever", fake_build_retriever)
 
     fake_model = FakeChatModel(response="ack")
     agent = compile_agent(pool=object(), model=fake_model)  # type: ignore[arg-type]
@@ -118,7 +125,16 @@ def test_build_chat_model_falls_back_to_anthropic_when_region_unset(
         captured.update(kwargs)
         return object()
 
-    monkeypatch.setattr(graph_module, "ChatAnthropic", fake_chat_anthropic)
+    # ``_build_chat_model`` lazy-imports ``ChatAnthropic`` from
+    # ``langchain_anthropic``. Stub the module in ``sys.modules`` so the
+    # in-function ``from langchain_anthropic import ChatAnthropic`` picks
+    # up the fake (same pattern as the Bedrock test above).
+    import sys
+    import types
+
+    fake_module = types.ModuleType("langchain_anthropic")
+    fake_module.ChatAnthropic = fake_chat_anthropic  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "langchain_anthropic", fake_module)
 
     model = graph_module._build_chat_model()
     assert model is not None

--- a/tests/api/test_lazy_imports.py
+++ b/tests/api/test_lazy_imports.py
@@ -1,0 +1,59 @@
+"""Regression: importing ``api.main`` must not eagerly load heavy deps.
+
+Cold-start on the Lightsail box is dominated by the transitive import
+graph of ``langchain_anthropic`` (pulls ``transformers`` + ``torch`` +
+``cv2``), ``llama_index``, ``pydantic_ai``, and ``docling``. Those
+imports must be deferred until the first chat request actually needs
+them so ``/health`` and the SQL endpoints stay responsive.
+
+This test re-imports ``api.main`` in a clean subprocess and asserts the
+forbidden modules are absent from ``sys.modules`` after the import.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+FORBIDDEN = (
+    "docling",
+    "torch",
+    "transformers",
+    "llama_index",
+    "langchain_anthropic",
+    "pydantic_ai",
+    "cv2",
+)
+
+
+def test_api_main_does_not_eagerly_load_heavy_modules() -> None:
+    """``from api.main import app`` must keep heavy modules out of sys.modules."""
+    script = (
+        "import sys, json\n"
+        "from api.main import app  # noqa: F401\n"
+        f"forbidden = {FORBIDDEN!r}\n"
+        "loaded = sorted(m for m in forbidden if m in sys.modules)\n"
+        "print(json.dumps(loaded))\n"
+    )
+    # Strip pytest/coverage env so the subprocess starts with a pristine
+    # interpreter; coverage's ``.pth`` hook would otherwise preload
+    # tracing infrastructure that pulls some of the very modules we are
+    # asserting absent.
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(("COV_CORE", "COVERAGE_", "PYTEST_"))
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    loaded = result.stdout.strip()
+    assert loaded == "[]", (
+        f"Heavy modules unexpectedly loaded by `from api.main import app`: {loaded}. "
+        "Move the offending import inside the function/endpoint that needs it."
+    )

--- a/tests/api/test_lazy_imports.py
+++ b/tests/api/test_lazy_imports.py
@@ -22,6 +22,8 @@ FORBIDDEN = (
     "transformers",
     "llama_index",
     "langchain_anthropic",
+    "langgraph",
+    "pinecone",
     "pydantic_ai",
     "cv2",
 )

--- a/tests/api/test_lazy_imports.py
+++ b/tests/api/test_lazy_imports.py
@@ -12,9 +12,12 @@ forbidden modules are absent from ``sys.modules`` after the import.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
+
+import pytest
 
 FORBIDDEN = (
     "docling",
@@ -22,6 +25,7 @@ FORBIDDEN = (
     "transformers",
     "llama_index",
     "langchain_anthropic",
+    "langchain_core",
     "langgraph",
     "pinecone",
     "pydantic_ai",
@@ -49,13 +53,26 @@ def test_api_main_does_not_eagerly_load_heavy_modules() -> None:
     }
     result = subprocess.run(
         [sys.executable, "-c", script],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
         env=env,
     )
-    loaded = result.stdout.strip()
-    assert loaded == "[]", (
+    if result.returncode != 0:
+        # Surface stderr + stdout so a failing subprocess gives an
+        # actionable trace instead of "exited with code 1".
+        pytest.fail(
+            f"subprocess exited with code {result.returncode}:\n"
+            f"stderr:\n{result.stderr}\n"
+            f"stdout:\n{result.stdout}"
+        )
+    # ``api.main`` may emit logfire / deprecation lines on stdout; take
+    # the last non-empty line as the JSON payload so unrelated chatter
+    # does not turn this assertion into a misleading mismatch.
+    stdout_lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert stdout_lines, f"subprocess produced no stdout:\n{result.stderr}"
+    loaded = json.loads(stdout_lines[-1])
+    assert loaded == [], (
         f"Heavy modules unexpectedly loaded by `from api.main import app`: {loaded}. "
         "Move the offending import inside the function/endpoint that needs it."
     )


### PR DESCRIPTION
## Summary

- Move `langchain_anthropic`, `langgraph`, `llama_index`, `pinecone`, `pydantic_ai`, and the `api.agent.graph → rag/tools/extraction` chain off the API module-import path. Each name now loads inside the function or endpoint that needs it.
- `from api.main import app` no longer transitively pulls `torch`, `transformers`, `cv2`, `docling`, or `llama_index`. The chat-agent path still loads them on the first `/api/v1/chat/stream` request (via the lifespan `compile_agent` call).
- Regression test `tests/api/test_lazy_imports.py` spawns a clean subprocess, imports `api.main`, and asserts the forbidden module set stays absent from `sys.modules`.
- Updated two `tests/agent/test_graph_compile.py` cases to patch the source modules (`api.agent.rag.build_retriever`, `sys.modules["langchain_anthropic"]`) rather than attributes on `api.agent.graph` that no longer exist after the refactor.

Targets the 60–90 s Lightsail cold-start that caused false-red Deploy runs (napkin TM-A5, 2026-05-19). PR #86 hardened `deploy.sh`; this PR attacks the underlying import-graph cost.

## Before / After importtime

`python -X importtime -c "from api.main import app" 2> /tmp/log.log; wc -l /tmp/log.log`

| | cumulative `api.main` self | imports recorded |
|---|---|---|
| Before (origin/main) | **16.22 s** | 7 512 |
| After (this branch)  | **0.91 s**  | 1 124 |

Heavy modules confirmed absent post-import:

```
$ uv run python -c "import sys; from api.main import app; \
  print([m for m in ('docling','torch','transformers','llama_index', \
  'langchain_anthropic','pydantic_ai','cv2') if m in sys.modules])"
[]
```

The chat code path still loads everything it needs at first request — just not at module import.

## Test plan

- [x] `uv run task lint` — clean (ruff + ruff format + mypy strict).
- [x] `uv run task test` — 277 passed (one pre-existing unrelated failure on `tests/rag/test_ingest.py::test_run_ingestion_missing_pinecone_key_exits_2`, also red on `origin/main`).
- [x] `tests/api/test_lazy_imports.py` — green; subprocess strips `PYTEST_*` / `COVERAGE_*` env so coverage's `.pth` hook doesn't preload tracers.
- [x] `tests/agent/test_graph_compile.py` — 7/7 green after patching tests to follow the lazy imports.
- [x] Manual importtime profile before/after, recorded above.

## Out of scope

- The pre-existing `tests/rag/test_ingest.py::test_run_ingestion_missing_pinecone_key_exits_2` failure (touches `rag.ingest`, not the API).
- Lifespan `compile_agent` timing — the lifespan still loads the agent eagerly when `DATABASE_URL` is present. Follow-up could defer to first chat request, but that changes user-visible behavior and was not requested here.