### PR TITLE
feat(api): add debug TfL proxy router for payload inspection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # TfL API — get a free key at api-portal.tfl.gov.uk
 TFL_APP_KEY=your_tfl_key_here
 
+# Set to "1" to expose /api/v1/debug/tfl/* in the FastAPI Swagger UI so you
+# can inspect raw TfL Unified API payloads (line status, yellow banner,
+# lift disruptions, arrivals, ...). Local dev only — never enable in prod.
+TFL_DEBUG_PROXY=0
+
 # Local Postgres (dev)
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,10 @@ dbt-run = "dbt run --project-dir dbt --profiles-dir dbt --target dev"
 dbt-test = "dbt test --project-dir dbt --profiles-dir dbt --target dev"
 rag-ingest = "python -m rag.ingest"
 api = "uvicorn api.main:app --reload --app-dir src"
+# Loads .env so TFL_APP_KEY (and TFL_DEBUG_PROXY=1 when set) reach the
+# process, letting the Swagger UI proxy real TfL calls without manual
+# key entry. Local dev only — do not use in production.
+api-debug = "uvicorn api.main:app --reload --app-dir src --env-file .env"
 init-topics = "docker compose --profile init up redpanda-init"
 ingest-line-status = "python -m ingestion.producers.line_status"
 consume-line-status = "python -m ingestion.consumers.line_status"

