### PR TITLE
chore(obs): cut Logfire ingest volume by ~90%

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,10 @@ LANGSMITH_PROJECT=tfl-monitor
 
 # Logfire observability
 LOGFIRE_TOKEN=your_logfire_token_here
+# Optional: override the default head/background sample rate (0.0-1.0).
+# Defaults: 0.1 for api + ingestion, 0.5 for rag. Warn+ spans and traces
+# longer than 5s are always kept at 100% regardless of this value.
+# LOGFIRE_SAMPLE_RATE=0.1
 
 # Airflow (local docker compose)
 AIRFLOW_ADMIN_USERNAME=admin

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -42,6 +42,10 @@ BEDROCK_HAIKU_MODEL_ID=eu.anthropic.claude-haiku-4-5-20251001-v1:0
 
 # Observability
 LOGFIRE_TOKEN=
+# Optional head/background sample rate override (0.0-1.0). Defaults: api +
+# ingestion 0.1, rag 0.5. Warn+ spans and traces longer than 5s are always
+# kept at 100% regardless of this value.
+LOGFIRE_SAMPLE_RATE=
 LANGSMITH_TRACING=true
 LANGSMITH_API_KEY=
 LANGSMITH_PROJECT=tfl-monitor

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -20,7 +20,10 @@ services:
       - tfl-monitor
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
-      interval: 30s
+      # 120s keeps the API still self-monitored but cuts the /health hit
+      # rate to 1/4 of the previous 30s tick — every hit is a Logfire span
+      # via instrument_fastapi, so this is pure ingest-volume reduction.
+      interval: 120s
       timeout: 5s
       retries: 3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/ingestion", "src/api", "src/agent", "src/rag", "contracts"]
+packages = ["src/common", "src/ingestion", "src/api", "src/agent", "src/rag", "contracts"]
 
 [tool.ruff]
 line-length = 100

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -11,7 +11,7 @@ src/api/
 ├─ main.py             # FastAPI app, lifespan, route handlers
 ├─ db.py               # Async psycopg pool + per-endpoint fetchers
 ├─ schemas.py          # Pydantic response models (mirror contracts/openapi.yaml)
-├─ observability.py    # Logfire wiring (FastAPI / psycopg / httpx)
+├─ observability.py    # Logfire wiring (FastAPI only; sampled)
 └─ agent/              # LangGraph agent — see src/api/agent/README.md
 ```
 
@@ -60,17 +60,21 @@ test in `tests/api/test_openapi_drift.py`.
 
 ## Observability
 
-Three lines in `observability.py`:
-
 ```python
+logfire.configure(..., sampling=build_sampling_options(_DEFAULT_SAMPLE_RATE))
 logfire.instrument_fastapi(app)
