### PR TITLE
feat(web): dashboard layout reorg + News pane behaviour (TM-28)

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -86,24 +86,26 @@ export default function HomePage() {
 	return (
 		<div className="tfl-app">
 			<TopNav summary={counts} clockLabel={clockLabel} repoUrl={REPO_URL} />
-			<main className="tfl-grid">
-				<div className="tfl-left-col">
+			<main className="tfl-shell">
+				<section className="tfl-grid">
 					<LineGrid
 						lines={lineSummaries}
 						selected={selectedCode ?? undefined}
 						onSelect={setSelectedCode}
 					/>
-					<div className="tfl-left-bottom">
-						<BusBanner buses={MOCK_BUSES} />
-						<NewsReports items={newsItems} />
+					<div className="tfl-right-col">
+						{selectedLine ? (
+							<LineDetail line={selectedLine} disruption={selectedDisruption} />
+						) : null}
+						<ChatPanel />
 					</div>
-				</div>
-				<div className="tfl-right-col">
-					{selectedLine ? (
-						<LineDetail line={selectedLine} disruption={selectedDisruption} />
-					) : null}
-					<ChatPanel />
-				</div>
+				</section>
+				<section className="tfl-news-band">
+					<NewsReports items={newsItems} />
+				</section>
+				<section className="tfl-bus-band">
+					<BusBanner buses={MOCK_BUSES} />
+				</section>
 			</main>
 			<WorkInProgress
 				label="TfL Monitor — still being built"

--- a/web/components/dashboard/__tests__/news-reports.test.tsx
+++ b/web/components/dashboard/__tests__/news-reports.test.tsx
@@ -23,7 +23,7 @@ describe("NewsReports", () => {
 		expect(
 			screen.getByText(/Elizabeth line — westbound severe delays/),
 		).toBeInTheDocument();
-		expect(screen.getByText(/1 today/)).toBeInTheDocument();
+		expect(screen.getByText(/1 in last 12h/)).toBeInTheDocument();
 		expect(screen.queryByText(/No further updates/)).not.toBeInTheDocument();
 		expect(document.querySelectorAll(".tfl-news-list > li")).toHaveLength(1);
 	});
@@ -56,7 +56,7 @@ describe("NewsReports", () => {
 		render(<NewsReports items={[]} />);
 
 		expect(screen.getByText(/No recent updates/)).toBeInTheDocument();
-		expect(screen.getByText(/0 today/)).toBeInTheDocument();
+		expect(screen.getByText(/0 in last 12h/)).toBeInTheDocument();
 	});
 
 	it("renders all supplied items beyond the visible window so the scroll surface stays populated", () => {
@@ -71,7 +71,7 @@ describe("NewsReports", () => {
 
 		render(<NewsReports items={items} />);
 
-		expect(screen.getByText(/8 today/)).toBeInTheDocument();
+		expect(screen.getByText(/8 in last 12h/)).toBeInTheDocument();
 		expect(document.querySelectorAll(".tfl-news-list > li")).toHaveLength(8);
 	});
 });

--- a/web/components/dashboard/__tests__/news-reports.test.tsx
+++ b/web/components/dashboard/__tests__/news-reports.test.tsx
@@ -3,7 +3,11 @@ import { render, screen } from "@testing-library/react";
 import { NewsReports } from "../news-reports";
 
 describe("NewsReports", () => {
-	it("renders supplied items and pads empty slots up to the slot count", () => {
+	it("renders only the supplied items without padding empty slots", () => {
+		// Pre-TM-28 the component padded the list up to `slotCount` with
+		// "No further updates" placeholder rows. Now the list is a fixed-
+		// height scroll surface, so empty rows would create dead space
+		// when the warehouse has fewer than 5 fresh disruptions.
 		render(
 			<NewsReports
 				items={[
@@ -13,7 +17,6 @@ describe("NewsReports", () => {
 						body: "Faulty train at Hayes & Harlington.",
 					},
 				]}
-				slotCount={3}
 			/>,
 		);
 
@@ -21,7 +24,8 @@ describe("NewsReports", () => {
 			screen.getByText(/Elizabeth line — westbound severe delays/),
 		).toBeInTheDocument();
 		expect(screen.getByText(/1 today/)).toBeInTheDocument();
-		expect(screen.getAllByText(/No further updates/)).toHaveLength(2);
+		expect(screen.queryByText(/No further updates/)).not.toBeInTheDocument();
+		expect(document.querySelectorAll(".tfl-news-list > li")).toHaveLength(1);
 	});
 
 	it("omits the body line when an item has no extra context to show", () => {
@@ -34,7 +38,6 @@ describe("NewsReports", () => {
 						body: "",
 					},
 				]}
-				slotCount={1}
 			/>,
 		);
 
@@ -47,16 +50,28 @@ describe("NewsReports", () => {
 		expect(document.querySelector(".tfl-news-body")).not.toBeInTheDocument();
 	});
 
-	it("reports the full item count in the meta label even when slots truncate", () => {
-		const items = Array.from({ length: 5 }, (_, i) => ({
+	it("renders an empty-state row when no disruptions are supplied", () => {
+		// Cold-DB sentinel — the news pane should not look broken before
+		// the first ingestion cycle has populated `disruptions_recent`.
+		render(<NewsReports items={[]} />);
+
+		expect(screen.getByText(/No recent updates/)).toBeInTheDocument();
+		expect(screen.getByText(/0 today/)).toBeInTheDocument();
+	});
+
+	it("renders all supplied items beyond the visible window so the scroll surface stays populated", () => {
+		// The visible window (max 5 rows) is enforced by CSS height +
+		// overflow. The component must keep every item in the DOM so
+		// the user can scroll to the older entries without re-fetching.
+		const items = Array.from({ length: 8 }, (_, i) => ({
 			time: `0${i}:00`,
 			title: `Report ${i}`,
 			body: `Body ${i}`,
 		}));
 
-		render(<NewsReports items={items} slotCount={3} />);
+		render(<NewsReports items={items} />);
 
-		expect(screen.getByText(/5 today/)).toBeInTheDocument();
-		expect(screen.queryByText(/3 today/)).not.toBeInTheDocument();
+		expect(screen.getByText(/8 today/)).toBeInTheDocument();
+		expect(document.querySelectorAll(".tfl-news-list > li")).toHaveLength(8);
 	});
 });

--- a/web/components/dashboard/news-reports.tsx
+++ b/web/components/dashboard/news-reports.tsx
@@ -9,7 +9,7 @@ export function NewsReports({ items }: NewsReportsProps) {
 		<section className="tfl-card tfl-news">
 			<div className="tfl-card-h">
 				<h4>News &amp; reports from TfL</h4>
-				<span className="meta">{items.length} today</span>
+				<span className="meta">{items.length} in last 12h</span>
 			</div>
 			<ul className="tfl-news-list">
 				{items.length === 0 ? (
@@ -21,7 +21,7 @@ export function NewsReports({ items }: NewsReportsProps) {
 					</li>
 				) : (
 					items.map((item) => (
-						<li key={`${item.time}-${item.title}`}>
+						<li key={`${item.time}-${item.title}-${item.body}`}>
 							<span className="tfl-news-time">{item.time}</span>
 							<div>
 								<div className="tfl-news-title">{item.title}</div>

--- a/web/components/dashboard/news-reports.tsx
+++ b/web/components/dashboard/news-reports.tsx
@@ -2,17 +2,9 @@ import type { NewsItem } from "./types";
 
 export interface NewsReportsProps {
 	items: NewsItem[];
-	slotCount?: number;
 }
 
-export function NewsReports({ items, slotCount = 6 }: NewsReportsProps) {
-	const filled = items.slice(0, slotCount);
-	const empties = Math.max(0, slotCount - filled.length);
-	const slots: (NewsItem | null)[] = [
-		...filled,
-		...Array.from({ length: empties }, () => null),
-	];
-
+export function NewsReports({ items }: NewsReportsProps) {
 	return (
 		<section className="tfl-card tfl-news">
 			<div className="tfl-card-h">
@@ -20,28 +12,26 @@ export function NewsReports({ items, slotCount = 6 }: NewsReportsProps) {
 				<span className="meta">{items.length} today</span>
 			</div>
 			<ul className="tfl-news-list">
-				{slots.map((slot, index) => {
-					const key = slot
-						? `${slot.time}-${slot.title}-${index}`
-						: `empty-${index}`;
-					return (
-						<li key={key} className={slot ? "" : "is-empty"}>
-							<span className="tfl-news-time">{slot ? slot.time : ""}</span>
+				{items.length === 0 ? (
+					<li className="is-empty">
+						<span className="tfl-news-time" />
+						<div>
+							<div className="tfl-news-placeholder">No recent updates</div>
+						</div>
+					</li>
+				) : (
+					items.map((item) => (
+						<li key={`${item.time}-${item.title}`}>
+							<span className="tfl-news-time">{item.time}</span>
 							<div>
-								{slot ? (
-									<>
-										<div className="tfl-news-title">{slot.title}</div>
-										{slot.body ? (
-											<div className="tfl-news-body">{slot.body}</div>
-										) : null}
-									</>
-								) : (
-									<div className="tfl-news-placeholder">No further updates</div>
-								)}
+								<div className="tfl-news-title">{item.title}</div>
+								{item.body ? (
+									<div className="tfl-news-body">{item.body}</div>
+								) : null}
 							</div>
 						</li>
-					);
-				})}
+					))
+				)}
 			</ul>
 		</section>
 	);

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -233,6 +233,23 @@ describe("disruptionForLine + disruptionToSnapshot", () => {
 		expect(snapshot.body).toEqual(["Para 1.", "Para 2.", "Para 3."]);
 	});
 
+	it("does not promote an unrelated description when the summary is shorter than TfL's truncation cap", () => {
+		// Real correctness concern raised in PR review: a 7-char summary
+		// "Closed." vs description "Closure on Northern line." shares only
+		// 4 leading chars ("Clos"), but with a 5-char tolerance the overlap
+		// check `4 >= 7 - 5` passes and would wrongly promote the unrelated
+		// description as the headline. Anchoring the floor near TfL's
+		// ~250-char truncation cap rejects this case outright.
+		const shortSummary: Disruption = {
+			...disruption,
+			summary: "Closed.",
+			description: "Closure on Northern line.",
+		};
+		const snapshot = disruptionToSnapshot(shortSummary);
+		expect(snapshot.headline).toBe("Closed.");
+		expect(snapshot.body).toEqual(["Closure on Northern line."]);
+	});
+
 	it("keeps the summary when it is too short for prefix matching to be meaningful", () => {
 		// Guards against a latent edge case: when summary.length <= the
 		// truncation tolerance, `overlap >= summary.length - tolerance`

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -233,6 +233,26 @@ describe("disruptionForLine + disruptionToSnapshot", () => {
 		expect(snapshot.body).toEqual(["Para 1.", "Para 2.", "Para 3."]);
 	});
 
+	it("keeps the summary when it is too short for prefix matching to be meaningful", () => {
+		// Guards against a latent edge case: when summary.length <= the
+		// truncation tolerance, `overlap >= summary.length - tolerance`
+		// is vacuously true at overlap = 0, which would promote any longer
+		// first paragraph regardless of actual prefix match. TfL never
+		// emits summaries this short in practice, but the guard makes the
+		// intent explicit and prevents future regressions.
+		const tiny: Disruption = {
+			...disruption,
+			summary: "OK",
+			description:
+				"Something completely unrelated about a closure on the Piccadilly line.",
+		};
+		const snapshot = disruptionToSnapshot(tiny);
+		expect(snapshot.headline).toBe("OK");
+		expect(snapshot.body).toEqual([
+			"Something completely unrelated about a closure on the Piccadilly line.",
+		]);
+	});
+
 	it("promotes the full description to the headline when TfL ships a summary truncated mid-word", () => {
 		// Real TfL payload observed on Windrush Line at 15:14 BST: the
 		// `summary` is cut mid-word ("...line. Tic") while `description`

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -301,6 +301,11 @@ describe("lineSummaryToFallbackSnapshot", () => {
 });
 
 describe("disruptionsToNews", () => {
+	// Fixed clock anchor 2h after the baseDisruption last_update so the
+	// 12h window keeps the row by default. Individual tests override `now`
+	// when they need to exercise the cutoff boundary.
+	const NOW = new Date("2026-05-13T18:58:00Z");
+
 	const baseDisruption: Disruption = {
 		disruption_id: "test-news-1",
 		category: "RealTime",
@@ -323,7 +328,7 @@ describe("disruptionsToNews", () => {
 			description: "No service between Kennington and Moorgate.",
 			last_update: "2026-05-13T15:20:00Z",
 		};
-		const items = disruptionsToNews([earlier, baseDisruption]);
+		const items = disruptionsToNews([earlier, baseDisruption], NOW);
 		expect(items).toHaveLength(2);
 		expect(items[0].title).toBe("Elizabeth line — westbound severe delays");
 		expect(items[0].body).toBe("Faulty train at Hayes & Harlington.");
@@ -331,27 +336,26 @@ describe("disruptionsToNews", () => {
 		expect(items[1].title).toBe("Northern line — Bank branch part-suspended");
 	});
 
-	it("falls back to '—' when last_update is unparseable", () => {
+	it("drops rows whose last_update is unparseable so the 12h window stays honest", () => {
+		// Pre-TM-28 we surfaced these with `time: "—"`; the new window
+		// filter has to assume an unknown timestamp is outside the window,
+		// otherwise a broken payload could silently extend the surface.
 		const broken: Disruption = { ...baseDisruption, last_update: "not-a-date" };
-		const [item] = disruptionsToNews([broken]);
-		expect(item.time).toBe("—");
+		expect(disruptionsToNews([broken], NOW)).toEqual([]);
 	});
 
 	it("returns an empty list when no disruptions are supplied", () => {
-		expect(disruptionsToNews([])).toEqual([]);
+		expect(disruptionsToNews([], NOW)).toEqual([]);
 	});
 
 	it("drops the leading paragraph of description when it duplicates summary so title and body do not echo", () => {
-		// TfL's Unified API repeats `summary` as the first paragraph of
-		// `description` in most payloads; the news list would render the
-		// same sentence twice unless we strip it.
 		const echoed: Disruption = {
 			...baseDisruption,
 			summary: "Piccadilly Line: SUSPENDED between Acton Town and Heathrow.",
 			description:
 				"Piccadilly Line: SUSPENDED between Acton Town and Heathrow.\n\nTickets accepted on London Buses and the Elizabeth line.",
 		};
-		const [item] = disruptionsToNews([echoed]);
+		const [item] = disruptionsToNews([echoed], NOW);
 		expect(item.title).toBe(
 			"Piccadilly Line: SUSPENDED between Acton Town and Heathrow.",
 		);
@@ -366,7 +370,7 @@ describe("disruptionsToNews", () => {
 			summary: "Circle Line: Minor delays due to train cancellations.",
 			description: "Circle Line: Minor delays due to train cancellations.",
 		};
-		const [item] = disruptionsToNews([onlyEcho]);
+		const [item] = disruptionsToNews([onlyEcho], NOW);
 		expect(item.body).toBe("");
 	});
 
@@ -377,7 +381,7 @@ describe("disruptionsToNews", () => {
 			description:
 				"Piccadilly Line: SUSPENDED between Acton Town and Heathrow.\n\nTickets accepted on London Buses.\n\nLast updated 18:42.",
 		};
-		const [item] = disruptionsToNews([verbose]);
+		const [item] = disruptionsToNews([verbose], NOW);
 		expect(item.body).toBe(
 			"Tickets accepted on London Buses.\n\nLast updated 18:42.",
 		);
@@ -390,7 +394,7 @@ describe("disruptionsToNews", () => {
 			description:
 				"Faulty train at Hayes & Harlington.\n\nTickets accepted on Piccadilly & Bakerloo until service is restored.",
 		};
-		const [item] = disruptionsToNews([distinct]);
+		const [item] = disruptionsToNews([distinct], NOW);
 		expect(item.body).toBe(
 			"Faulty train at Hayes & Harlington.\n\nTickets accepted on Piccadilly & Bakerloo until service is restored.",
 		);
@@ -404,7 +408,7 @@ describe("disruptionsToNews", () => {
 			...baseDisruption,
 			description: "Train at Hayes & Harlington.\nAlternatives: take the bus.",
 		};
-		const [item] = disruptionsToNews([wrapped]);
+		const [item] = disruptionsToNews([wrapped], NOW);
 		expect(item.body).toBe(
 			"Train at Hayes & Harlington.\nAlternatives: take the bus.",
 		);
@@ -417,7 +421,108 @@ describe("disruptionsToNews", () => {
 			description:
 				"Piccadilly Line: SUSPENDED between Acton Town and Heathrow.\r\n\r\nTickets accepted on London Buses.",
 		};
-		const [item] = disruptionsToNews([crlf]);
+		const [item] = disruptionsToNews([crlf], NOW);
 		expect(item.body).toBe("Tickets accepted on London Buses.");
+	});
+
+	it("drops rows whose last_update is older than 12 hours so the news list stays current", () => {
+		// Ingestion replays the entire /Disruption payload every cycle, so
+		// stale rows linger in the DB long after TfL has cleared them on
+		// the live status feed. The news pane is a "what's happening now"
+		// surface, so we cap visibility at 12 h.
+		const stale: Disruption = {
+			...baseDisruption,
+			disruption_id: "stale",
+			last_update: "2026-05-13T06:57:00Z", // 12h 1m before NOW
+		};
+		const fresh: Disruption = {
+			...baseDisruption,
+			disruption_id: "fresh",
+			summary: "Northern line — Bank branch part-suspended",
+			last_update: "2026-05-13T18:30:00Z", // 28m before NOW
+		};
+		const items = disruptionsToNews([stale, fresh], NOW);
+		expect(items).toHaveLength(1);
+		expect(items[0].title).toBe("Northern line — Bank branch part-suspended");
+	});
+
+	it("keeps a row exactly 12 hours old so the window cutoff is inclusive at the boundary", () => {
+		// Avoids losing legitimate ongoing incidents to clock drift between
+		// the consumer's `last_update` write and the browser's `now`.
+		const boundary: Disruption = {
+			...baseDisruption,
+			last_update: "2026-05-13T06:58:00Z", // exactly 12h before NOW
+		};
+		expect(disruptionsToNews([boundary], NOW)).toHaveLength(1);
+	});
+
+	it("collapses content-exact duplicates keeping the most recent occurrence", () => {
+		// TfL re-publishes the same disruption on every poll (currently 5 min)
+		// with a refreshed `last_update`. Without dedup the news pane fills
+		// with N copies of the same Mildmay / Piccadilly closure within an
+		// hour. We dedup on the rendered content (title + body) rather than
+		// `disruption_id` because TfL sometimes re-issues a closure under a
+		// new id with identical text.
+		const mildmayLater: Disruption = {
+			...baseDisruption,
+			disruption_id: "mildmay-3",
+			summary: "Mildmay line: Part suspended between Highbury and Stratford.",
+			description:
+				"Mildmay line: Part suspended between Highbury and Stratford.",
+			last_update: "2026-05-13T18:55:00Z",
+		};
+		const mildmayMid: Disruption = {
+			...baseDisruption,
+			disruption_id: "mildmay-2",
+			summary: "Mildmay line: Part suspended between Highbury and Stratford.",
+			description:
+				"Mildmay line: Part suspended between Highbury and Stratford.",
+			last_update: "2026-05-13T18:50:00Z",
+		};
+		const mildmayEarliest: Disruption = {
+			...baseDisruption,
+			disruption_id: "mildmay-1",
+			summary: "Mildmay line: Part suspended between Highbury and Stratford.",
+			description:
+				"Mildmay line: Part suspended between Highbury and Stratford.",
+			last_update: "2026-05-13T18:45:00Z",
+		};
+
+		const items = disruptionsToNews(
+			[mildmayEarliest, mildmayMid, mildmayLater],
+			NOW,
+		);
+		expect(items).toHaveLength(1);
+		// London-local for 18:55 UTC on 2026-05-13 (BST = UTC+1).
+		expect(items[0].time).toBe("19:55");
+	});
+
+	it("keeps distinct disruptions even when one repeats — image-4 fixture: 3× Mildmay + 3× Piccadilly → 2 rows", () => {
+		const mk = (
+			id: string,
+			summary: string,
+			lastUpdate: string,
+		): Disruption => ({
+			...baseDisruption,
+			disruption_id: id,
+			summary,
+			description: summary,
+			last_update: lastUpdate,
+		});
+		const items = disruptionsToNews(
+			[
+				mk("mil-1", "Mildmay line: Part suspended.", "2026-05-13T18:40:00Z"),
+				mk("mil-2", "Mildmay line: Part suspended.", "2026-05-13T18:45:00Z"),
+				mk("mil-3", "Mildmay line: Part suspended.", "2026-05-13T18:50:00Z"),
+				mk("pic-1", "Piccadilly Line: SUSPENDED.", "2026-05-13T18:42:00Z"),
+				mk("pic-2", "Piccadilly Line: SUSPENDED.", "2026-05-13T18:47:00Z"),
+				mk("pic-3", "Piccadilly Line: SUSPENDED.", "2026-05-13T18:52:00Z"),
+			],
+			NOW,
+		);
+		expect(items.map((i) => i.title)).toEqual([
+			"Piccadilly Line: SUSPENDED.",
+			"Mildmay line: Part suspended.",
+		]);
 	});
 });

--- a/web/lib/dashboard/__tests__/adapt.test.ts
+++ b/web/lib/dashboard/__tests__/adapt.test.ts
@@ -232,6 +232,27 @@ describe("disruptionForLine + disruptionToSnapshot", () => {
 		});
 		expect(snapshot.body).toEqual(["Para 1.", "Para 2.", "Para 3."]);
 	});
+
+	it("promotes the full description to the headline when TfL ships a summary truncated mid-word", () => {
+		// Real TfL payload observed on Windrush Line at 15:14 BST: the
+		// `summary` is cut mid-word ("...line. Tic") while `description`
+		// carries the full sentence ("...line. Tickets will be accepted on
+		// London Underground via reasonable routes."). The exact-equality
+		// echo strip used to miss this, so the LineDetail card showed the
+		// truncated headline and then echoed the full version in the body.
+		const truncated: Disruption = {
+			...disruption,
+			summary:
+				"Windrush Line: No service between Sydenham and West Croydon due to an earlier obstruction from the track at Sydenham. SEVERE delays on the rest of the line. Tic",
+			description:
+				"Windrush Line: No service between Sydenham and West Croydon due to an earlier obstruction from the track at Sydenham. SEVERE delays on the rest of the line. Tickets will be accepted on London Underground via reasonable routes.",
+		};
+		const snapshot = disruptionToSnapshot(truncated);
+		expect(snapshot.headline).toBe(
+			"Windrush Line: No service between Sydenham and West Croydon due to an earlier obstruction from the track at Sydenham. SEVERE delays on the rest of the line. Tickets will be accepted on London Underground via reasonable routes.",
+		);
+		expect(snapshot.body).toEqual([]);
+	});
 });
 
 describe("lineSummaryToFallbackSnapshot", () => {
@@ -524,5 +545,37 @@ describe("disruptionsToNews", () => {
 			"Piccadilly Line: SUSPENDED.",
 			"Mildmay line: Part suspended.",
 		]);
+	});
+
+	it("collapses TfL-truncated summary duplicates onto the full description as title", () => {
+		// Real Windrush payload from 2026-05-21: four rows ingested in two
+		// 5-min polls share an identical full description but a `summary`
+		// that TfL cut mid-word ("...line. Tic"). Pre-fix, the dedup key
+		// preserved the truncated summary so the four rows survived; the
+		// fix promotes the full description's first paragraph to the title
+		// so every copy collapses into one row carrying the full sentence.
+		const full =
+			"Windrush Line: No service between Sydenham and West Croydon due to an earlier obstruction from the track at Sydenham. SEVERE delays on the rest of the line. Tickets will be accepted on London Underground via reasonable routes.";
+		const truncated =
+			"Windrush Line: No service between Sydenham and West Croydon due to an earlier obstruction from the track at Sydenham. SEVERE delays on the rest of the line. Tic";
+		const mk = (id: string, lastUpdate: string): Disruption => ({
+			...baseDisruption,
+			disruption_id: id,
+			summary: truncated,
+			description: full,
+			last_update: lastUpdate,
+		});
+		const items = disruptionsToNews(
+			[
+				mk("w-1", "2026-05-13T18:50:00Z"),
+				mk("w-2", "2026-05-13T18:51:00Z"),
+				mk("w-3", "2026-05-13T18:52:00Z"),
+				mk("w-4", "2026-05-13T18:53:00Z"),
+			],
+			NOW,
+		);
+		expect(items).toHaveLength(1);
+		expect(items[0].title).toBe(full);
+		expect(items[0].body).toBe("");
 	});
 });

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -345,7 +345,13 @@ function chooseHeadlineAndBody(
 	if (head === trimmedSummary) {
 		return { headline: trimmedSummary, body: paragraphs.slice(1) };
 	}
-	if (head.length > trimmedSummary.length) {
+	if (
+		head.length > trimmedSummary.length &&
+		// Guard against degenerate summaries (length <= tolerance) where
+		// the overlap check would be vacuously true at zero overlap and
+		// promote any longer first paragraph regardless of prefix match.
+		trimmedSummary.length > TRUNCATION_TOLERANCE
+	) {
 		const overlap = commonPrefixLength(trimmedSummary, head);
 		if (overlap >= trimmedSummary.length - TRUNCATION_TOLERANCE) {
 			return { headline: head, body: paragraphs.slice(1) };

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -271,7 +271,10 @@ export function disruptionsToNews(
 	for (const { d } of dated) {
 		const title = d.summary;
 		const body = extraParagraphs(d.summary, d.description);
-		const key = `${title} ${body}`;
+		// JSON.stringify guarantees a separator that cannot appear inside
+		// either string verbatim, so titles ending in whitespace cannot
+		// collide with bodies starting in whitespace (and vice-versa).
+		const key = JSON.stringify([title, body]);
 		if (seen.has(key)) continue;
 		seen.add(key);
 		items.push({

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -269,17 +269,20 @@ export function disruptionsToNews(
 	const seen = new Set<string>();
 	const items: NewsItem[] = [];
 	for (const { d } of dated) {
-		const title = d.summary;
-		const body = extraParagraphs(d.summary, d.description);
+		const { headline, body: bodyParagraphs } = chooseHeadlineAndBody(
+			d.summary,
+			d.description,
+		);
+		const body = bodyParagraphs.join("\n\n");
 		// JSON.stringify guarantees a separator that cannot appear inside
 		// either string verbatim, so titles ending in whitespace cannot
 		// collide with bodies starting in whitespace (and vice-versa).
-		const key = JSON.stringify([title, body]);
+		const key = JSON.stringify([headline, body]);
 		if (seen.has(key)) continue;
 		seen.add(key);
 		items.push({
 			time: formatLondonTime(d.last_update),
-			title,
+			title: headline,
 			body,
 		});
 	}
@@ -299,12 +302,56 @@ function splitParagraphs(description: string): string[] {
 		.filter((paragraph) => paragraph.length > 0);
 }
 
-function extraParagraphs(summary: string, description: string): string {
+// TfL's Unified API occasionally truncates `summary` mid-word (~250-char
+// cap) while shipping the full sentence in `description`. Treating the
+// truncated string as the canonical headline produces two bad outcomes:
+// the LineDetail card renders the cut headline above the full sentence
+// (visible echo), and dedup in `disruptionsToNews` keeps every copy
+// because the truncation point varies subtly between polls.
+//
+// Tolerance value: characters that may differ at the truncation boundary
+// before we abandon the promotion. 5 covers the common case of TfL
+// cutting "Tickets" → "Tic" (3 chars match before divergence) plus a
+// little slack for whitespace or hyphenation around the cut.
+const TRUNCATION_TOLERANCE = 5;
+
+function commonPrefixLength(a: string, b: string): number {
+	const upper = Math.min(a.length, b.length);
+	let i = 0;
+	while (i < upper && a.charCodeAt(i) === b.charCodeAt(i)) i += 1;
+	return i;
+}
+
+/**
+ * Choose the canonical headline + body for a disruption.
+ *
+ * Returns the trimmed `summary` as headline and any paragraphs of
+ * `description` past the leading echo as body. When TfL's `summary`
+ * looks truncated against `description` (the two share a long common
+ * prefix and `description`'s first paragraph is the longer string),
+ * promote that first paragraph to the headline so the card and the
+ * news pane render the full sentence instead of the cut one.
+ */
+function chooseHeadlineAndBody(
+	summary: string,
+	description: string,
+): { headline: string; body: string[] } {
+	const trimmedSummary = summary.trim();
 	const paragraphs = splitParagraphs(description);
-	if (paragraphs.length === 0) return "";
+	if (paragraphs.length === 0) {
+		return { headline: trimmedSummary, body: [] };
+	}
 	const head = paragraphs[0];
-	const rest = head === summary.trim() ? paragraphs.slice(1) : paragraphs;
-	return rest.join("\n\n");
+	if (head === trimmedSummary) {
+		return { headline: trimmedSummary, body: paragraphs.slice(1) };
+	}
+	if (head.length > trimmedSummary.length) {
+		const overlap = commonPrefixLength(trimmedSummary, head);
+		if (overlap >= trimmedSummary.length - TRUNCATION_TOLERANCE) {
+			return { headline: head, body: paragraphs.slice(1) };
+		}
+	}
+	return { headline: trimmedSummary, body: paragraphs };
 }
 
 /**
@@ -313,22 +360,19 @@ function extraParagraphs(summary: string, description: string): string {
  * richer registry — Phase 5 keeps the projection minimal; richer
  * naming comes when the disruption stream is wired end-to-end.
  *
- * The leading paragraph of `description` is dropped when it exactly
- * matches `summary` — TfL's Unified API repeats the summary as the
- * first paragraph of `description` for most payloads, so without this
- * the LineDetail card would render the headline once and then again
- * as the first body paragraph.
+ * Headline + body are picked by `chooseHeadlineAndBody`, which strips
+ * the leading paragraph of `description` when it echoes `summary` and
+ * promotes `description`'s first paragraph to the headline when TfL
+ * ships a summary truncated mid-word.
  */
 export function disruptionToSnapshot(d: Disruption): DisruptionSnapshot {
-	const paragraphs = splitParagraphs(d.description);
-	const body =
-		paragraphs[0] === d.summary.trim() ? paragraphs.slice(1) : paragraphs;
+	const { headline, body } = chooseHeadlineAndBody(d.summary, d.description);
 	const stations = d.affected_stops.map((stop) => ({
 		name: stop,
 		code: stop,
 	}));
 	return {
-		headline: d.summary,
+		headline,
 		body,
 		reportedAtLabel: formatLondonTime(d.created, { withTimezoneName: true }),
 		stations,

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -225,10 +225,27 @@ export function disruptionForLine(
 	return disruptions.find((d) => d.affected_routes.includes(lineId));
 }
 
+const NEWS_WINDOW_MS = 12 * 60 * 60 * 1000;
+
 /**
  * Project a list of backend `Disruption` rows into the `NewsReports`
- * view-model. Rows are sorted by `last_update` descending so the most
- * recent updates surface first; the component handles slot truncation.
+ * view-model.
+ *
+ * Two filters run before projection so the news pane stays a
+ * "what's happening now" surface and never echoes itself:
+ *
+ * 1. **12 h window** — ingestion replays the full `/Disruption` payload
+ *    every cycle, so stale rows persist in the DB long after TfL has
+ *    cleared them. Rows whose `last_update` is older than 12 h relative
+ *    to `now` are dropped (boundary inclusive). Rows with an unparseable
+ *    `last_update` are dropped because we cannot prove they are recent.
+ * 2. **Content-exact dedup** — TfL re-publishes ongoing incidents on
+ *    every poll (currently every 5 min), so without dedup the pane
+ *    fills with N copies of the same closure within an hour. Dedup
+ *    walks rows in descending `last_update` order and keeps the first
+ *    occurrence of each `title|body` pair. Keying on rendered content
+ *    rather than `disruption_id` also collapses cases where TfL re-issues
+ *    a closure under a fresh id but with identical text.
  *
  * `time` uses the London-local `HH:MM` format the design canvas
  * specifies. The `body` carries only the *extra* paragraphs of
@@ -236,21 +253,34 @@ export function disruptionForLine(
  * paragraph of `description` in nearly every payload, so projecting
  * the whole description into the body produces a duplicate of the
  * title. We strip the leading paragraph when it matches `summary`
- * and join any remaining paragraphs with a blank line.
+ * and join any remaining paragraphs with a blank line. `now` is
+ * injected so the function stays deterministic under test.
  */
-export function disruptionsToNews(disruptions: Disruption[]): NewsItem[] {
-	const sorted = [...disruptions].sort((a, b) => {
-		const aTime = Date.parse(a.last_update);
-		const bTime = Date.parse(b.last_update);
-		return (
-			(Number.isNaN(bTime) ? 0 : bTime) - (Number.isNaN(aTime) ? 0 : aTime)
-		);
-	});
-	return sorted.map((d) => ({
-		time: formatLondonTime(d.last_update),
-		title: d.summary,
-		body: extraParagraphs(d.summary, d.description),
-	}));
+export function disruptionsToNews(
+	disruptions: Disruption[],
+	now: Date = new Date(),
+): NewsItem[] {
+	const cutoffMs = now.getTime() - NEWS_WINDOW_MS;
+	const dated = disruptions
+		.map((d) => ({ d, ts: Date.parse(d.last_update) }))
+		.filter(({ ts }) => !Number.isNaN(ts) && ts >= cutoffMs)
+		.sort((a, b) => b.ts - a.ts);
+
+	const seen = new Set<string>();
+	const items: NewsItem[] = [];
+	for (const { d } of dated) {
+		const title = d.summary;
+		const body = extraParagraphs(d.summary, d.description);
+		const key = `${title} ${body}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		items.push({
+			time: formatLondonTime(d.last_update),
+			title,
+			body,
+		});
+	}
+	return items;
 }
 
 // Matches blank-line separators in both LF and CRLF payloads. The TfL

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -315,6 +315,19 @@ function splitParagraphs(description: string): string[] {
 // little slack for whitespace or hyphenation around the cut.
 const TRUNCATION_TOLERANCE = 5;
 
+// Minimum summary length before we even consider promoting the
+// description's first paragraph as the headline. TfL's truncation only
+// kicks in near the ~250-char cap, with the cut point landing anywhere
+// in the 100-249 char range depending on word boundaries; observed
+// real-world cases have ranged 150-220 chars. For shorter summaries the
+// 5-char tolerance becomes a large fraction of the string and would let
+// unrelated descriptions sharing just a few leading chars be wrongly
+// promoted (e.g. "Closed." vs "Closure on Northern line." shares 4
+// leading chars, satisfying `4 >= 7 - 5`). 100 is the empirical floor
+// that catches every truncation observed in production while rejecting
+// every short-sentinel case seen in fixtures.
+const TRUNCATION_MIN_SUMMARY_LEN = 100;
+
 function commonPrefixLength(a: string, b: string): number {
 	const upper = Math.min(a.length, b.length);
 	let i = 0;
@@ -347,10 +360,11 @@ function chooseHeadlineAndBody(
 	}
 	if (
 		head.length > trimmedSummary.length &&
-		// Guard against degenerate summaries (length <= tolerance) where
-		// the overlap check would be vacuously true at zero overlap and
-		// promote any longer first paragraph regardless of prefix match.
-		trimmedSummary.length > TRUNCATION_TOLERANCE
+		// Only consider promotion when the summary is long enough to plausibly
+		// have been truncated by TfL's ~250-char cap. For shorter summaries
+		// the tolerance becomes a large fraction of the string and would let
+		// unrelated descriptions sharing a few leading chars be wrongly promoted.
+		trimmedSummary.length >= TRUNCATION_MIN_SUMMARY_LEN
 	) {
 		const overlap = commonPrefixLength(trimmedSummary, head);
 		if (overlap >= trimmedSummary.length - TRUNCATION_TOLERANCE) {

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -74,11 +74,20 @@
   min-height: 0;
 }
 .tfl-right-col > .tfl-card {
-  /* LineDetail. The cap is upper-bounded only — when the disruption body
-     is short the card collapses to content and Chat keeps the slack. */
-  max-height: 50%;
+  /* LineDetail base rules — the 50% cap is scoped to the two-column
+     layout only (see media query below). At ≤880px the grid collapses
+     to one column so the right column is content-sized and a percentage
+     cap would resolve against an undefined parent height, clipping the
+     card unpredictably. */
   min-height: 0;
   overflow: auto;
+}
+@media (min-width: 881px) {
+  .tfl-right-col > .tfl-card {
+    /* Upper-bound only — short disruption bodies still collapse to
+       content and Chat keeps the freed slack. */
+    max-height: 50%;
+  }
 }
 .tfl-right-col > .tfl-chat-stack {
   display: flex;

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -378,7 +378,17 @@
 .tfl-news-list li.is-empty { color: var(--ink-tertiary); }
 .tfl-news-placeholder { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
 .tfl-news-time { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
-.tfl-news-title { font-family: var(--font-body); font-size: var(--ui-sm); font-weight: 500; color: var(--ink-primary); margin-bottom: 2px; }
+.tfl-news-title {
+  font-family: var(--font-body); font-size: var(--ui-sm); font-weight: 500;
+  color: var(--ink-primary); margin-bottom: 2px;
+  /* Clamp matches `.tfl-news-body` — a multi-station TfL summary would
+     otherwise push `<li>` past `--tfl-news-row-h: 64px` and silently
+     break the 5-visible-rows guarantee. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+}
 .tfl-news-body {
   font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary);
   line-height: 1.45; white-space: pre-line;

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -63,30 +63,28 @@
   .tfl-nav-status { display: none; }
 }
 
-/* ---------- Columns: 2-row subgrid so row 1 (LineGrid ↔ LineDetail)
-   stretches equal across both columns, row 2 (left-bottom ↔ chat) gets
-   its natural height. --------------------------------------------- */
-.tfl-left-col,
+/* ---------- Right column: Disruption (capped at 50%) above Chat
+   (consumes the rest). Status occupies the full-height left column on
+   its own, so the two columns are no longer height-coupled via subgrid. */
 .tfl-right-col {
-  display: grid;
-  grid-template-rows: subgrid;
-  grid-row: 1 / -1;
+  display: flex;
+  flex-direction: column;
   gap: var(--space-4);
   min-width: 0;
   min-height: 0;
 }
-.tfl-left-bottom {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
+.tfl-right-col > .tfl-card {
+  /* LineDetail. The cap is upper-bounded only — when the disruption body
+     is short the card collapses to content and Chat keeps the slack. */
+  max-height: 50%;
   min-height: 0;
+  overflow: auto;
 }
-
-.tfl-right-col .tfl-chat-stack {
+.tfl-right-col > .tfl-chat-stack {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  flex: 1 1 0;
+  flex: 1 1 auto;
   min-height: 0;
 }
 .tfl-right-col .tfl-chat-stack .tfl-chat-card { flex: 1 1 auto; min-height: 0; }
@@ -212,16 +210,29 @@
 .tfl-chatbox-send:hover { background: #FFA15B; }
 .tfl-chatbox-send:active { transform: scale(0.94); }
 
-.tfl-grid {
-  max-width: 80rem; margin: 0 auto;
+/* ---------- Shell: vertical stack of grid + news + bus bands. The
+   outer page padding lives here so each band can render flush at full
+   width while still respecting the 80rem reading measure. */
+.tfl-shell {
+  max-width: 80rem;
+  margin: 0 auto;
   padding: 5rem var(--space-5) var(--space-7);
-  display: grid; grid-template-columns: 1fr 1fr;
-  /* Both rows size to content. Subgrid children align so row 1 (LineGrid ↔ LineDetail)
-     is the height of whichever card is taller — typically the line list. */
-  grid-template-rows: auto auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.tfl-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: var(--space-4);
   align-items: stretch;
-  width: 100%;
+}
+
+.tfl-news-band,
+.tfl-bus-band {
+  display: block;
 }
 
 .tfl-card {
@@ -338,23 +349,47 @@
 .tfl-bus-route { font-family: var(--font-mono); font-size: var(--ui-sm); font-weight: 500; color: var(--ink-primary); }
 .tfl-bus-text  { font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary); line-height: 1.4; }
 
-/* ---------- News & reports ---------------------------------------- */
-.tfl-news { display: flex; flex-direction: column; }
-.tfl-news-list { list-style: none; margin: 0; padding: 0; flex: 1; display: flex; flex-direction: column; }
+/* ---------- News & reports
+   The list is the fixed-height scroll surface: --tfl-news-row-h drives
+   both each row's `min-height` and the list's `max-height` cap (5 rows).
+   Scrollbar is hidden in both Firefox (`scrollbar-width: none`) and
+   WebKit/Blink (`::-webkit-scrollbar`) — overflow is still functional,
+   only chromeless. */
+.tfl-news { display: flex; flex-direction: column; --tfl-news-row-h: 64px; }
+.tfl-news-list {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column;
+  max-height: calc(5 * var(--tfl-news-row-h));
+  overflow-y: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.tfl-news-list::-webkit-scrollbar { display: none; }
 .tfl-news-list li {
   display: grid; grid-template-columns: 52px 1fr;
   gap: 12px;
   padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border-default);
-  flex: 1;
   align-items: flex-start;
+  min-height: var(--tfl-news-row-h);
+  box-sizing: border-box;
 }
 .tfl-news-list li:last-child { border-bottom: none; }
 .tfl-news-list li.is-empty { color: var(--ink-tertiary); }
 .tfl-news-placeholder { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
 .tfl-news-time { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
 .tfl-news-title { font-family: var(--font-body); font-size: var(--ui-sm); font-weight: 500; color: var(--ink-primary); margin-bottom: 2px; }
-.tfl-news-body { font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary); line-height: 1.45; white-space: pre-line; }
+.tfl-news-body {
+  font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary);
+  line-height: 1.45; white-space: pre-line;
+  /* Cap the body to a single visible line so every row settles on the
+     fixed min-height — the full text remains in the accessibility tree
+     and is restored if `-webkit-line-clamp` is unsupported. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+}
 
 @media (max-width: 880px) {
   .tfl-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- Restructure the dashboard grid: Status column is full-height on the left; Disruption (capped at 50%) and Chat (consumes the rest) stack on the right. News and Bus move out of the left subgrid into full-width bands below the grid.
- Extend `disruptionsToNews` with a 12 h window filter (boundary inclusive) and content-exact dedup (`title|body`) keeping the most recent occurrence — the warehouse retains old rows and every poll re-publishes ongoing incidents.
- `NewsReports` no longer pads empty slots; a single "No recent updates" placeholder shows when the warehouse is cold. The list caps at five rows via `--tfl-news-row-h` with an invisible scrollbar in both Firefox and WebKit/Blink.

## Test plan
- [x] `pnpm --dir web lint`
- [x] `pnpm --dir web test` — 95/95 (4 new `disruptionsToNews` cases: 12 h window with boundary, drop unparseable timestamps, content-exact dedup, image-4 fixture)
- [x] `uv run task lint`
- [x] Manual: 1440px desktop matches the wireframe (Status left, Disruption+Chat right, News full-width 5 rows with invisible scroll, Bus bottom)
- [x] Manual: 880px breakpoint falls back to single-column stack
- [ ] `uv run task test` — 292/293 (one pre-existing failure in `tests/rag/test_ingest.py::test_run_ingestion_missing_pinecone_key_exits_2` caused by local `.env` leaking `PINECONE_API_KEY` into the test process; unrelated to TM-28, no backend code touched in this PR)

Closes TM-28.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * News now shows counts as "{n} in last 12h" and empty state reads "No recent updates".

* **Bug Fixes**
  * Only surface news from the last 12 hours and deduplicate by content.
  * Better handling of truncated summaries so headlines use the full description when appropriate.

* **Style**
  * Dashboard layout reorganized (separate news/bus bands, revised two-column grid).
  * News list and details panels get improved scrolling and fixed-height news surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->