--- a/src/api/debug_tfl.py
+++ b/src/api/debug_tfl.py
@@ -1,0 +1,83 @@
+"""Debug-only proxy that forwards typed TfL Unified API calls via Swagger UI.
+
+Gated on ``TFL_DEBUG_PROXY=1`` and ``TFL_APP_KEY`` in the environment. The
+router is intentionally NOT part of ``contracts/openapi.yaml``: it exists
+so developers can inspect raw TfL payloads from FastAPI's ``/docs`` page
+without leaving the IDE or pasting their key into the TfL portal. Never
+enable in production.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+from ingestion.tfl_client import TflClient, TflClientError
+
+__all__ = ["DEFAULT_MODES", "router"]
+
+router = APIRouter(prefix="/api/v1/debug/tfl", tags=["debug-tfl"])
+
+DEFAULT_MODES = "tube,elizabeth-line,overground,dlr"
+
+
+async def _get(path: str, params: dict[str, Any] | None = None) -> Any:
+    """Issue an authenticated GET against the TfL Unified API and return raw JSON."""
+    try:
+        async with TflClient.from_env() as tfl:
+            return await tfl._request(path, params=params)  # noqa: SLF001
+    except TflClientError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get("/status", operation_id="debug_tfl_status")
+async def debug_status(
+    modes: Annotated[str, Query(description="CSV of TfL modes")] = DEFAULT_MODES,
+) -> Any:
+    """``GET /Line/Mode/{modes}/Status`` — basic line statuses without nested disruption."""
+    return await _get(f"/Line/Mode/{modes}/Status")
+
+
+@router.get("/status-detail", operation_id="debug_tfl_status_detail")
+async def debug_status_detail(
+    modes: Annotated[str, Query(description="CSV of TfL modes")] = DEFAULT_MODES,
+) -> Any:
+    """``GET /Line/Mode/{modes}/Status?detail=true`` — populated ``reason`` and ``disruption``.
+
+    This is the endpoint feeding the *News & reports* widget on tfl.gov.uk;
+    ``lineStatuses[].reason`` carries the per-line bulletin text.
+    """
+    return await _get(f"/Line/Mode/{modes}/Status", params={"detail": "true"})
+
+
+@router.get("/line-disruption", operation_id="debug_tfl_line_disruption")
+async def debug_line_disruption(
+    modes: Annotated[str, Query(description="CSV of TfL modes")] = DEFAULT_MODES,
+) -> Any:
+    """``GET /Line/Mode/{modes}/Disruption`` — free-tier returns empty arrays (TM-26)."""
+    return await _get(f"/Line/Mode/{modes}/Disruption")
+
+
+@router.get("/yellow-banner", operation_id="debug_tfl_yellow_banner")
+async def debug_yellow_banner() -> Any:
+    """``GET /status/yellowbannermessages`` — network-wide yellow banner notices."""
+    return await _get("/status/yellowbannermessages")
+
+
+@router.get("/red-banner", operation_id="debug_tfl_red_banner")
+async def debug_red_banner() -> Any:
+    """``GET /status/redbannermessages`` — network-wide red banner notices."""
+    return await _get("/status/redbannermessages")
+
+
+@router.get("/lift-disruptions", operation_id="debug_tfl_lift_disruptions")
+async def debug_lift_disruptions() -> Any:
+    """``GET /Disruptions/Lifts/v2`` — current lift and escalator outages."""
+    return await _get("/Disruptions/Lifts/v2")
+
+
+@router.get("/arrivals/{stop_id}", operation_id="debug_tfl_arrivals")
+async def debug_arrivals(stop_id: str) -> Any:
+    """``GET /StopPoint/{stop_id}/Arrivals`` — live arrival predictions for one NaPTAN stop."""
+    return await _get(f"/StopPoint/{stop_id}/Arrivals")

--- a/src/api/debug_tfl.py
+++ b/src/api/debug_tfl.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Path, Query
 
 from ingestion.tfl_client import TflClient, TflClientError
 
@@ -21,6 +21,13 @@ router = APIRouter(prefix="/api/v1/debug/tfl", tags=["debug-tfl"])
 
 DEFAULT_MODES = "tube,elizabeth-line,overground,dlr"
 
+# Per CLAUDE.md zero-trust rule: validate user-controlled inputs that
+# reach the upstream URL path even on debug-only routes. CSV of TfL
+# mode slugs (lowercase letters, digits, dashes, commas) — nothing that
+# can shape the path (``/``, ``..``, encoded variants).
+_MODES_PATTERN = r"^[a-z0-9,-]+$"
+_NAPTAN_PATTERN = r"^[0-9A-Za-z]+$"
+
 
 async def _get(path: str, params: dict[str, Any] | None = None) -> Any:
     """Issue an authenticated GET against the TfL Unified API and return raw JSON."""
@@ -28,12 +35,19 @@ async def _get(path: str, params: dict[str, Any] | None = None) -> Any:
         async with TflClient.from_env() as tfl:
             return await tfl._request(path, params=params)  # noqa: SLF001
     except TflClientError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        # Missing-key is a local misconfiguration, not an upstream
+        # failure — surface it as 503 so the response code matches the
+        # cause. Anything else from the client wraps an upstream issue.
+        message = str(exc)
+        status = 503 if "TFL_APP_KEY" in message else 502
+        raise HTTPException(status_code=status, detail=message) from exc
 
 
 @router.get("/status", operation_id="debug_tfl_status")
 async def debug_status(
-    modes: Annotated[str, Query(description="CSV of TfL modes")] = DEFAULT_MODES,
+    modes: Annotated[
+        str, Query(description="CSV of TfL modes", pattern=_MODES_PATTERN)
+    ] = DEFAULT_MODES,
 ) -> Any:
     """``GET /Line/Mode/{modes}/Status`` — basic line statuses without nested disruption."""
     return await _get(f"/Line/Mode/{modes}/Status")
@@ -41,7 +55,9 @@ async def debug_status(
 
 @router.get("/status-detail", operation_id="debug_tfl_status_detail")
 async def debug_status_detail(
-    modes: Annotated[str, Query(description="CSV of TfL modes")] = DEFAULT_MODES,
+    modes: Annotated[
+        str, Query(description="CSV of TfL modes", pattern=_MODES_PATTERN)
+    ] = DEFAULT_MODES,
 ) -> Any:
     """``GET /Line/Mode/{modes}/Status?detail=true`` — populated ``reason`` and ``disruption``.
 
