### PR TITLE
feat(web): LineDetail falls back to /status/live reason when no disruption matches

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -16,6 +16,7 @@ import {
 	disruptionsToNews,
 	disruptionToSnapshot,
 	lineStatusesToSummaries,
+	lineSummaryToFallbackSnapshot,
 	summarizeCounts,
 } from "@/lib/dashboard/adapt";
 import { useAutoRefresh } from "@/lib/hooks/use-auto-refresh";
@@ -67,9 +68,12 @@ export default function HomePage() {
 	);
 
 	const selectedDisruption = useMemo(() => {
-		if (!selectedLine || !disruptions.data) return undefined;
-		const match = disruptionForLine(disruptions.data, selectedLine);
-		return match ? disruptionToSnapshot(match) : undefined;
+		if (!selectedLine) return undefined;
+		if (disruptions.data) {
+			const match = disruptionForLine(disruptions.data, selectedLine);
+			if (match) return disruptionToSnapshot(match);
+		}
+		return lineSummaryToFallbackSnapshot(selectedLine);
 	}, [disruptions.data, selectedLine]);
 
 	const newsItems = useMemo(

--- a/web/components/dashboard/types.ts
+++ b/web/components/dashboard/types.ts
@@ -17,6 +17,19 @@ export interface LineSummary {
 	status: StatusBucket;
 	statusText: string;
 	updatedLabel: string;
+	/**
+	 * Free-text disruption explanation propagated from `/status/live`'s
+	 * `reason` field. Null for `Good Service` lines. Used as a fallback
+	 * for the LineDetail card when no matching `/disruptions/recent`
+	 * row exists for the selected line.
+	 */
+	reason?: string | null;
+	/**
+	 * ISO timestamp of the underlying `LineStatus.valid_from` field —
+	 * threaded so the fallback snapshot built from `reason` can render
+	 * a "reported HH:MM" label without re-fetching the raw row.
+	 */
+	validFromIso?: string;
 }
 
 export interface StatusSummaryCounts {

--- a/web/lib/api/status-live.ts
+++ b/web/lib/api/status-live.ts
@@ -59,7 +59,7 @@ function lineSummaryToLineStatus(line: LineSummary, now: Date): LineStatus {
 		mode: CODE_TO_MODE[line.code] ?? "tube",
 		status_severity: BUCKET_TO_SEVERITY[line.status],
 		status_severity_description: line.statusText,
-		reason: null,
+		reason: line.reason ?? null,
 		valid_from: validFrom.toISOString(),
 		valid_to: validTo.toISOString(),
 	};

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -7,6 +7,7 @@ import {
 	disruptionsToNews,
 	disruptionToSnapshot,
 	lineStatusesToSummaries,
+	lineSummaryToFallbackSnapshot,
 	severityToBucket,
 	summarizeCounts,
 } from "@/lib/dashboard/adapt";
@@ -64,6 +65,26 @@ describe("lineStatusesToSummaries", () => {
 			color: "#6950A1",
 			status: "severe",
 		});
+	});
+
+	it("threads reason + validFromIso onto the summary so the LineDetail fallback can use them", () => {
+		const [, elizabeth] = lineStatusesToSummaries([
+			SAMPLE_LINES[0],
+			{
+				...SAMPLE_LINES[1],
+				reason: "Elizabeth line: signal failure at Hayes & Harlington.",
+				valid_from: "2026-05-13T17:42:00Z",
+			},
+		]);
+		expect(elizabeth.reason).toBe(
+			"Elizabeth line: signal failure at Hayes & Harlington.",
+		);
+		expect(elizabeth.validFromIso).toBe("2026-05-13T17:42:00Z");
+	});
+
+	it("normalises a missing reason to null so consumers can branch on truthy text", () => {
+		const [victoria] = lineStatusesToSummaries(SAMPLE_LINES);
+		expect(victoria.reason).toBeNull();
 	});
 
 	it("strips trailing ' line' so downstream components don't duplicate it", () => {
@@ -202,6 +223,54 @@ describe("disruptionForLine + disruptionToSnapshot", () => {
 			description: "Para 1.\n\nPara 2.\n\nPara 3.",
 		});
 		expect(snapshot.body).toEqual(["Para 1.", "Para 2.", "Para 3."]);
+	});
+});
+
+describe("lineSummaryToFallbackSnapshot", () => {
+	const baseSummary = {
+		code: "PIC",
+		name: "Piccadilly",
+		color: "#0019A8",
+		status: "suspended" as const,
+		statusText: "Part Suspended",
+		updatedLabel: "updated 6m ago",
+	};
+
+	it("returns undefined when the line has no reason text", () => {
+		expect(lineSummaryToFallbackSnapshot(baseSummary)).toBeUndefined();
+		expect(
+			lineSummaryToFallbackSnapshot({ ...baseSummary, reason: null }),
+		).toBeUndefined();
+		expect(
+			lineSummaryToFallbackSnapshot({ ...baseSummary, reason: "   " }),
+		).toBeUndefined();
+	});
+
+	it("projects the status-feed reason into a DisruptionSnapshot with empty stations", () => {
+		const snapshot = lineSummaryToFallbackSnapshot({
+			...baseSummary,
+			reason:
+				"Piccadilly Line: No service between Northfields and Heathrow Airport while we fix a signal failure at Northfields.",
+			validFromIso: "2026-05-19T23:36:00Z",
+		});
+		expect(snapshot).toBeDefined();
+		if (!snapshot) return;
+		expect(snapshot.headline).toBe("Part Suspended");
+		expect(snapshot.body).toEqual([
+			"Piccadilly Line: No service between Northfields and Heathrow Airport while we fix a signal failure at Northfields.",
+		]);
+		expect(snapshot.stations).toEqual([]);
+		expect(snapshot.sourceLabel).toBe("Source: TfL Unified API (status feed)");
+		expect(snapshot.reportedAtLabel).toMatch(/\d{2}:\d{2}/);
+		expect(snapshot.updatedAtLabel).toBe(snapshot.reportedAtLabel);
+	});
+
+	it("falls back to '—' for reportedAtLabel when validFromIso is missing", () => {
+		const snapshot = lineSummaryToFallbackSnapshot({
+			...baseSummary,
+			reason: "Something happened.",
+		});
+		expect(snapshot?.reportedAtLabel).toBe("—");
 	});
 });
 

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -87,6 +87,14 @@ describe("lineStatusesToSummaries", () => {
 		expect(victoria.reason).toBeNull();
 	});
 