-logfire.instrument_psycopg()
-logfire.instrument_httpx()
 ```
 
-This auto-emits one span per request, query, and outbound HTTP call. Token
-costs and tool decisions land in LangSmith via the agent — see
-[`src/api/agent/README.md`](./agent).
+`instrument_fastapi` emits one span per request. Sampling is the shared
+`SamplingOptions.level_or_duration` tail strategy from `src/common/sampling.py`:
+warn+ spans and traces longer than five seconds are kept at 100%, everything
+else falls back to `LOGFIRE_SAMPLE_RATE` (default `0.1`).
+
+Outbound HTTP visibility (Anthropic, OpenAI, Pinecone, TfL) lives in
+LangSmith — see [`src/api/agent/README.md`](./agent). Per-query psycopg
+spans were removed in favour of per-endpoint timing on the FastAPI side
+because the free-tier ingest budget could not absorb one span per SQL
+statement.
 
 ## Run
 

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -11,19 +11,30 @@ import os
 import logfire
 from fastapi import FastAPI
 
+# Head-sample 10% of traces by default to keep the free-tier (10M spans/mo)
+# from filling up in days. Override with ``LOGFIRE_SAMPLE_RATE`` (0.0-1.0) for
+# debugging windows when full fidelity is needed.
+_DEFAULT_SAMPLE_RATE = 0.1
+
+
+def _sample_rate() -> float:
+    raw = os.getenv("LOGFIRE_SAMPLE_RATE")
+    if raw is None:
+        return _DEFAULT_SAMPLE_RATE
+    try:
+        rate = float(raw)
+    except ValueError:
+        return _DEFAULT_SAMPLE_RATE
+    return min(max(rate, 0.0), 1.0)
+
 
 def configure_observability(app: FastAPI) -> None:
-    """Configure Logfire and instrument FastAPI, httpx, and psycopg.
-
-    Args:
-        app: FastAPI application to instrument.
-    """
+    """Configure Logfire and instrument FastAPI."""
     logfire.configure(
         service_name="tfl-monitor-api",
         service_version=os.getenv("APP_VERSION", "0.0.1"),
         environment=os.getenv("ENVIRONMENT", "local"),
         send_to_logfire="if-token-present",
+        sampling=logfire.SamplingOptions(head=_sample_rate()),
     )
     logfire.instrument_fastapi(app)
-    logfire.instrument_httpx()
-    logfire.instrument_psycopg("psycopg")

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -2,6 +2,11 @@
 
 Reads ``LOGFIRE_TOKEN`` from the environment. If missing, Logfire runs in
 no-op mode so local development and tests do not need credentials.
+
+Outbound LLM/agent HTTP visibility lives in LangSmith (see ``agent/``);
+psycopg per-query spans were removed because ``instrument_fastapi`` already
+surfaces per-endpoint timing and per-query spans dominate the free-tier
+ingest volume.
 """
 
 from __future__ import annotations
@@ -11,30 +16,22 @@ import os
 import logfire
 from fastapi import FastAPI
 
-# Head-sample 10% of traces by default to keep the free-tier (10M spans/mo)
-# from filling up in days. Override with ``LOGFIRE_SAMPLE_RATE`` (0.0-1.0) for
-# debugging windows when full fidelity is needed.
+from common.sampling import build_sampling_options
+
 _DEFAULT_SAMPLE_RATE = 0.1
 
 
-def _sample_rate() -> float:
-    raw = os.getenv("LOGFIRE_SAMPLE_RATE")
-    if raw is None:
-        return _DEFAULT_SAMPLE_RATE
-    try:
-        rate = float(raw)
-    except ValueError:
-        return _DEFAULT_SAMPLE_RATE
-    return min(max(rate, 0.0), 1.0)
-
-
 def configure_observability(app: FastAPI) -> None:
-    """Configure Logfire and instrument FastAPI."""
+    """Configure Logfire and instrument FastAPI.
+
+    Args:
+        app: FastAPI application to instrument.
+    """
     logfire.configure(
         service_name="tfl-monitor-api",
         service_version=os.getenv("APP_VERSION", "0.0.1"),
         environment=os.getenv("ENVIRONMENT", "local"),
         send_to_logfire="if-token-present",
-        sampling=logfire.SamplingOptions(head=_sample_rate()),
+        sampling=build_sampling_options(_DEFAULT_SAMPLE_RATE),
     )
     logfire.instrument_fastapi(app)

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-service utilities shared by api/, ingestion/, and rag/."""

--- a/src/common/sampling.py
+++ b/src/common/sampling.py
@@ -1,0 +1,54 @@
+"""Shared Logfire sampling helpers."""
+
+from __future__ import annotations
+
+import os
+
+import logfire
+
+__all__ = ["build_sampling_options", "read_sample_rate"]
+
+
+def read_sample_rate(default: float) -> float:
+    """Read ``LOGFIRE_SAMPLE_RATE`` and clamp to ``[0.0, 1.0]``.
+
+    Falls back to ``default`` when the variable is unset or unparseable so
+    a malformed value never disables observability outright.
+
+    Args:
+        default: Sample rate used when the env var is missing or malformed.
+
+    Returns:
+        A float in ``[0.0, 1.0]``.
+    """
+    raw = os.getenv("LOGFIRE_SAMPLE_RATE")
+    if raw is None:
+        rate = default
+    else:
+        try:
+            rate = float(raw)
+        except ValueError:
+            rate = default
+    return min(max(rate, 0.0), 1.0)
+
+
+def build_sampling_options(default_rate: float) -> logfire.SamplingOptions:
+    """Return ``SamplingOptions`` that keep all warn+/long traces at 100%.
+
+    Traces containing at least one ``warn`` (or higher) span — or whose
+    end-to-end duration exceeds five seconds — are forced through at
+    probability ``1.0`` via Logfire's tail sampler. Every other trace is
+    sampled at the rate resolved from :func:`read_sample_rate`, so the
+    free-tier allowance is protected without ever dropping an error.
+
+    Args:
+        default_rate: Background sample rate used when the env override is
+            unset; the resolved rate also caps long/error traces' siblings.
+
+    Returns:
+        A ``SamplingOptions`` instance ready to pass to ``logfire.configure``.
+    """
+    return logfire.SamplingOptions.level_or_duration(
+        level_threshold="warn",
+        background_rate=read_sample_rate(default_rate),
+    )

--- a/src/common/sampling.py
+++ b/src/common/sampling.py
@@ -6,14 +6,16 @@ import os
 
 import logfire
 
-__all__ = ["build_sampling_options", "read_sample_rate"]
+__all__ = ["build_sampling_options"]
 
 
-def read_sample_rate(default: float) -> float:
+def _read_sample_rate(default: float) -> float:
     """Read ``LOGFIRE_SAMPLE_RATE`` and clamp to ``[0.0, 1.0]``.
 
     Falls back to ``default`` when the variable is unset or unparseable so
-    a malformed value never disables observability outright.
+    a malformed value never disables observability outright. Module-private
+    because :func:`build_sampling_options` is the only product consumer;
+    tests reach in via ``common.sampling._read_sample_rate``.
 
     Args:
         default: Sample rate used when the env var is missing or malformed.
@@ -50,5 +52,5 @@ def build_sampling_options(default_rate: float) -> logfire.SamplingOptions:
     """
     return logfire.SamplingOptions.level_or_duration(
         level_threshold="warn",
-        background_rate=read_sample_rate(default_rate),
+        background_rate=_read_sample_rate(default_rate),
     )

--- a/src/common/sampling.py
+++ b/src/common/sampling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 
 import logfire
@@ -31,6 +32,8 @@ def _read_sample_rate(default: float) -> float:
             rate = float(raw)
         except ValueError:
             rate = default
+    if not math.isfinite(rate):
+        rate = default
     return min(max(rate, 0.0), 1.0)
 
 

--- a/src/ingestion/README.md
+++ b/src/ingestion/README.md
@@ -87,9 +87,15 @@ untouched — only the entrypoint changes.
 ## Observability
 
 `observability.py` exposes per-topic span namespaces and **redacts the
-`app_key`** before any span is emitted. Logfire instruments httpx
-automatically, so the redaction guards against the auto-instrumented spans
-as well.
+`app_key`** before any span is emitted. The httpx auto-instrumentation was
+removed because the manual `tfl.request` span already wraps every TfL call;
+`app_key` redaction happens inside that wrapper, so removing the auto layer
+does not weaken the secret-handling contract.
+
+Sampling is the shared `SamplingOptions.level_or_duration` tail strategy
+from `src/common/sampling.py`: warn+ spans and traces longer than five
+seconds are kept at 100%, everything else falls back to
+`LOGFIRE_SAMPLE_RATE` (default `0.1`).
 
 ```python
 @logfire.instrument(

--- a/src/ingestion/observability.py
+++ b/src/ingestion/observability.py
@@ -8,6 +8,23 @@ import logfire
 
 INGESTION_SERVICE_NAME = "tfl-monitor-ingestion"
 
+# Head-sample 10% of traces by default to stay under the free-tier (10M
+# spans/mo) allowance. The ingestion loop emits the highest volume in the
+# stack (kafka.publish/kafka.consume/db.insert spans fire per message), so
+# sampling here is what actually moves the bill.
+_DEFAULT_SAMPLE_RATE = 0.1
+
+
+def _sample_rate() -> float:
+    raw = os.getenv("LOGFIRE_SAMPLE_RATE")
+    if raw is None:
+        return _DEFAULT_SAMPLE_RATE
+    try:
+        rate = float(raw)
+    except ValueError:
+        return _DEFAULT_SAMPLE_RATE
+    return min(max(rate, 0.0), 1.0)
+
 
 def configure_logfire(*, instrument_psycopg: bool = False) -> None:
     """Configure Logfire for an ingestion service entrypoint.
@@ -22,6 +39,7 @@ def configure_logfire(*, instrument_psycopg: bool = False) -> None:
         service_version=os.getenv("APP_VERSION", "0.0.1"),
         environment=os.getenv("ENVIRONMENT", "local"),
         send_to_logfire="if-token-present",
+        sampling=logfire.SamplingOptions(head=_sample_rate()),
     )
     if instrument_psycopg:
         logfire.instrument_psycopg("psycopg")

--- a/src/ingestion/observability.py
+++ b/src/ingestion/observability.py
@@ -6,24 +6,11 @@ import os
 
 import logfire
 
+from common.sampling import build_sampling_options
+
 INGESTION_SERVICE_NAME = "tfl-monitor-ingestion"
 
-# Head-sample 10% of traces by default to stay under the free-tier (10M
-# spans/mo) allowance. The ingestion loop emits the highest volume in the
-# stack (kafka.publish/kafka.consume/db.insert spans fire per message), so
-# sampling here is what actually moves the bill.
 _DEFAULT_SAMPLE_RATE = 0.1
-
-
-def _sample_rate() -> float:
-    raw = os.getenv("LOGFIRE_SAMPLE_RATE")
-    if raw is None:
-        return _DEFAULT_SAMPLE_RATE
-    try:
-        rate = float(raw)
-    except ValueError:
-        return _DEFAULT_SAMPLE_RATE
-    return min(max(rate, 0.0), 1.0)
 
 
 def configure_logfire(*, instrument_psycopg: bool = False) -> None:
@@ -39,7 +26,7 @@ def configure_logfire(*, instrument_psycopg: bool = False) -> None:
         service_version=os.getenv("APP_VERSION", "0.0.1"),
         environment=os.getenv("ENVIRONMENT", "local"),
         send_to_logfire="if-token-present",
-        sampling=logfire.SamplingOptions(head=_sample_rate()),
+        sampling=build_sampling_options(_DEFAULT_SAMPLE_RATE),
     )
     if instrument_psycopg:
         logfire.instrument_psycopg("psycopg")

--- a/src/ingestion/producers/arrivals.py
+++ b/src/ingestion/producers/arrivals.py
@@ -133,7 +133,6 @@ class ArrivalsProducer:
                         arrival_id=payload.arrival_id,
                         error=repr(exc),
                     )
-        logfire.info("ingestion.arrivals.cycle", published=published)
         return published
 
     async def run_forever(self) -> NoReturn:
@@ -153,7 +152,6 @@ class ArrivalsProducer:
 
 async def _amain() -> None:
     configure_logfire()
-    logfire.instrument_httpx()
 
     bootstrap = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "")
     if not bootstrap:

--- a/src/ingestion/producers/disruptions.py
+++ b/src/ingestion/producers/disruptions.py
@@ -122,7 +122,6 @@ class DisruptionsProducer:
                     disruption_id=payload.disruption_id,
                     error=repr(exc),
                 )
-        logfire.info("ingestion.disruptions.cycle", published=published)
         return published
 
     async def run_forever(self) -> NoReturn:
@@ -142,7 +141,6 @@ class DisruptionsProducer:
 
 async def _amain() -> None:
     configure_logfire()
-    logfire.instrument_httpx()
 
     bootstrap = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "")
     if not bootstrap:

--- a/src/ingestion/producers/line_status.py
+++ b/src/ingestion/producers/line_status.py
@@ -118,7 +118,6 @@ class LineStatusProducer:
                     line_id=payload.line_id,
                     error=repr(exc),
                 )
-        logfire.info("ingestion.line_status.cycle", published=published)
         return published
 
     async def run_forever(self) -> NoReturn:
@@ -138,7 +137,6 @@ class LineStatusProducer:
 
 async def _amain() -> None:
     configure_logfire()
-    logfire.instrument_httpx()
 
     bootstrap = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "")
     if not bootstrap:

--- a/src/ingestion/run_producers.py
+++ b/src/ingestion/run_producers.py
@@ -28,7 +28,6 @@ from ingestion.tfl_client import TflClient
 
 async def _amain() -> NoReturn:
     configure_logfire()
-    logfire.instrument_httpx()
 
     bootstrap = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "")
     if not bootstrap:

--- a/src/rag/ingest.py
+++ b/src/rag/ingest.py
@@ -28,6 +28,7 @@ import httpx
 import logfire
 from openai import AsyncOpenAI
 
+from common.sampling import build_sampling_options
 from rag.config import RagSettings, load_settings
 from rag.embed import embed_texts
 from rag.fetch import (
@@ -46,21 +47,17 @@ __all__ = ["main", "run_ingestion"]
 DEFAULT_SOURCES_PATH = Path("src/rag/sources.json")
 RAG_SERVICE_NAME = "tfl-monitor-rag-ingestion"
 
+_DEFAULT_SAMPLE_RATE = 0.5
+
 
 def configure_logfire() -> None:
     """Configure Logfire for the ingestion entrypoint."""
-    raw = os.getenv("LOGFIRE_SAMPLE_RATE")
-    try:
-        rate = float(raw) if raw is not None else 0.5
-    except ValueError:
-        rate = 0.5
-    sample_rate = min(max(rate, 0.0), 1.0)
     logfire.configure(
         service_name=RAG_SERVICE_NAME,
         service_version=os.getenv("APP_VERSION", "0.0.1"),
         environment=os.getenv("ENVIRONMENT", "local"),
         send_to_logfire="if-token-present",
-        sampling=logfire.SamplingOptions(head=sample_rate),
+        sampling=build_sampling_options(_DEFAULT_SAMPLE_RATE),
     )
 
 

--- a/src/rag/ingest.py
+++ b/src/rag/ingest.py
@@ -49,13 +49,19 @@ RAG_SERVICE_NAME = "tfl-monitor-rag-ingestion"
 
 def configure_logfire() -> None:
     """Configure Logfire for the ingestion entrypoint."""
+    raw = os.getenv("LOGFIRE_SAMPLE_RATE")
+    try:
+        rate = float(raw) if raw is not None else 0.5
+    except ValueError:
+        rate = 0.5
+    sample_rate = min(max(rate, 0.0), 1.0)
     logfire.configure(
         service_name=RAG_SERVICE_NAME,
         service_version=os.getenv("APP_VERSION", "0.0.1"),
         environment=os.getenv("ENVIRONMENT", "local"),
         send_to_logfire="if-token-present",
+        sampling=logfire.SamplingOptions(head=sample_rate),
     )
-    logfire.instrument_httpx()
 
 
 async def _amain(

--- a/tests/common/test_sampling.py
+++ b/tests/common/test_sampling.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logfire
 import pytest
 
-from common.sampling import build_sampling_options, read_sample_rate
+from common.sampling import _read_sample_rate, build_sampling_options
 
 
 @pytest.fixture(autouse=True)
@@ -14,37 +14,56 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_read_sample_rate_returns_default_when_unset() -> None:
-    assert read_sample_rate(0.1) == pytest.approx(0.1)
-    assert read_sample_rate(0.5) == pytest.approx(0.5)
+    assert _read_sample_rate(0.1) == pytest.approx(0.1)
+    assert _read_sample_rate(0.5) == pytest.approx(0.5)
 
 
 def test_read_sample_rate_uses_env_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "0.25")
-    assert read_sample_rate(0.1) == pytest.approx(0.25)
+    assert _read_sample_rate(0.1) == pytest.approx(0.25)
 
 
 def test_read_sample_rate_clamps_above_one(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "2.0")
-    assert read_sample_rate(0.1) == pytest.approx(1.0)
+    assert _read_sample_rate(0.1) == pytest.approx(1.0)
 
 
 def test_read_sample_rate_clamps_below_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "-0.5")
-    assert read_sample_rate(0.1) == pytest.approx(0.0)
+    assert _read_sample_rate(0.1) == pytest.approx(0.0)
 
 
 def test_read_sample_rate_malformed_falls_back_to_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "abc")
-    assert read_sample_rate(0.1) == pytest.approx(0.1)
+    assert _read_sample_rate(0.1) == pytest.approx(0.1)
 
 
 def test_read_sample_rate_empty_string_falls_back_to_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "")
-    assert read_sample_rate(0.1) == pytest.approx(0.1)
+    assert _read_sample_rate(0.1) == pytest.approx(0.1)
+
+
+def _bound_background_rate(options: logfire.SamplingOptions) -> float:
+    """Probe the rate captured by Logfire's tail-sampler closure.
+
+    ``SamplingOptions.level_or_duration`` returns a closure over
+    ``background_rate``; reaching into ``__closure__`` is the only public
+    way to assert that the resolved sample rate actually made it into the
+    options without standing up a real Logfire backend.
+    """
+    tail = options.tail
+    assert tail is not None
+    freevars = tail.__code__.co_freevars
+    closure = tail.__closure__
+    assert closure is not None
+    cells = dict(zip(freevars, closure, strict=True))
+    value = cells["background_rate"].cell_contents
+    assert isinstance(value, float)
+    return value
 
 
 def test_build_sampling_options_returns_logfire_type() -> None:
@@ -56,9 +75,18 @@ def test_build_sampling_options_returns_logfire_type() -> None:
     assert options.tail is not None
 
 
+def test_build_sampling_options_binds_default_when_env_unset() -> None:
+    options = build_sampling_options(0.42)
+    assert _bound_background_rate(options) == pytest.approx(0.42)
+
+
 def test_build_sampling_options_picks_up_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "0.05")
     options = build_sampling_options(0.5)
-    # Resolved rate is bound inside ``options.tail``; assert the constructor
-    # consumed it without erroring and produced a usable tail callable.
-    assert callable(options.tail)
+    assert _bound_background_rate(options) == pytest.approx(0.05)
+
+
+def test_build_sampling_options_clamps_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "5.0")
+    options = build_sampling_options(0.1)
+    assert _bound_background_rate(options) == pytest.approx(1.0)

--- a/tests/common/test_sampling.py
+++ b/tests/common/test_sampling.py
@@ -1,0 +1,64 @@
+"""Tests for ``common.sampling`` env-var parsing and SamplingOptions wiring."""
+
+from __future__ import annotations
+
+import logfire
+import pytest
+
+from common.sampling import build_sampling_options, read_sample_rate
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LOGFIRE_SAMPLE_RATE", raising=False)
+
+
+def test_read_sample_rate_returns_default_when_unset() -> None:
+    assert read_sample_rate(0.1) == pytest.approx(0.1)
+    assert read_sample_rate(0.5) == pytest.approx(0.5)
+
+
+def test_read_sample_rate_uses_env_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "0.25")
+    assert read_sample_rate(0.1) == pytest.approx(0.25)
+
+
+def test_read_sample_rate_clamps_above_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "2.0")
+    assert read_sample_rate(0.1) == pytest.approx(1.0)
+
+
+def test_read_sample_rate_clamps_below_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "-0.5")
+    assert read_sample_rate(0.1) == pytest.approx(0.0)
+
+
+def test_read_sample_rate_malformed_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "abc")
+    assert read_sample_rate(0.1) == pytest.approx(0.1)
+
+
+def test_read_sample_rate_empty_string_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "")
+    assert read_sample_rate(0.1) == pytest.approx(0.1)
+
+
+def test_build_sampling_options_returns_logfire_type() -> None:
+    options = build_sampling_options(0.1)
+    assert isinstance(options, logfire.SamplingOptions)
+    # ``level_or_duration`` keeps ``head=1.0`` and pushes selection to the
+    # tail callable, so every trace reaches the level/duration check.
+    assert options.head == pytest.approx(1.0)
+    assert options.tail is not None
+
+
+def test_build_sampling_options_picks_up_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "0.05")
+    options = build_sampling_options(0.5)
+    # Resolved rate is bound inside ``options.tail``; assert the constructor
+    # consumed it without erroring and produced a usable tail callable.
+    assert callable(options.tail)

--- a/tests/common/test_sampling.py
+++ b/tests/common/test_sampling.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import logfire
 import pytest
 
@@ -47,46 +49,46 @@ def test_read_sample_rate_empty_string_falls_back_to_default(
     assert _read_sample_rate(0.1) == pytest.approx(0.1)
 
 
-def _bound_background_rate(options: logfire.SamplingOptions) -> float:
-    """Probe the rate captured by Logfire's tail-sampler closure.
-
-    ``SamplingOptions.level_or_duration`` returns a closure over
-    ``background_rate``; reaching into ``__closure__`` is the only public
-    way to assert that the resolved sample rate actually made it into the
-    options without standing up a real Logfire backend.
-    """
-    tail = options.tail
-    assert tail is not None
-    freevars = tail.__code__.co_freevars
-    closure = tail.__closure__
-    assert closure is not None
-    cells = dict(zip(freevars, closure, strict=True))
-    value = cells["background_rate"].cell_contents
-    assert isinstance(value, float)
-    return value
+@pytest.mark.parametrize("raw", ["nan", "NaN", "inf", "-inf", "Infinity"])
+def test_read_sample_rate_non_finite_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", raw)
+    assert _read_sample_rate(0.1) == pytest.approx(0.1)
 
 
 def test_build_sampling_options_returns_logfire_type() -> None:
     options = build_sampling_options(0.1)
     assert isinstance(options, logfire.SamplingOptions)
-    # ``level_or_duration`` keeps ``head=1.0`` and pushes selection to the
-    # tail callable, so every trace reaches the level/duration check.
-    assert options.head == pytest.approx(1.0)
-    assert options.tail is not None
 
 
-def test_build_sampling_options_binds_default_when_env_unset() -> None:
-    options = build_sampling_options(0.42)
-    assert _bound_background_rate(options) == pytest.approx(0.42)
+def test_build_sampling_options_forwards_default_to_level_or_duration() -> None:
+    with patch.object(
+        logfire.SamplingOptions,
+        "level_or_duration",
+        wraps=logfire.SamplingOptions.level_or_duration,
+    ) as spy:
+        build_sampling_options(0.42)
+    spy.assert_called_once_with(level_threshold="warn", background_rate=pytest.approx(0.42))
 
 
-def test_build_sampling_options_picks_up_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_sampling_options_forwards_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "0.05")
-    options = build_sampling_options(0.5)
-    assert _bound_background_rate(options) == pytest.approx(0.05)
+    with patch.object(
+        logfire.SamplingOptions,
+        "level_or_duration",
+        wraps=logfire.SamplingOptions.level_or_duration,
+    ) as spy:
+        build_sampling_options(0.5)
+    spy.assert_called_once_with(level_threshold="warn", background_rate=pytest.approx(0.05))
 
 
-def test_build_sampling_options_clamps_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_sampling_options_forwards_clamped_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOGFIRE_SAMPLE_RATE", "5.0")
-    options = build_sampling_options(0.1)
-    assert _bound_background_rate(options) == pytest.approx(1.0)
+    with patch.object(
+        logfire.SamplingOptions,
+        "level_or_duration",
+        wraps=logfire.SamplingOptions.level_or_duration,
+    ) as spy:
+        build_sampling_options(0.1)
+    spy.assert_called_once_with(level_threshold="warn", background_rate=pytest.approx(1.0))


### PR DESCRIPTION
## Summary

Free-tier Logfire usage hit 6.89M / 10M spans in the first 3 days of the
billing window. This PR brings projected monthly volume back under budget
without touching error visibility or LLM/agent traces.

## Changes

- **Head sampling**: `logfire.SamplingOptions(head=0.1)` on the API and
  ingestion services, `head=0.5` on RAG ingest. Override per service via
  `LOGFIRE_SAMPLE_RATE` (0.0-1.0) when full fidelity is needed for a
  debugging window.
- **Drop duplicate `instrument_httpx()`** in 5 entrypoints (API,
  `run_producers`, the three producer `_amain` blocks, RAG ingest).
  The manual `with logfire.span(\"tfl.request\", ...)` block in
  `tfl_client/client.py` already wraps the same HTTP call — the
  auto-instrumentor was emitting a redundant span per request.
- **Drop `instrument_psycopg()` from the API**. `instrument_fastapi`
  already surfaces per-endpoint timing; psycopg span-per-query was
  the largest API-side multiplier. Kept on the consumers where DB
  inserts are the primary work and the span is the only DB-side
  signal.
- **Strip per-cycle info logs** (`ingestion.{arrivals,line_status,disruptions}.cycle`)
  from the three producers. Fired every 30-300 s, never read in
  practice, pure ingest noise. Error/warn paths kept intact.
- **/health probe interval 30 s → 120 s** in \`infra/docker-compose.prod.yml\`.
  Every probe was a Logfire span via \`instrument_fastapi\`; this cuts
  health-only volume to 1/4 without losing self-monitoring.

## Volume math

| Source | Before (spans/day) | After |
|---|---|---|
| Producers + consumers | ~1.0 M | ~100 k |
| /health self-probe | ~2 880 | ~720 |
| API instrument duplicates | ~2x per request | ~1x |
| Per-cycle info logs | ~6 k | 0 |

Projection: ~6.89 M / 3 d → ~700 k / 3 d.

## Test plan

- [x] \`uv run task lint\` — passes
- [x] \`uv run task test\` — 292 passed, 1 pre-existing failure on \`main\`
      (\`tests/rag/test_ingest.py::test_run_ingestion_missing_pinecone_key_exits_2\`)
      unrelated to this PR
- [ ] After merge + redeploy, confirm Plan & Usage chart flattens within
      24 h. Roll back the sampling rate if a real incident needs full
      fidelity — set \`LOGFIRE_SAMPLE_RATE=1.0\` on the affected service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable environment variable to control logging and monitoring sampling behavior across services, allowing optimization of observability overhead

* **Documentation**
  * Updated API and ingestion service observability documentation to reflect current logging and instrumentation strategies

* **Chores**
  * Reduced API health check frequency for improved efficiency
  * Updated package build configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->