### PR TITLE
feat(web): strip echoed summary from disruption news body

### DIFF
--- a/web/components/dashboard/__tests__/news-reports.test.tsx
+++ b/web/components/dashboard/__tests__/news-reports.test.tsx
@@ -13,6 +13,7 @@ describe("NewsReports", () => {
 						body: "Faulty train at Hayes & Harlington.",
 					},
 				]}
+				slotCount={3}
 			/>,
 		);
 
@@ -21,6 +22,29 @@ describe("NewsReports", () => {
 		).toBeInTheDocument();
 		expect(screen.getByText(/1 today/)).toBeInTheDocument();
 		expect(screen.getAllByText(/No further updates/)).toHaveLength(2);
+	});
+
+	it("omits the body line when an item has no extra context to show", () => {
+		render(
+			<NewsReports
+				items={[
+					{
+						time: "17:58",
+						title: "Circle Line: Minor delays due to train cancellations.",
+						body: "",
+					},
+				]}
+				slotCount={1}
+			/>,
+		);
+
+		expect(
+			screen.getByText(
+				/Circle Line: Minor delays due to train cancellations\./,
+			),
+		).toBeInTheDocument();
+		// No empty body div should leak through — only the title row.
+		expect(document.querySelector(".tfl-news-body")).not.toBeInTheDocument();
 	});
 
 	it("reports the full item count in the meta label even when slots truncate", () => {

--- a/web/components/dashboard/news-reports.tsx
+++ b/web/components/dashboard/news-reports.tsx
@@ -5,7 +5,7 @@ export interface NewsReportsProps {
 	slotCount?: number;
 }
 
-export function NewsReports({ items, slotCount = 3 }: NewsReportsProps) {
+export function NewsReports({ items, slotCount = 6 }: NewsReportsProps) {
 	const filled = items.slice(0, slotCount);
 	const empties = Math.max(0, slotCount - filled.length);
 	const slots: (NewsItem | null)[] = [
@@ -31,7 +31,9 @@ export function NewsReports({ items, slotCount = 3 }: NewsReportsProps) {
 								{slot ? (
 									<>
 										<div className="tfl-news-title">{slot.title}</div>
-										<div className="tfl-news-body">{slot.body}</div>
+										{slot.body ? (
+											<div className="tfl-news-body">{slot.body}</div>
+										) : null}
 									</>
 								) : (
 									<div className="tfl-news-placeholder">No further updates</div>

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -177,6 +177,32 @@ describe("disruptionForLine + disruptionToSnapshot", () => {
 		expect(snapshot.reportedAtLabel).toMatch(/\d{2}:\d{2}/);
 		expect(snapshot.updatedAtLabel).toMatch(/\d{2}:\d{2}/);
 	});
+
+	it("drops the leading description paragraph when it duplicates summary so LineDetail does not echo the headline", () => {
+		// Same TfL Unified API echo pattern that `disruptionsToNews`
+		// already handles — the headline would otherwise render once
+		// in the .summary div and again as the first <p> body paragraph.
+		const echoed: Disruption = {
+			...disruption,
+			summary: "Piccadilly Line: SUSPENDED between Acton Town and Heathrow.",
+			description:
+				"Piccadilly Line: SUSPENDED between Acton Town and Heathrow.\n\nTickets accepted on London Buses.",
+		};
+		const snapshot = disruptionToSnapshot(echoed);
+		expect(snapshot.headline).toBe(
+			"Piccadilly Line: SUSPENDED between Acton Town and Heathrow.",
+		);
+		expect(snapshot.body).toEqual(["Tickets accepted on London Buses."]);
+	});
+
+	it("keeps the full description when the leading paragraph does not match summary", () => {
+		const snapshot = disruptionToSnapshot({
+			...disruption,
+			summary: "Severe delays westbound",
+			description: "Para 1.\n\nPara 2.\n\nPara 3.",
+		});
+		expect(snapshot.body).toEqual(["Para 1.", "Para 2.", "Para 3."]);
+	});
 });
 
 describe("disruptionsToNews", () => {

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -220,14 +220,59 @@ describe("disruptionsToNews", () => {
 		expect(disruptionsToNews([])).toEqual([]);
 	});
 
-	it("trims multi-paragraph descriptions to the first paragraph so the dense news list does not overflow", () => {
+	it("drops the leading paragraph of description when it duplicates summary so title and body do not echo", () => {
+		// TfL's Unified API repeats `summary` as the first paragraph of
+		// `description` in most payloads; the news list would render the
+		// same sentence twice unless we strip it.
+		const echoed: Disruption = {
+			...baseDisruption,
+			summary: "Piccadilly Line: SUSPENDED between Acton Town and Heathrow.",
+			description:
+				"Piccadilly Line: SUSPENDED between Acton Town and Heathrow.\n\nTickets accepted on London Buses and the Elizabeth line.",
+		};
+		const [item] = disruptionsToNews([echoed]);
+		expect(item.title).toBe(
+			"Piccadilly Line: SUSPENDED between Acton Town and Heathrow.",
+		);
+		expect(item.body).toBe(
+			"Tickets accepted on London Buses and the Elizabeth line.",
+		);
+	});
+
+	it("returns an empty body when the description only echoes summary", () => {
+		const onlyEcho: Disruption = {
+			...baseDisruption,
+			summary: "Circle Line: Minor delays due to train cancellations.",
+			description: "Circle Line: Minor delays due to train cancellations.",
+		};
+		const [item] = disruptionsToNews([onlyEcho]);
+		expect(item.body).toBe("");
+	});
+
+	it("joins trailing paragraphs with a blank line so multi-paragraph context is preserved", () => {
 		const verbose: Disruption = {
 			...baseDisruption,
+			summary: "Piccadilly Line: SUSPENDED between Acton Town and Heathrow.",
+			description:
+				"Piccadilly Line: SUSPENDED between Acton Town and Heathrow.\n\nTickets accepted on London Buses.\n\nLast updated 18:42.",
+		};
+		const [item] = disruptionsToNews([verbose]);
+		expect(item.body).toBe(
+			"Tickets accepted on London Buses.\n\nLast updated 18:42.",
+		);
+	});
+
+	it("keeps the full description when the leading paragraph does not match summary", () => {
+		const distinct: Disruption = {
+			...baseDisruption,
+			summary: "Elizabeth line — westbound severe delays",
 			description:
 				"Faulty train at Hayes & Harlington.\n\nTickets accepted on Piccadilly & Bakerloo until service is restored.",
 		};
-		const [item] = disruptionsToNews([verbose]);
-		expect(item.body).toBe("Faulty train at Hayes & Harlington.");
+		const [item] = disruptionsToNews([distinct]);
+		expect(item.body).toBe(
+			"Faulty train at Hayes & Harlington.\n\nTickets accepted on Piccadilly & Bakerloo until service is restored.",
+		);
 	});
 
 	it("keeps line-broken sentences together within a single paragraph", () => {
@@ -244,13 +289,14 @@ describe("disruptionsToNews", () => {
 		);
 	});
 
-	it("trims paragraphs split by CRLF blank lines so Windows-encoded payloads behave like LF ones", () => {
+	it("handles CRLF blank lines so Windows-encoded payloads strip the echoed lead too", () => {
 		const crlf: Disruption = {
 			...baseDisruption,
+			summary: "Piccadilly Line: SUSPENDED between Acton Town and Heathrow.",
 			description:
-				"Faulty train at Hayes & Harlington.\r\n\r\nTickets accepted on Piccadilly & Bakerloo until service is restored.",
+				"Piccadilly Line: SUSPENDED between Acton Town and Heathrow.\r\n\r\nTickets accepted on London Buses.",
 		};
 		const [item] = disruptionsToNews([crlf]);
-		expect(item.body).toBe("Faulty train at Hayes & Harlington.");
+		expect(item.body).toBe("Tickets accepted on London Buses.");
 	});
 });

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -249,12 +249,17 @@ function extraParagraphs(summary: string, description: string): string {
  * consumes. Station names degrade to the raw stop ID when we lack a
  * richer registry — Phase 5 keeps the projection minimal; richer
  * naming comes when the disruption stream is wired end-to-end.
+ *
+ * The leading paragraph of `description` is dropped when it exactly
+ * matches `summary` — TfL's Unified API repeats the summary as the
+ * first paragraph of `description` for most payloads, so without this
+ * the LineDetail card would render the headline once and then again
+ * as the first body paragraph.
  */
 export function disruptionToSnapshot(d: Disruption): DisruptionSnapshot {
-	const body = d.description
-		.split(PARAGRAPH_SPLIT_RE)
-		.map((paragraph) => paragraph.trim())
-		.filter((paragraph) => paragraph.length > 0);
+	const paragraphs = splitParagraphs(d.description);
+	const body =
+		paragraphs[0] === d.summary.trim() ? paragraphs.slice(1) : paragraphs;
 	const stations = d.affected_stops.map((stop) => ({
 		name: stop,
 		code: stop,

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -201,10 +201,12 @@ export function disruptionForLine(
  * recent updates surface first; the component handles slot truncation.
  *
  * `time` uses the London-local `HH:MM` format the design canvas
- * specifies. The `body` is trimmed to the first paragraph of
- * `description` so the dense news list does not overflow when the TfL
- * payload carries a multi-paragraph blob — the LineDetail card already
- * surfaces the full description.
+ * specifies. The `body` carries only the *extra* paragraphs of
+ * `description` — TfL's Unified API repeats `summary` as the first
+ * paragraph of `description` in nearly every payload, so projecting
+ * the whole description into the body produces a duplicate of the
+ * title. We strip the leading paragraph when it matches `summary`
+ * and join any remaining paragraphs with a blank line.
  */
 export function disruptionsToNews(disruptions: Disruption[]): NewsItem[] {
 	const sorted = [...disruptions].sort((a, b) => {
@@ -217,7 +219,7 @@ export function disruptionsToNews(disruptions: Disruption[]): NewsItem[] {
 	return sorted.map((d) => ({
 		time: formatLondonTime(d.last_update),
 		title: d.summary,
-		body: firstParagraph(d.description),
+		body: extraParagraphs(d.summary, d.description),
 	}));
 }
 
@@ -227,9 +229,19 @@ export function disruptionsToNews(disruptions: Disruption[]): NewsItem[] {
 // and the snapshot body trimmed under both line-ending conventions.
 const PARAGRAPH_SPLIT_RE = /\r?\n\s*\r?\n+/;
 
-function firstParagraph(description: string): string {
-	const [first] = description.split(PARAGRAPH_SPLIT_RE);
-	return first.trim();
+function splitParagraphs(description: string): string[] {
+	return description
+		.split(PARAGRAPH_SPLIT_RE)
+		.map((paragraph) => paragraph.trim())
+		.filter((paragraph) => paragraph.length > 0);
+}
+
+function extraParagraphs(summary: string, description: string): string {
+	const paragraphs = splitParagraphs(description);
+	if (paragraphs.length === 0) return "";
+	const head = paragraphs[0];
+	const rest = head === summary.trim() ? paragraphs.slice(1) : paragraphs;
+	return rest.join("\n\n");
 }
 
 /**

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -354,7 +354,7 @@
 .tfl-news-placeholder { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
 .tfl-news-time { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
 .tfl-news-title { font-family: var(--font-body); font-size: var(--ui-sm); font-weight: 500; color: var(--ink-primary); margin-bottom: 2px; }
-.tfl-news-body { font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary); line-height: 1.45; }
+.tfl-news-body { font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary); line-height: 1.45; white-space: pre-line; }
 
 @media (max-width: 880px) {
   .tfl-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary

Follow-up polish on top of PR #89 (TM-F3 BusBanner + NewsReports finalisation). Two related fixes uncovered while watching the live API on the deployed dashboard:

- **Strip echoed summary**: TfL's Unified API repeats `summary` as the first paragraph of `description` in nearly every payload. Projecting the whole description onto the news `body` produced a visible duplicate of the title. New `extraParagraphs(summary, description)` in `web/lib/dashboard/adapt.ts` drops the leading paragraph when it equals `summary` and joins any remaining paragraphs with a blank line.
- **Omit empty body**: when an item has no extra context to show (e.g. a disruption whose description is *only* the echoed summary), the `<div class="tfl-news-body">` rendered empty and left a layout gap. `web/components/dashboard/news-reports.tsx` now conditionally renders the body.
- **Default `slotCount` 3 → 6** to match the dashboard's left-column real estate; the existing override in the test still pins it to 3 where needed.

## Test plan

- [x] `pnpm --dir web lint` passes
- [x] `pnpm --dir web test` passes — new cases cover echo / only-echo / distinct / multi-paragraph / CRLF / empty-body
- [ ] Manual: verify on the live dashboard that disruptions whose description echoes the summary no longer render duplicated title text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard news section now defaults to displaying 6 items.

* **Bug Fixes**
  * News items with empty bodies no longer display blank sections.
  * Improved handling of duplicate summary text in news descriptions.
  * Multi-paragraph descriptions now format correctly.

* **Tests**
  * Enhanced test coverage for news rendering and description handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->