+	it("coerces whitespace-only reason to null so consumers cannot trip on a truthy blank string", () => {
+		const [, elizabeth] = lineStatusesToSummaries([
+			SAMPLE_LINES[0],
+			{ ...SAMPLE_LINES[1], reason: "   \n\t  " },
+		]);
+		expect(elizabeth.reason).toBeNull();
+	});
+
 	it("strips trailing ' line' so downstream components don't duplicate it", () => {
 		const summaries = lineStatusesToSummaries([
 			{
@@ -271,6 +279,24 @@ describe("lineSummaryToFallbackSnapshot", () => {
 			reason: "Something happened.",
 		});
 		expect(snapshot?.reportedAtLabel).toBe("—");
+	});
+
+	it("splits multi-paragraph reason text so LineDetail renders each paragraph in its own <p>", () => {
+		// TfL occasionally returns reason text with explicit \n\n separators
+		// — e.g. "Piccadilly Line: suspended.\n\nTickets accepted on London Buses."
+		// Joining into a single array element would collapse the paragraph
+		// break under HTML whitespace rules; splitting matches what
+		// disruptionToSnapshot emits.
+		const snapshot = lineSummaryToFallbackSnapshot({
+			...baseSummary,
+			reason:
+				"Piccadilly Line: suspended between Acton Town and Heathrow.\n\nTickets accepted on London Buses.",
+			validFromIso: "2026-05-19T23:36:00Z",
+		});
+		expect(snapshot?.body).toEqual([
+			"Piccadilly Line: suspended between Acton Town and Heathrow.",
+			"Tickets accepted on London Buses.",
+		]);
 	});
 });
 

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -145,8 +145,38 @@ export function lineStatusesToSummaries(
 			status: severityToBucket(line.status_severity),
 			statusText: line.status_severity_description,
 			updatedLabel: relativeUpdatedLabel(line.valid_from, now),
+			reason: line.reason ?? null,
+			validFromIso: line.valid_from,
 		};
 	});