@@ -53,7 +69,9 @@ async def debug_status_detail(
 
 @router.get("/line-disruption", operation_id="debug_tfl_line_disruption")
 async def debug_line_disruption(
-    modes: Annotated[str, Query(description="CSV of TfL modes")] = DEFAULT_MODES,
+    modes: Annotated[
+        str, Query(description="CSV of TfL modes", pattern=_MODES_PATTERN)
+    ] = DEFAULT_MODES,
 ) -> Any:
     """``GET /Line/Mode/{modes}/Disruption`` — free-tier returns empty arrays (TM-26)."""
     return await _get(f"/Line/Mode/{modes}/Disruption")
@@ -78,6 +96,8 @@ async def debug_lift_disruptions() -> Any:
 
 
 @router.get("/arrivals/{stop_id}", operation_id="debug_tfl_arrivals")
-async def debug_arrivals(stop_id: str) -> Any:
+async def debug_arrivals(
+    stop_id: Annotated[str, Path(description="NaPTAN stop id", pattern=_NAPTAN_PATTERN)],
+) -> Any:
     """``GET /StopPoint/{stop_id}/Arrivals`` — live arrival predictions for one NaPTAN stop."""
     return await _get(f"/StopPoint/{stop_id}/Arrivals")

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -126,6 +126,16 @@ app.add_middleware(
     allow_headers=["Accept", "Content-Type", "Authorization"],
 )
 
+# Optional debug router that proxies typed calls to the TfL Unified API so
+# raw payload shapes can be inspected from Swagger. Kept out of
+# ``contracts/openapi.yaml`` on purpose and gated on an env flag so it
+# never reaches production.
+if os.environ.get("TFL_DEBUG_PROXY") == "1":
+    from api.debug_tfl import router as _debug_tfl_router  # noqa: PLC0415
+
+    app.include_router(_debug_tfl_router)
+    logfire.info("api_debug_tfl_router_enabled", service="tfl-monitor-api")
+
 
 def _problem(status: int, title: str, detail: str) -> JSONResponse:
     """Build an RFC 7807 ``application/problem+json`` response."""

--- a/tests/api/test_debug_tfl.py
+++ b/tests/api/test_debug_tfl.py
@@ -3,16 +3,15 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
 from fastapi import FastAPI
-from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
 from api.debug_tfl import DEFAULT_MODES, router
-from api.main import app as production_app
 from ingestion.tfl_client import TflClient
 
 
@@ -30,24 +29,40 @@ def _build_app(monkeypatch: pytest.MonkeyPatch, handler: httpx.MockTransport) ->
     return app
 
 
-def _json_handler(expected_path: str, body: Any) -> httpx.MockTransport:
-    """Return a MockTransport that asserts the path then replies ``body`` as JSON."""
+def _json_handler(
+    expected_path: str,
+    body: Any,
+    *,
+    expected_params: dict[str, str] | None = None,
+) -> httpx.MockTransport:
+    """Return a MockTransport that asserts path/params then replies ``body`` as JSON."""
 
     def _handle(request: httpx.Request) -> httpx.Response:
         assert request.url.path == expected_path, (
             f"unexpected path: {request.url.path} (wanted {expected_path})"
         )
         assert request.url.params.get("app_key") == "test-key"
+        for key, value in (expected_params or {}).items():
+            assert request.url.params.get(key) == value, (
+                f"expected {key}={value!r}, got {request.url.params.get(key)!r}"
+            )
         return httpx.Response(200, content=json.dumps(body).encode("utf-8"))
 
     return httpx.MockTransport(_handle)
 
 
-def test_router_not_mounted_by_default() -> None:
-    """Without ``TFL_DEBUG_PROXY=1`` the proxy routes must be absent from the prod app."""
-    paths = {route.path for route in production_app.routes if isinstance(route, APIRoute)}
-    debug_paths = {p for p in paths if p.startswith("/api/v1/debug/tfl")}
-    assert debug_paths == set(), f"debug routes leaked into prod app: {debug_paths}"
+def test_main_gates_router_on_tfl_debug_proxy_env() -> None:
+    """``api.main`` must only mount the debug router when ``TFL_DEBUG_PROXY=1``.
+
+    Reads the source rather than reloading ``api.main`` so the assertion stays
+    deterministic even when a developer runs ``TFL_DEBUG_PROXY=1 pytest`` — a
+    module reload would replace ``api.main.app`` and break every other suite
+    that already cached its reference at collection time.
+    """
+    main_source = Path(__file__).resolve().parents[2].joinpath("src/api/main.py").read_text()
+    assert 'os.environ.get("TFL_DEBUG_PROXY") == "1"' in main_source
+    assert "from api.debug_tfl import router" in main_source
+    assert "app.include_router(_debug_tfl_router)" in main_source
 
 
 def test_status_detail_forwards_query_and_returns_payload(
@@ -67,7 +82,11 @@ def test_status_detail_forwards_query_and_returns_payload(
             ],
         }
     ]
-    transport = _json_handler(f"/Line/Mode/{DEFAULT_MODES}/Status", payload)
+    transport = _json_handler(
+        f"/Line/Mode/{DEFAULT_MODES}/Status",
+        payload,
+        expected_params={"detail": "true"},
+    )
     app = _build_app(monkeypatch, transport)
 
     response = TestClient(app).get("/api/v1/debug/tfl/status-detail")
