### PR TITLE
fix(infra): cap warehouse volume + cut producer cadence

### DIFF
--- a/infra/.env.example
+++ b/infra/.env.example
@@ -53,3 +53,11 @@ LANGSMITH_PROJECT=tfl-monitor
 # App metadata
 ENVIRONMENT=production
 APP_VERSION=v1.0.0
+
+# Ingestion tuning
+# ArrivalsProducer poll period (seconds). Default 30s is fine for dev;
+# prod sets 900s (15 min) to keep warehouse volume bounded under the
+# free-tier ceiling. Historical reliability marts only need this
+# cadence — live "next arrivals" queries hit TfL directly via the
+# agent's get_arrivals_tool (not via the warehouse).
+ARRIVALS_POLL_PERIOD_SECONDS=900

--- a/infra/cron.d/tfl-monitor
+++ b/infra/cron.d/tfl-monitor
@@ -17,6 +17,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # Nightly retention sweep — drops raw.* rows older than per-table
 # windows (api.maintenance.DEFAULT_RULES) and VACUUMs each table.
 # Keeps the warehouse bounded under the Supabase free-tier ceiling;
-# dbt marts already carry the long-term aggregates. Runs at 03:00 UTC
-# to avoid colliding with the */15 dbt cron's even-quarter hours.
+# dbt marts already carry the long-term aggregates. Runs at 03:03 UTC
+# (3 minutes past the hour, off the */15 dbt cron's even-quarter ticks
+# so the retention sweep never races a `dbt build` for the same row).
 3 3 * * * ubuntu /opt/tfl-monitor/scripts/cron-retention.sh >> /opt/tfl-monitor/cron.log 2>&1

--- a/infra/cron.d/tfl-monitor
+++ b/infra/cron.d/tfl-monitor
@@ -13,3 +13,10 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # and would fail silently. The script uses flock to skip overlapping
 # ticks, so a slow build does not pile up concurrent runs.
 */15 * * * * ubuntu /opt/tfl-monitor/scripts/cron-dbt-run.sh >> /opt/tfl-monitor/cron.log 2>&1
+
+# Nightly retention sweep — drops raw.* rows older than per-table
+# windows (api.maintenance.DEFAULT_RULES) and VACUUMs each table.
+# Keeps the warehouse bounded under the Supabase free-tier ceiling;
+# dbt marts already carry the long-term aggregates. Runs at 03:00 UTC
+# to avoid colliding with the */15 dbt cron's even-quarter hours.
+3 3 * * * ubuntu /opt/tfl-monitor/scripts/cron-retention.sh >> /opt/tfl-monitor/cron.log 2>&1

--- a/scripts/cron-retention.sh
+++ b/scripts/cron-retention.sh
@@ -46,7 +46,15 @@ timeout "${RETENTION_TIMEOUT}" docker exec "${API_CONTAINER}" \
 retention_status=$?
 set -e
 if [[ $retention_status -eq 124 ]]; then
-  echo "[$(date -Iseconds)] $LOG_TAG ERROR: retention timed out after ${RETENTION_TIMEOUT}" >&2
+  # `docker exec` does NOT forward SIGTERM to the in-container process by
+  # default, so killing the `docker exec` client on host timeout leaves the
+  # actual maintenance run still attached to the warehouse. Signal it from
+  # inside the container so the next tick does not race a stuck DELETE on
+  # the same table. Mirrors `cron-dbt-run.sh`.
+  echo "[$(date -Iseconds)] $LOG_TAG ERROR: retention timed out after ${RETENTION_TIMEOUT} — killing in-container process" >&2
+  docker exec "${API_CONTAINER}" pkill -TERM -f 'api.maintenance' 2>/dev/null || true
+  sleep 2
+  docker exec "${API_CONTAINER}" pkill -KILL -f 'api.maintenance' 2>/dev/null || true
   exit 124
 elif [[ $retention_status -ne 0 ]]; then
   echo "[$(date -Iseconds)] $LOG_TAG ERROR: retention failed (exit $retention_status)" >&2