+}
+
+/**
+ * Build a `DisruptionSnapshot` from a line's status-feed `reason` text
+ * when no `/disruptions/recent` row covers the selected line.
+ *
+ * The TfL Unified API's `lineStatuses[].reason` is always the most
+ * authoritative blurb for a non-Good Service line — `/disruptions/recent`
+ * is event-style and frequently lags or omits ongoing incidents. Returns
+ * `undefined` when the line has no reason text so the caller can keep
+ * the "No reported disruption." copy.
+ */
+export function lineSummaryToFallbackSnapshot(
+	summary: LineSummary,
+): DisruptionSnapshot | undefined {
+	const reason = summary.reason?.trim();
+	if (!reason) return undefined;
+	const reportedAtLabel = summary.validFromIso
+		? formatLondonTime(summary.validFromIso, { withTimezoneName: true })
+		: "—";
+	return {
+		headline: summary.statusText,
+		body: [reason],
+		reportedAtLabel,
+		stations: [],
+		sourceLabel: "Source: TfL Unified API (status feed)",
+		updatedAtLabel: reportedAtLabel,
+	};
 }
 
 /**

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -145,7 +145,7 @@ export function lineStatusesToSummaries(
 			status: severityToBucket(line.status_severity),
 			statusText: line.status_severity_description,
 			updatedLabel: relativeUpdatedLabel(line.valid_from, now),
-			reason: line.reason ?? null,
+			reason: line.reason?.trim() || null,
 			validFromIso: line.valid_from,
 		};
 	});
@@ -171,7 +171,7 @@ export function lineSummaryToFallbackSnapshot(
 		: "—";
 	return {
 		headline: summary.statusText,
-		body: [reason],
+		body: splitParagraphs(reason),
 		reportedAtLabel,
 		stations: [],
 		sourceLabel: "Source: TfL Unified API (status feed)",

--- a/web/lib/mocks/lines.ts
+++ b/web/lib/mocks/lines.ts
@@ -49,6 +49,8 @@ export const MOCK_LINES: LineSummary[] = [
 		status: "severe",
 		statusText: "Severe delays",
 		updatedLabel: "updated 2m ago",
+		reason:
+			"Elizabeth line: Severe delays between Paddington and Reading due to a faulty train at Hayes & Harlington.\n\nTickets accepted on local buses and on GWR services between affected stations.",
 	},
 	{
 		code: "HAM",
@@ -105,6 +107,8 @@ export const MOCK_LINES: LineSummary[] = [
 		status: "suspended",
 		statusText: "Suspended",
 		updatedLabel: "updated 2m ago",
+		reason:
+			"Waterloo & City Line: No service while we fix a signal failure at Bank.",
 	},
 	{
 		code: "DLR",


### PR DESCRIPTION
## Summary

- `LineDetail` used to render "No reported disruption." for every non-Good Service line, because `/disruptions/recent`'s `affected_routes` is currently empty for every row (separate backend bug — issue to be filed in Linear).
- `/status/live` already carries the canonical TfL incident blurb in `LineStatus.reason`. This PR projects it into a `DisruptionSnapshot` fallback so a tapped Piccadilly / Northern / DLR row immediately surfaces the live incident text.
- `LineSummary` gains optional `reason: string | null` and `validFromIso: string` so the fallback projection in `lineSummaryToFallbackSnapshot` is self-contained — no need to thread the raw `LineStatus[]` through to the page.
- The fallback stays useful even after the backend disruptions feed is fixed, since `/status/live.reason` is the lower-latency source for active incidents.

## Files

- `web/components/dashboard/types.ts` — extends `LineSummary` with optional `reason` + `validFromIso`.
- `web/lib/dashboard/adapt.ts` — `lineStatusesToSummaries` threads the two new fields; new `lineSummaryToFallbackSnapshot(summary)` projects `reason` into a `DisruptionSnapshot` with empty stations and `sourceLabel: "Source: TfL Unified API (status feed)"`.
- `web/app/page.tsx` — `selectedDisruption` falls back to `lineSummaryToFallbackSnapshot(selectedLine)` when `disruptionForLine` returns nothing.
- `web/lib/dashboard/__tests__/adapt.test.ts` — 5 new tests covering field threading, null normalisation, and the three fallback branches (no reason → undefined, with reason → full snapshot, missing `validFromIso` → "—" label).

## Test plan

- [x] `pnpm test` — 88 / 88 green
- [x] `pnpm lint` — biome clean
- [ ] Manual: open the dashboard, tap a non-Good Service line (Piccadilly / Northern / DLR), confirm the right pane renders the TfL `reason` text instead of "No reported disruption."

## Out of scope

- Backend fix for `/disruptions/recent.affected_routes` being empty across the board — separate Linear issue.
- "Reported HH:MM" label divergence when the fallback fires (status-feed `valid_from` vs disruption-feed `created`); the source label disambiguates the origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)