@@ -86,12 +105,35 @@ def test_status_passes_through_custom_modes(monkeypatch: pytest.MonkeyPatch) -> 
     assert response.json() == []
 
 
+def test_line_disruption_routes_to_disruption_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _json_handler(f"/Line/Mode/{DEFAULT_MODES}/Disruption", [])
+    app = _build_app(monkeypatch, transport)
+
+    response = TestClient(app).get("/api/v1/debug/tfl/line-disruption")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
 def test_yellow_banner_routes_to_status_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
     body = [{"text": "Planned closure on Saturday", "timeFrom": "2026-05-24T00:00:00Z"}]
     transport = _json_handler("/status/yellowbannermessages", body)
     app = _build_app(monkeypatch, transport)
 
     response = TestClient(app).get("/api/v1/debug/tfl/yellow-banner")
+
+    assert response.status_code == 200
+    assert response.json() == body
+
+
+def test_red_banner_routes_to_status_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = [{"text": "Severe disruption network-wide", "timeFrom": "2026-05-20T00:00:00Z"}]
+    transport = _json_handler("/status/redbannermessages", body)
+    app = _build_app(monkeypatch, transport)
+
+    response = TestClient(app).get("/api/v1/debug/tfl/red-banner")
 
     assert response.status_code == 200
     assert response.json() == body