--- a/scripts/cron-retention.sh
+++ b/scripts/cron-retention.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Cron entrypoint for nightly retention prune on the production
+# Lightsail box. Installed at /etc/cron.d/tfl-monitor via
+# infra/cron.d/tfl-monitor (next to cron-dbt-run.sh).
+#
+# Drops raw.* rows older than per-table windows defined in
+# api.maintenance.DEFAULT_RULES, then VACUUMs each table so the dead
+# tuples actually return disk pages on a near-full Supabase.
+
+set -euo pipefail
+
+LOG_TAG="tfl-monitor-cron-retention"
+LOCK_FILE="/tmp/tfl-monitor-retention.lock"
+API_CONTAINER="${API_CONTAINER:-tfl-monitor-api-1}"
+# Cap each run at 10 min. The DELETE on a near-full Supabase has
+# historically been the slow phase; if it stalls past 10 min something
+# is wrong (lock contention, query plan regression) and the next tick
+# should investigate, not pile up.
+RETENTION_TIMEOUT="${RETENTION_TIMEOUT:-10m}"
+
+if ! command -v flock >/dev/null 2>&1; then
+  echo "[$(date -Iseconds)] $LOG_TAG ERROR: flock not installed" >&2
+  exit 127
+fi
+
+exec 9>>"$LOCK_FILE"
+set +e
+flock -n 9
+flock_status=$?
+set -e
+if [[ $flock_status -eq 1 ]]; then
+  echo "[$(date -Iseconds)] $LOG_TAG retention already running, skipping"
+  exit 0
+elif [[ $flock_status -ne 0 ]]; then
+  echo "[$(date -Iseconds)] $LOG_TAG ERROR: flock failed (exit $flock_status)" >&2
+  exit $flock_status
+fi
+
+echo "[$(date -Iseconds)] $LOG_TAG retention start"
+
+cd /opt/tfl-monitor
+
+set +e
+timeout "${RETENTION_TIMEOUT}" docker exec "${API_CONTAINER}" \
+  python -m api.maintenance
+retention_status=$?
+set -e
+if [[ $retention_status -eq 124 ]]; then
+  echo "[$(date -Iseconds)] $LOG_TAG ERROR: retention timed out after ${RETENTION_TIMEOUT}" >&2
+  exit 124
+elif [[ $retention_status -ne 0 ]]; then
+  echo "[$(date -Iseconds)] $LOG_TAG ERROR: retention failed (exit $retention_status)" >&2
+  exit $retention_status
+fi
+
+echo "[$(date -Iseconds)] $LOG_TAG retention done"

--- a/src/api/maintenance.py
+++ b/src/api/maintenance.py
@@ -1,0 +1,111 @@
+"""Retention sweep for ``raw.*`` tables.
+
+Driven nightly by ``scripts/cron-retention.sh`` (host cron) so the
+warehouse stays bounded under the Supabase free-tier ceiling. dbt
+marts already aggregate the raw rows; the retention window is short
+because the marts carry the long-term signal.
+
+Usage::
+
+    python -m api.maintenance
+
+Reads ``DATABASE_URL`` from the environment. Exits non-zero (and
+flushes Logfire) on any error so cron raises the alarm.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Final
+
+import logfire
+import psycopg
+
+
+@dataclass(frozen=True)
+class RetentionRule:
+    """One table + age threshold."""
+
+    schema: str
+    table: str
+    days: int
+
+    @property
+    def qualified(self) -> str:
+        return f"{self.schema}.{self.table}"
+
+
+# Retention windows. Tuned for the post-hotfix volume:
+#  - arrivals at 15 min poll → ~14K rows/day → 7d cap ≈ 100K rows
+#  - line_status at 30 s poll → ~40K rows/day → 30d cap ≈ 1.2M rows
+#  - disruptions tiny (<1 MB/day) → 30d cap is generous
+# Marts hold the long-term aggregates; truncating raw beyond these
+# windows costs nothing analytically. Order matters: VACUUM after each
+# DELETE so the next rule sees freshly reclaimed disk on a near-full
+# Supabase. Arrivals first because it dominates volume.
+DEFAULT_RULES: Final[tuple[RetentionRule, ...]] = (
+    RetentionRule(schema="raw", table="arrivals", days=7),
+    RetentionRule(schema="raw", table="line_status", days=30),
+    RetentionRule(schema="raw", table="disruptions", days=30),
+)
+
+
+async def prune(
+    *,
+    dsn: str,
+    rules: tuple[RetentionRule, ...] = DEFAULT_RULES,
+) -> dict[str, int]:
+    """Delete rows older than each rule's window. Returns deleted counts.
+
+    A VACUUM (without FULL) follows each DELETE to reclaim heap pages
+    on the autovacuum-disabled Supabase instance — on a near-full disk
+    the DELETE alone leaves dead tuples that still consume space.
+    """
+    deleted: dict[str, int] = {}
+    async with await psycopg.AsyncConnection.connect(dsn, autocommit=True) as conn:
+        for rule in rules:
+            count = await _prune_one(conn, rule)
+            deleted[rule.qualified] = count
+    logfire.info("maintenance.prune.done", deleted=deleted)
+    return deleted
+
+
+async def _prune_one(conn: psycopg.AsyncConnection, rule: RetentionRule) -> int:
+    delete_sql = (
+        f"DELETE FROM {rule.qualified} WHERE ingested_at < now() - INTERVAL '{rule.days} days'"
+    )
+    vacuum_sql = f"VACUUM {rule.qualified}"
+    with logfire.span(
+        "maintenance.prune.rule",
+        table=rule.qualified,
+        retention_days=rule.days,
+    ):
+        async with conn.cursor() as cur:
+            await cur.execute(delete_sql)
+            count = cur.rowcount
+            logfire.info(
+                "maintenance.prune.deleted",
+                table=rule.qualified,
+                deleted_rows=count,
+            )
+            await cur.execute(vacuum_sql)
+    return count
+
+
+async def _amain() -> int:
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        raise SystemExit("DATABASE_URL is required")
+    await prune(dsn=dsn)
+    return 0
+
+
+def main() -> None:
+    """Module entrypoint used by ``python -m api.maintenance``."""
+    raise SystemExit(asyncio.run(_amain()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/maintenance.py
+++ b/src/api/maintenance.py
@@ -17,11 +17,21 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 from dataclasses import dataclass
 from typing import Final
 
 import logfire
 import psycopg
+from psycopg import sql
+
+MAINTENANCE_SERVICE_NAME = "tfl-monitor-maintenance"
+
+# Defensive identifier guard. Belt-and-braces on top of
+# ``psycopg.sql.Identifier`` which already quotes safely; this rejects
+# any caller that tries to construct a ``RetentionRule`` with a non-
+# identifier schema/table name before it ever reaches the cursor.
+_IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
 
 
 @dataclass(frozen=True)
@@ -31,6 +41,13 @@ class RetentionRule:
     schema: str
     table: str
     days: int
+
+    def __post_init__(self) -> None:
+        for label, value in (("schema", self.schema), ("table", self.table)):
+            if not _IDENTIFIER_RE.match(value):
+                raise ValueError(f"{label} must match {_IDENTIFIER_RE.pattern}; got {value!r}")
+        if self.days <= 0:
+            raise ValueError(f"days must be > 0; got {self.days}")
 
     @property
     def qualified(self) -> str:
@@ -73,28 +90,48 @@ async def prune(
 
 
 async def _prune_one(conn: psycopg.AsyncConnection, rule: RetentionRule) -> int:
-    delete_sql = (
-        f"DELETE FROM {rule.qualified} WHERE ingested_at < now() - INTERVAL '{rule.days} days'"
+    table_ident = sql.Identifier(rule.schema, rule.table)
+    delete_stmt = sql.SQL("DELETE FROM {table} WHERE ingested_at < now() - %s::interval").format(
+        table=table_ident
     )
-    vacuum_sql = f"VACUUM {rule.qualified}"
+    vacuum_stmt = sql.SQL("VACUUM {table}").format(table=table_ident)
+    interval_literal = f"{rule.days} days"
     with logfire.span(
         "maintenance.prune.rule",
         table=rule.qualified,
         retention_days=rule.days,
     ):
         async with conn.cursor() as cur:
-            await cur.execute(delete_sql)
+            await cur.execute(delete_stmt, (interval_literal,))
             count = cur.rowcount
             logfire.info(
                 "maintenance.prune.deleted",
                 table=rule.qualified,
                 deleted_rows=count,
             )
-            await cur.execute(vacuum_sql)
+            await cur.execute(vacuum_stmt)
     return count
 
 
+def _configure_logfire() -> None:
+    """Initialise Logfire for the maintenance entrypoint.
+
+    Cron invokes ``python -m api.maintenance`` as a standalone process —
+    no FastAPI lifespan or ingestion runner ever sets Logfire up here.
+    Without this call the spans below are dropped with a
+    ``LogfireNotConfiguredWarning`` and the cron run is observability-blind.
+    """
+    logfire.configure(
+        service_name=MAINTENANCE_SERVICE_NAME,
+        service_version=os.getenv("APP_VERSION", "0.0.1"),
+        environment=os.getenv("ENVIRONMENT", "local"),
+        send_to_logfire="if-token-present",
+    )
+    logfire.instrument_psycopg("psycopg")
+
+
 async def _amain() -> int:
+    _configure_logfire()
     dsn = os.environ.get("DATABASE_URL", "")
     if not dsn:
         raise SystemExit("DATABASE_URL is required")

--- a/src/ingestion/producers/arrivals.py
+++ b/src/ingestion/producers/arrivals.py
@@ -20,6 +20,7 @@ via Logfire and the daemon continues on the next tick.
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import time
 import uuid
@@ -69,7 +70,9 @@ def _read_poll_period_env() -> float:
         value = float(raw)
     except ValueError:
         return _DEFAULT_POLL_PERIOD_SECONDS
-    return value if value > 0 else _DEFAULT_POLL_PERIOD_SECONDS
+    if not math.isfinite(value) or value <= 0:
+        return _DEFAULT_POLL_PERIOD_SECONDS
+    return value
 
 
 # Module-level alias preserved for back-compat with imports. Reflects
@@ -109,8 +112,8 @@ class ArrivalsProducer:
         # at construction time so prod ``.env`` flips (e.g. 30s → 900s)
         # apply at the next container recreate without a code change.
         resolved_period = period_seconds if period_seconds is not None else _read_poll_period_env()
-        if resolved_period <= 0:
-            raise ValueError("period_seconds must be > 0")
+        if not math.isfinite(resolved_period) or resolved_period <= 0:
+            raise ValueError("period_seconds must be a positive finite number")
         if not stops:
             raise ValueError("stops must contain at least one NaPTAN id")
         self._tfl_client = tfl_client

--- a/src/ingestion/producers/arrivals.py
+++ b/src/ingestion/producers/arrivals.py
@@ -44,7 +44,38 @@ __all__ = [
 ]
 
 ARRIVALS_EVENT_TYPE = "arrivals.snapshot"
-ARRIVALS_POLL_PERIOD_SECONDS = 30.0
+
+_DEFAULT_POLL_PERIOD_SECONDS = 30.0
+
+
+def _read_poll_period_env() -> float:
+    """Read ``ARRIVALS_POLL_PERIOD_SECONDS`` from the environment.
+
+    The poll period is env-configurable to let production slow ingestion
+    down to a non-bleeding rate (Supabase free tier caps storage; PR #105
+    + this hotfix together cut Logfire span volume by another order of
+    magnitude). Local dev keeps the 30 s default unless explicitly
+    overridden.
+
+    Returns:
+        Positive number of seconds between polls. Falls back to the
+        30 s default on missing, empty, non-numeric, or non-positive
+        values so a malformed env var cannot brick the producer.
+    """
+    raw = os.environ.get("ARRIVALS_POLL_PERIOD_SECONDS")
+    if not raw:
+        return _DEFAULT_POLL_PERIOD_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return _DEFAULT_POLL_PERIOD_SECONDS
+    return value if value > 0 else _DEFAULT_POLL_PERIOD_SECONDS
+
+
+# Module-level alias preserved for back-compat with imports. Reflects
+# the env at import time; callers wanting runtime overrides should
+# pass ``period_seconds`` to :class:`ArrivalsProducer` explicitly.
+ARRIVALS_POLL_PERIOD_SECONDS = _read_poll_period_env()
 
 # Major Underground hubs covering high passenger volume across the
 # zone-1 core. NaPTAN stop-area identifiers (TfL surface IDs).
@@ -70,18 +101,22 @@ class ArrivalsProducer:
         tfl_client: TflClient,
         kafka_producer: KafkaEventProducer,
         stops: Sequence[str] = DEFAULT_ARRIVAL_STOPS,
-        period_seconds: float = ARRIVALS_POLL_PERIOD_SECONDS,
+        period_seconds: float | None = None,
         clock: Callable[[], datetime] = _utc_now,
         event_id_factory: Callable[[], UUID] = uuid.uuid4,
     ) -> None:
-        if period_seconds <= 0:
+        # ``period_seconds=None`` reads ``ARRIVALS_POLL_PERIOD_SECONDS``
+        # at construction time so prod ``.env`` flips (e.g. 30s → 900s)
+        # apply at the next container recreate without a code change.
+        resolved_period = period_seconds if period_seconds is not None else _read_poll_period_env()
+        if resolved_period <= 0:
             raise ValueError("period_seconds must be > 0")
         if not stops:
             raise ValueError("stops must contain at least one NaPTAN id")
         self._tfl_client = tfl_client
         self._kafka_producer = kafka_producer
         self._stops = tuple(stops)
-        self._period_seconds = period_seconds
+        self._period_seconds = resolved_period
         self._clock = clock
         self._event_id_factory = event_id_factory
 

--- a/tests/api/test_maintenance.py
+++ b/tests/api/test_maintenance.py
@@ -1,0 +1,133 @@
+"""Unit tests for the retention prune (``api.maintenance``)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+
+import pytest
+
+from api import maintenance
+
+
+@dataclass
+class _FakeCursor:
+    executed: list[str] = field(default_factory=list)
+    rowcount: int = 0
+    rowcount_by_sql: dict[str, int] = field(default_factory=dict)
+
+    async def __aenter__(self) -> _FakeCursor:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    async def execute(self, sql: str) -> None:
+        self.executed.append(sql)
+        # Set rowcount based on the executed DELETE so the test asserts
+        # on per-rule counts. VACUUM keeps the previous rowcount; it
+        # is never consumed by callers.
+        for marker, count in self.rowcount_by_sql.items():
+            if marker in sql and sql.startswith("DELETE"):
+                self.rowcount = count
+                break
+
+
+@dataclass
+class _FakeConn:
+    cursor_obj: _FakeCursor
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_obj
+
+    async def __aenter__(self) -> _FakeConn:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+@asynccontextmanager
+async def _patch_connect(
+    monkeypatch: pytest.MonkeyPatch, cursor: _FakeCursor
+) -> AsyncIterator[_FakeConn]:
+    conn = _FakeConn(cursor_obj=cursor)
+
+    async def _fake_connect(*_args: object, **_kwargs: object) -> _FakeConn:
+        return conn
+
+    monkeypatch.setattr("api.maintenance.psycopg.AsyncConnection.connect", _fake_connect)
+    yield conn
+
+
+@pytest.mark.asyncio
+async def test_prune_runs_delete_then_vacuum_per_rule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _FakeCursor(rowcount_by_sql={"raw.arrivals": 100, "raw.line_status": 5})
+    async with _patch_connect(monkeypatch, cursor):
+        deleted = await maintenance.prune(
+            dsn="fake://",
+            rules=(
+                maintenance.RetentionRule(schema="raw", table="arrivals", days=7),
+                maintenance.RetentionRule(schema="raw", table="line_status", days=30),
+            ),
+        )
+
+    assert deleted == {"raw.arrivals": 100, "raw.line_status": 5}
+    # Each rule produces exactly DELETE then VACUUM, in order.
+    assert cursor.executed == [
+        "DELETE FROM raw.arrivals WHERE ingested_at < now() - INTERVAL '7 days'",
+        "VACUUM raw.arrivals",
+        "DELETE FROM raw.line_status WHERE ingested_at < now() - INTERVAL '30 days'",
+        "VACUUM raw.line_status",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prune_zero_rows_still_runs_vacuum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even on a quiet day the VACUUM should run — dead tuples linger
+    from previous deletes and only VACUUM reclaims their pages."""
+    cursor = _FakeCursor(rowcount_by_sql={})
+    async with _patch_connect(monkeypatch, cursor):
+        deleted = await maintenance.prune(
+            dsn="fake://",
+            rules=(maintenance.RetentionRule(schema="raw", table="arrivals", days=7),),
+        )
+
+    assert deleted == {"raw.arrivals": 0}
+    assert any(stmt.startswith("VACUUM") for stmt in cursor.executed)
+
+
+def test_default_rules_target_only_raw_schema() -> None:
+    """Marts must never be pruned by retention — they hold the long-term
+    aggregates the API endpoints depend on."""
+    schemas = {rule.schema for rule in maintenance.DEFAULT_RULES}
+    assert schemas == {"raw"}
+
+
+def test_default_rules_cover_every_high_volume_raw_table() -> None:
+    """Regression guard: a new raw.* table from a future producer must be
+    added to DEFAULT_RULES or the warehouse drifts unbounded again."""
+    expected_tables = {"arrivals", "line_status", "disruptions"}
+    tables = {rule.table for rule in maintenance.DEFAULT_RULES}
+    assert tables == expected_tables
+
+
+def test_arrivals_retention_window_tightest() -> None:
+    """Arrivals has the highest write volume and the shortest analytical
+    half-life — its retention must stay strictly below line_status's."""
+    by_table = {rule.table: rule.days for rule in maintenance.DEFAULT_RULES}
+    assert by_table["arrivals"] < by_table["line_status"]
+
+
+@pytest.mark.asyncio
+async def test_amain_exits_when_database_url_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(SystemExit, match="DATABASE_URL"):
+        await maintenance._amain()  # noqa: SLF001

--- a/tests/api/test_maintenance.py
+++ b/tests/api/test_maintenance.py
@@ -7,8 +7,16 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 
 import pytest
+from psycopg.sql import Composable
 
 from api import maintenance
+
+
+def _stmt_str(stmt: object) -> str:
+    """Render a SQL Composable (or plain string) to a flat string for tests."""
+    if isinstance(stmt, Composable):
+        return stmt.as_string(None)
+    return str(stmt)
 
 
 @dataclass
@@ -23,13 +31,14 @@ class _FakeCursor:
     async def __aexit__(self, *_args: object) -> None:
         return None
 
-    async def execute(self, sql: str) -> None:
-        self.executed.append(sql)
+    async def execute(self, stmt: object, params: tuple[object, ...] | None = None) -> None:
+        rendered = _stmt_str(stmt)
+        self.executed.append(rendered)
         # Set rowcount based on the executed DELETE so the test asserts
         # on per-rule counts. VACUUM keeps the previous rowcount; it
         # is never consumed by callers.
         for marker, count in self.rowcount_by_sql.items():
-            if marker in sql and sql.startswith("DELETE"):
+            if marker in rendered and rendered.startswith("DELETE"):
                 self.rowcount = count
                 break
 
@@ -65,7 +74,9 @@ async def _patch_connect(
 async def test_prune_runs_delete_then_vacuum_per_rule(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    cursor = _FakeCursor(rowcount_by_sql={"raw.arrivals": 100, "raw.line_status": 5})
+    # Identifiers are quoted by psycopg.sql.Identifier; markers must match
+    # the rendered form, not the dotted shortcut.
+    cursor = _FakeCursor(rowcount_by_sql={'"raw"."arrivals"': 100, '"raw"."line_status"': 5})
     async with _patch_connect(monkeypatch, cursor):
         deleted = await maintenance.prune(
             dsn="fake://",
@@ -76,12 +87,14 @@ async def test_prune_runs_delete_then_vacuum_per_rule(
         )
 
     assert deleted == {"raw.arrivals": 100, "raw.line_status": 5}
-    # Each rule produces exactly DELETE then VACUUM, in order.
+    # Each rule produces exactly DELETE then VACUUM, in order. Identifiers
+    # are quoted by psycopg.sql.Identifier (the security-hardening fix);
+    # parameter placeholder %s carries the days literal.
     assert cursor.executed == [
-        "DELETE FROM raw.arrivals WHERE ingested_at < now() - INTERVAL '7 days'",
-        "VACUUM raw.arrivals",
-        "DELETE FROM raw.line_status WHERE ingested_at < now() - INTERVAL '30 days'",
-        "VACUUM raw.line_status",
+        'DELETE FROM "raw"."arrivals" WHERE ingested_at < now() - %s::interval',
+        'VACUUM "raw"."arrivals"',
+        'DELETE FROM "raw"."line_status" WHERE ingested_at < now() - %s::interval',
+        'VACUUM "raw"."line_status"',
     ]
 
 
@@ -115,6 +128,26 @@ def test_default_rules_cover_every_high_volume_raw_table() -> None:
     expected_tables = {"arrivals", "line_status", "disruptions"}
     tables = {rule.table for rule in maintenance.DEFAULT_RULES}
     assert tables == expected_tables
+
+
+def test_retention_rule_rejects_non_identifier_schema() -> None:
+    """Belt-and-braces on top of psycopg.sql.Identifier: an attacker who
+    bypasses the static DEFAULT_RULES list still cannot smuggle a quoted
+    string through the schema or table slot."""
+    with pytest.raises(ValueError, match="schema"):
+        maintenance.RetentionRule(schema='raw"; DROP TABLE x;--', table="arrivals", days=7)
+
+
+def test_retention_rule_rejects_non_identifier_table() -> None:
+    with pytest.raises(ValueError, match="table"):
+        maintenance.RetentionRule(schema="raw", table="arrivals; DROP", days=7)
+
+
+def test_retention_rule_rejects_non_positive_days() -> None:
+    with pytest.raises(ValueError, match="days"):
+        maintenance.RetentionRule(schema="raw", table="arrivals", days=0)
+    with pytest.raises(ValueError, match="days"):
+        maintenance.RetentionRule(schema="raw", table="arrivals", days=-1)
 
 
 def test_arrivals_retention_window_tightest() -> None:

--- a/tests/ingestion/test_arrivals_producer.py
+++ b/tests/ingestion/test_arrivals_producer.py
@@ -332,6 +332,34 @@ def test_constructor_falls_back_to_default_on_non_positive_env(
     assert producer._period_seconds == 30.0  # noqa: SLF001
 
 
+@pytest.mark.parametrize("value", ["inf", "-inf", "nan", "Infinity", "NaN"])
+def test_constructor_falls_back_to_default_on_non_finite_env(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """``float('inf')`` would silently disable polling forever; ``nan``
+    breaks the ``> 0`` comparison. Both must collapse to the default."""
+    monkeypatch.setenv("ARRIVALS_POLL_PERIOD_SECONDS", value)
+
+    producer = ArrivalsProducer(
+        tfl_client=cast(TflClient, object()),
+        kafka_producer=cast(KafkaEventProducer, object()),
+    )
+
+    assert producer._period_seconds == 30.0  # noqa: SLF001
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("nan")])
+def test_constructor_rejects_non_finite_explicit_period(value: float) -> None:
+    """An explicit ``period_seconds=inf/nan`` is a programmer error and
+    must raise, distinct from the env-var path that falls back silently."""
+    with pytest.raises(ValueError, match="finite"):
+        ArrivalsProducer(
+            tfl_client=cast(TflClient, object()),
+            kafka_producer=cast(KafkaEventProducer, object()),
+            period_seconds=value,
+        )
+
+
 def test_constructor_rejects_non_positive_period() -> None:
     with pytest.raises(ValueError):
         ArrivalsProducer(

--- a/tests/ingestion/test_arrivals_producer.py
+++ b/tests/ingestion/test_arrivals_producer.py
@@ -286,6 +286,52 @@ async def test_event_envelope_serialises_to_valid_json(
     assert roundtrip.event_type == ARRIVALS_EVENT_TYPE
 
 
+def test_constructor_reads_period_from_env_when_not_overridden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prod slows the producer to 15min via the env var; the constructor
+    must honour it without a code change. Tested at instantiation time
+    (not module load) so a fresh env always wins."""
+    monkeypatch.setenv("ARRIVALS_POLL_PERIOD_SECONDS", "900")
+
+    producer = ArrivalsProducer(
+        tfl_client=cast(TflClient, object()),
+        kafka_producer=cast(KafkaEventProducer, object()),
+    )
+
+    assert producer._period_seconds == 900.0  # noqa: SLF001
+
+
+def test_constructor_falls_back_to_default_on_malformed_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typo / non-numeric env value must not brick the producer."""
+    monkeypatch.setenv("ARRIVALS_POLL_PERIOD_SECONDS", "fifteen")
+
+    producer = ArrivalsProducer(
+        tfl_client=cast(TflClient, object()),
+        kafka_producer=cast(KafkaEventProducer, object()),
+    )
+
+    assert producer._period_seconds == 30.0  # noqa: SLF001
+
+
+def test_constructor_falls_back_to_default_on_non_positive_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``0`` / negative env values fall back to the safe default rather
+    than raise — a misconfig should not prevent the bundled runner from
+    starting line_status + disruptions alongside arrivals."""
+    monkeypatch.setenv("ARRIVALS_POLL_PERIOD_SECONDS", "0")
+
+    producer = ArrivalsProducer(
+        tfl_client=cast(TflClient, object()),
+        kafka_producer=cast(KafkaEventProducer, object()),
+    )
+
+    assert producer._period_seconds == 30.0  # noqa: SLF001
+
+
 def test_constructor_rejects_non_positive_period() -> None:
     with pytest.raises(ValueError):
         ArrivalsProducer(


### PR DESCRIPTION
## Summary

Supabase free tier (500 MB) hit disk-full today: `raw.arrivals` + `analytics.stg_arrivals` consumed 1.2 GB combined (~92% of storage) driven by the 30s `ArrivalsProducer` cadence on five tube hubs. Cascade:

- Disk full → consumer `INSERT INTO raw.arrivals` failed with `OperationalError`
- Bundled consumer container (`tfl-monitor-consumers-1`) crashed
- Docker `restart: unless-stopped` restarted it
- Kafka consumer re-read the backlog from the last committed offset (`enable_auto_commit=False` per TM-B3)
- Crash → restart → re-fetch loop → **517 GB inbound traffic spike** on the Lightsail box (24h)

## Changes

### `src/ingestion/producers/arrivals.py`
- Poll period is now env-configurable: `ARRIVALS_POLL_PERIOD_SECONDS` (default 30 s for local dev; prod `.env` sets 900 s).
- Read at instantiation, not import, so `.env` flips apply at next container recreate (per napkin #11).
- Falls back to the 30 s default on missing / non-numeric / non-positive values — a misconfig cannot brick the bundled `run_producers` runner alongside line-status + disruptions.

### `src/api/maintenance.py` (new)
- Async `prune()` runs `DELETE ... WHERE ingested_at < now() - INTERVAL '<N> days'` + `VACUUM` per `RetentionRule`.
- Default rules: `raw.arrivals` 7 d, `raw.line_status` 30 d, `raw.disruptions` 30 d.
- Marts deliberately excluded — they hold the long-term aggregates the API endpoints depend on.
- `python -m api.maintenance` entrypoint for the cron script.

### `scripts/cron-retention.sh` (new)
- Mirrors `cron-dbt-run.sh`: flock-guarded, 10 min timeout, `docker exec` into the api container.
- Recorded with `+x` mode in git (`git ls-files --stage` shows 100755) so the rsync deploy preserves the bit.

### `infra/cron.d/tfl-monitor`
- New entry: `3 3 * * * ubuntu /opt/tfl-monitor/scripts/cron-retention.sh ...`
- 03:03 UTC chosen to avoid colliding with the `*/15` dbt cron's even-quarter hours.

### `infra/.env.example`
- Documents `ARRIVALS_POLL_PERIOD_SECONDS=900` with the rationale: warehouse cadence (historical-insight tool); live "next arrivals" queries hit TfL directly via the upcoming `get_arrivals_tool` (TM-30), not the warehouse.

## Volume projection post-hotfix

| Table | Before | After |
|---|---|---|
| `raw.arrivals` row growth | ~585 K/day | ~14 K/day (30× ↓) |
| `raw.arrivals` storage (steady-state) | unbounded | ~60 MB (7 d retention) |
| Logfire spans from arrivals polling | ~14 K/day | ~480/day (30× ↓) |

Total Supabase usage estimate post-hotfix: **~100 MB** (well under the 500 MB free-tier ceiling, with retention keeping it bounded indefinitely).

## Operator action required before merge

This PR ships the code change. The one-time TRUNCATE of the accumulated 1.2 GB must be executed by the operator — the MCP enforces read-only on `execute_sql` / `apply_migration` so I cannot run destructive writes from this session.

```sql
TRUNCATE TABLE raw.arrivals, analytics.stg_arrivals;
```

Run via Supabase dashboard SQL editor at `https://supabase.com/dashboard/project/tozxhspicmyztblpwecj/sql/new`, or psql directly. After TRUNCATE the disk drops to ~100 MB, the consumer crashloop ends (writes succeed), and the inbound traffic spike clears.

## Test plan

- [x] `uv run task lint` (ruff + format + mypy strict)
- [x] `uv run task test` — 316 pass + 1 skipped + 1 pre-existing local fail (`tests/rag/test_ingest.py::test_run_ingestion_missing_pinecone_key_exits_2`; unrelated `.env` leak; CI passes)
- [x] `uv run bandit -r src --severity-level high` — 0 findings
- [x] `uv run task dbt-parse` — clean
- [x] New tests cover: env-var override (3 cases on producer), retention prune (6 cases — DELETE+VACUUM ordering, zero-row VACUUM still runs, default rules audit, arrivals window < line_status window, `_amain` fail-fast on missing DSN)
- [ ] Manual post-deploy smoke: SSH `docker logs tfl-monitor-producers-1 -n 50` should show `ingestion.arrivals.cycle_overrun` absent + 15 min between consecutive `tfl.request path=/StopPoint/.../Arrivals` spans
- [ ] Manual post-deploy smoke: next 03:03 UTC cron tick logs to `/opt/tfl-monitor/cron.log` with `tfl-monitor-cron-retention retention done`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automated nightly data retention that prunes old records and optimizes storage to keep the system within limits
  * Made arrivals polling period configurable through environment settings, allowing fine-tuning of ingestion cadence

* **Documentation**
  * Added environment configuration documentation for tuning the arrivals polling frequency

* **Tests**
  * Added unit tests for data retention and polling configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->