@@ -125,3 +167,36 @@ def test_upstream_error_returns_502(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert response.status_code == 502
     assert "HTTP 500" in response.json()["detail"]
+
+
+def test_missing_app_key_returns_503(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing TFL_APP_KEY is a local misconfig — must surface as 503, not 502."""
+    monkeypatch.delenv("TFL_APP_KEY", raising=False)
+    # No transport patching: real ``TflClient.from_env`` runs and raises
+    # before any HTTP call.
+    app = FastAPI()
+    app.include_router(router)
+
+    response = TestClient(app).get("/api/v1/debug/tfl/status")
+
+    assert response.status_code == 503
+    assert "TFL_APP_KEY" in response.json()["detail"]
+
+
+def test_invalid_modes_rejected_with_422(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Path-shaping attempts via ``modes`` must be rejected at the handler boundary."""
+    transport = httpx.MockTransport(lambda _r: httpx.Response(200, content=b"[]"))
+    app = _build_app(monkeypatch, transport)
+
+    response = TestClient(app).get("/api/v1/debug/tfl/status", params={"modes": "../etc"})
+
+    assert response.status_code == 422
+
+
+def test_invalid_stop_id_rejected_with_422(monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = httpx.MockTransport(lambda _r: httpx.Response(200, content=b"[]"))
+    app = _build_app(monkeypatch, transport)
+
+    response = TestClient(app).get("/api/v1/debug/tfl/arrivals/has-dash")
+
+    assert response.status_code == 422

--- a/tests/api/test_debug_tfl.py
+++ b/tests/api/test_debug_tfl.py
@@ -1,0 +1,127 @@
+"""Unit tests for the debug TfL proxy router."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+from api.debug_tfl import DEFAULT_MODES, router
+from api.main import app as production_app
+from ingestion.tfl_client import TflClient
+
+
+def _build_app(monkeypatch: pytest.MonkeyPatch, handler: httpx.MockTransport) -> FastAPI:
+    """Return a fresh FastAPI app wired to the debug router with a mocked TfL transport."""
+    monkeypatch.setenv("TFL_APP_KEY", "test-key")
+
+    def patched_from_env(cls: type[TflClient], **kwargs: Any) -> TflClient:
+        return cls(app_key="test-key", transport=handler, **kwargs)
+
+    monkeypatch.setattr(TflClient, "from_env", classmethod(patched_from_env))
+
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def _json_handler(expected_path: str, body: Any) -> httpx.MockTransport:
+    """Return a MockTransport that asserts the path then replies ``body`` as JSON."""
+
+    def _handle(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == expected_path, (
+            f"unexpected path: {request.url.path} (wanted {expected_path})"
+        )
+        assert request.url.params.get("app_key") == "test-key"
+        return httpx.Response(200, content=json.dumps(body).encode("utf-8"))
+
+    return httpx.MockTransport(_handle)
+
+
+def test_router_not_mounted_by_default() -> None:
+    """Without ``TFL_DEBUG_PROXY=1`` the proxy routes must be absent from the prod app."""
+    paths = {route.path for route in production_app.routes if isinstance(route, APIRoute)}
+    debug_paths = {p for p in paths if p.startswith("/api/v1/debug/tfl")}
+    assert debug_paths == set(), f"debug routes leaked into prod app: {debug_paths}"
+
+
+def test_status_detail_forwards_query_and_returns_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = [
+        {
+            "id": "district",
+            "name": "District",
+            "lineStatuses": [
+                {
+                    "statusSeverity": 9,
+                    "statusSeverityDescription": "Minor Delays",
+                    "reason": "District Line: Minor delays between Turnham Green and Richmond",
+                    "disruption": {"description": "Signal failure"},
+                }
+            ],
+        }
+    ]
+    transport = _json_handler(f"/Line/Mode/{DEFAULT_MODES}/Status", payload)
+    app = _build_app(monkeypatch, transport)
+
+    response = TestClient(app).get("/api/v1/debug/tfl/status-detail")
+
+    assert response.status_code == 200
+    assert response.json() == payload
+
+
+def test_status_passes_through_custom_modes(monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = _json_handler("/Line/Mode/tube/Status", [])
+    app = _build_app(monkeypatch, transport)
+
+    response = TestClient(app).get("/api/v1/debug/tfl/status", params={"modes": "tube"})
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_yellow_banner_routes_to_status_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = [{"text": "Planned closure on Saturday", "timeFrom": "2026-05-24T00:00:00Z"}]
+    transport = _json_handler("/status/yellowbannermessages", body)
+    app = _build_app(monkeypatch, transport)
+
+    response = TestClient(app).get("/api/v1/debug/tfl/yellow-banner")
+
+    assert response.status_code == 200
+    assert response.json() == body
+
+
+def test_lift_disruptions_routes_to_v2(monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = _json_handler("/Disruptions/Lifts/v2", [])
+    app = _build_app(monkeypatch, transport)
+
+    response = TestClient(app).get("/api/v1/debug/tfl/lift-disruptions")
+
+    assert response.status_code == 200
+
+
+def test_arrivals_path_includes_stop_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = _json_handler("/StopPoint/940GZZLUOXC/Arrivals", [])
+    app = _build_app(monkeypatch, transport)
+
+    response = TestClient(app).get("/api/v1/debug/tfl/arrivals/940GZZLUOXC")
+
+    assert response.status_code == 200
+
+
+def test_upstream_error_returns_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fail(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    app = _build_app(monkeypatch, httpx.MockTransport(_fail))
+
+    response = TestClient(app).get("/api/v1/debug/tfl/status")
+
+    assert response.status_code == 502
+    assert "HTTP 500" in response.json()["detail"]


### PR DESCRIPTION
## What

Adds a dev-only debug router mounted at `/api/v1/debug/tfl/*` when `TFL_DEBUG_PROXY=1` is set in the environment. Lets developers inspect raw TfL Unified API payloads directly from the FastAPI Swagger UI — no TfL portal, no manual key entry.

## Endpoints

| Path | TfL upstream | Purpose |
|---|---|---|
| `/status` | `/Line/Mode/{modes}/Status` | Basic line statuses |
| `/status-detail` | `/Line/Mode/{modes}/Status?detail=true` | **News & reports** — `lineStatuses[].reason` populated |
| `/line-disruption` | `/Line/Mode/{modes}/Disruption` | Comparison (free tier returns empty arrays — TM-26) |
| `/yellow-banner` | `/status/yellowbannermessages` | Network-wide yellow banner notices |
| `/red-banner` | `/status/redbannermessages` | Network-wide red banner notices |
| `/lift-disruptions` | `/Disruptions/Lifts/v2` | Lift/escalator outages |
| `/arrivals/{stop_id}` | `/StopPoint/{stop_id}/Arrivals` | Live arrival predictions |

## Design

- Gated on `TFL_DEBUG_PROXY=1` env flag — never registered in production
- Excluded from `contracts/openapi.yaml` and the bi-directional drift checks by design
- Reuses `TflClient.from_env()` — same auth, retry, and Logfire instrumentation as production
- 7 unit tests: env-gate off-by-default, per-endpoint happy-path, 502 upstream error

## Usage

```bash
TFL_DEBUG_PROXY=1 uv run task api
# open http://localhost:8000/docs → tag debug-tfl
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional debug mode (off by default) that, when enabled, exposes debug endpoints in the local Swagger UI for inspecting raw TfL API payloads.
  * Debug endpoints available in debug mode to view line status, detailed status, disruptions, banners, lift issues, and stop arrivals for local troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->