### PR TITLE
feat(web): dashboard pane heights, news wrap, Overground fixture

### DIFF
--- a/web/components/dashboard/line-grid.tsx
+++ b/web/components/dashboard/line-grid.tsx
@@ -23,7 +23,7 @@ function activateOnEnterOrSpace(
 
 export function LineGrid({ lines, selected, onSelect }: LineGridProps) {
 	return (
-		<section className="tfl-card">
+		<section className="tfl-card tfl-left-col">
 			<div className="tfl-card-h">
 				<h4>Tube, Overground, DLR &amp; Elizabeth</h4>
 				<span className="meta">tap a line</span>

--- a/web/lib/api/status-live.mock.test.ts
+++ b/web/lib/api/status-live.mock.test.ts
@@ -22,7 +22,7 @@ describe("getStatusLive — USE_MOCKS branch", () => {
 		const result = await getStatusLive();
 
 		expect(fetchMock).not.toHaveBeenCalled();
-		// 13 tube + Elizabeth + DLR + 6 Overground (post-Nov-2024 split).
+		// 11 tube + Elizabeth + DLR + 6 Overground (post-Nov-2024 split).
 		expect(result.length).toBe(19);
 	});
 

--- a/web/lib/api/status-live.mock.test.ts
+++ b/web/lib/api/status-live.mock.test.ts
@@ -22,7 +22,8 @@ describe("getStatusLive — USE_MOCKS branch", () => {
 		const result = await getStatusLive();
 
 		expect(fetchMock).not.toHaveBeenCalled();
-		expect(result.length).toBe(14);
+		// 13 tube + Elizabeth + DLR + 6 Overground (post-Nov-2024 split).
+		expect(result.length).toBe(19);
 	});
 
 	it("projects fixtures into the LineStatus schema", async () => {
@@ -44,9 +45,22 @@ describe("getStatusLive — USE_MOCKS branch", () => {
 		expect(
 			lines.find((line) => line.line_id === "waterloo-city"),
 		).toBeDefined();
-		expect(
-			lines.find((line) => line.line_id === "london-overground"),
-		).toBeDefined();
+		// Sanity-check the post-Nov-2024 Overground split: every named
+		// successor line should ship with `mode === "overground"` so the
+		// adapter's mode-precedence sort places them after the tube /
+		// Elizabeth / DLR rows.
+		for (const overgroundId of [
+			"liberty",
+			"lioness",
+			"mildmay",
+			"suffragette",
+			"weaver",
+			"windrush",
+		]) {
+			const line = lines.find((l) => l.line_id === overgroundId);
+			expect(line, `missing fixture for ${overgroundId}`).toBeDefined();
+			expect(line?.mode).toBe("overground");
+		}
 
 		for (const line of lines) {
 			expect(line.valid_from).toBeTypeOf("string");

--- a/web/lib/api/status-live.ts
+++ b/web/lib/api/status-live.ts
@@ -29,7 +29,12 @@ const MOCK_UPDATED_AGO_MS = 2 * 60_000;
 const CODE_TO_MODE: Record<string, Mode> = {
 	ELZ: "elizabeth-line",
 	DLR: "dlr",
-	OVG: "overground",
+	LIB: "overground",
+	LIO: "overground",
+	MIL: "overground",
+	SUF: "overground",
+	WEA: "overground",
+	WIN: "overground",
 };
 
 const CODE_TO_LINE_ID: Record<string, string> = {
@@ -46,7 +51,12 @@ const CODE_TO_LINE_ID: Record<string, string> = {
 	VIC: "victoria",
 	WAT: "waterloo-city",
 	DLR: "dlr",
-	OVG: "london-overground",
+	LIB: "liberty",
+	LIO: "lioness",
+	MIL: "mildmay",
+	SUF: "suffragette",
+	WEA: "weaver",
+	WIN: "windrush",
 };
 
 function lineSummaryToLineStatus(line: LineSummary, now: Date): LineStatus {

--- a/web/lib/api/status-live.ts
+++ b/web/lib/api/status-live.ts
@@ -35,6 +35,11 @@ const CODE_TO_MODE: Record<string, Mode> = {
 	SUF: "overground",
 	WEA: "overground",
 	WIN: "overground",
+	// Defensive: keep the legacy single-line code mapping. The November
+	// 2024 split replaced this with six named lines on the live feed,
+	// but a stale fixture or legacy backend response should still
+	// resolve to `overground` rather than the `tube` fallback.
+	OVG: "overground",
 };
 
 const CODE_TO_LINE_ID: Record<string, string> = {
@@ -57,6 +62,11 @@ const CODE_TO_LINE_ID: Record<string, string> = {
 	SUF: "suffragette",
 	WEA: "weaver",
 	WIN: "windrush",
+	// Defensive: pair the legacy `OVG` code mapping above so a stale
+	// fixture / legacy backend response resolves to the same
+	// `london-overground` ID that `LINE_META_BY_ID` (adapt.ts) still
+	// carries for the rolled-up badge.
+	OVG: "london-overground",
 };
 
 function lineSummaryToLineStatus(line: LineSummary, now: Date): LineStatus {

--- a/web/lib/dashboard/adapt.ts
+++ b/web/lib/dashboard/adapt.ts
@@ -39,7 +39,17 @@ const LINE_META_BY_ID: Record<string, LineMeta> = {
 	victoria: { code: "VIC", color: "#039BE5" },
 	"waterloo-city": { code: "WAT", color: "#76D0BD" },
 	dlr: { code: "DLR", color: "#00AFAD" },
+	// Post-Nov-2024 Overground split. The legacy `london-overground`
+	// line_id is kept as a defensive entry: TfL still returns it from
+	// some endpoints (e.g. ad-hoc `/Disruption` payloads) and dropping
+	// it would force those rows down the unknown-fallback grey path.
 	"london-overground": { code: "OVG", color: "#EE7C0E" },
+	liberty: { code: "LIB", color: "#61686B" },
+	lioness: { code: "LIO", color: "#FAA61A" },
+	mildmay: { code: "MIL", color: "#0072BC" },
+	suffragette: { code: "SUF", color: "#25BD3B" },
+	weaver: { code: "WEA", color: "#9B0058" },
+	windrush: { code: "WIN", color: "#ED1B2D" },
 };
 
 const UNKNOWN_CODE_PREFIX = "UNK:";

--- a/web/lib/mocks/__tests__/fixtures.test.ts
+++ b/web/lib/mocks/__tests__/fixtures.test.ts
@@ -6,7 +6,7 @@ import { MOCK_LINES } from "@/lib/mocks/lines";
 
 describe("design-system mock fixtures", () => {
 	it("ships 19 line summaries with unique codes", () => {
-		// 13 tube + Elizabeth + DLR + 6 Overground (post-Nov-2024 split).
+		// 11 tube + Elizabeth + DLR + 6 Overground (post-Nov-2024 split).
 		expect(MOCK_LINES).toHaveLength(19);
 		const codes = new Set(MOCK_LINES.map((line) => line.code));
 		expect(codes.size).toBe(MOCK_LINES.length);

--- a/web/lib/mocks/__tests__/fixtures.test.ts
+++ b/web/lib/mocks/__tests__/fixtures.test.ts
@@ -5,8 +5,9 @@ import { MOCK_DISRUPTION } from "@/lib/mocks/disruptions";
 import { MOCK_LINES } from "@/lib/mocks/lines";
 
 describe("design-system mock fixtures", () => {
-	it("ships 14 line summaries with unique codes", () => {
-		expect(MOCK_LINES).toHaveLength(14);
+	it("ships 19 line summaries with unique codes", () => {
+		// 13 tube + Elizabeth + DLR + 6 Overground (post-Nov-2024 split).
+		expect(MOCK_LINES).toHaveLength(19);
 		const codes = new Set(MOCK_LINES.map((line) => line.code));
 		expect(codes.size).toBe(MOCK_LINES.length);
 	});

--- a/web/lib/mocks/lines.ts
+++ b/web/lib/mocks/lines.ts
@@ -120,9 +120,10 @@ export const MOCK_LINES: LineSummary[] = [
 	},
 	// Post-Nov-2024 Overground split: six named lines replacing the
 	// single "London Overground" badge. Colours follow TfL's 2024 brand
-	// reveal. Order mirrors the alphabetical-within-mode rule in
-	// `MODE_PRECEDENCE` (adapt.ts) so the fixture matches the order the
-	// adapter would produce from a real `/status/live` payload.
+	// reveal. Order matches the mode-precedence + alphabetical-within-
+	// mode sort applied by `lineStatusesToSummaries` (adapt.ts) so the
+	// fixture matches the order the adapter would produce from a real
+	// `/status/live` payload.
 	{
 		code: "LIB",
 		name: "Liberty",

--- a/web/lib/mocks/lines.ts
+++ b/web/lib/mocks/lines.ts
@@ -118,10 +118,55 @@ export const MOCK_LINES: LineSummary[] = [
 		statusText: "Good service",
 		updatedLabel: "updated 2m ago",
 	},
+	// Post-Nov-2024 Overground split: six named lines replacing the
+	// single "London Overground" badge. Colours follow TfL's 2024 brand
+	// reveal. Order mirrors the alphabetical-within-mode rule in
+	// `MODE_PRECEDENCE` (adapt.ts) so the fixture matches the order the
+	// adapter would produce from a real `/status/live` payload.
 	{
-		code: "OVG",
-		name: "London Overground",
-		color: "#EE7C0E",
+		code: "LIB",
+		name: "Liberty",
+		color: "#61686B",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "LIO",
+		name: "Lioness",
+		color: "#FAA61A",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "MIL",
+		name: "Mildmay",
+		color: "#0072BC",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "SUF",
+		name: "Suffragette",
+		color: "#25BD3B",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "WEA",
+		name: "Weaver",
+		color: "#9B0058",
+		status: "good",
+		statusText: "Good service",
+		updatedLabel: "updated 2m ago",
+	},
+	{
+		code: "WIN",
+		name: "Windrush",
+		color: "#ED1B2D",
 		status: "good",
 		statusText: "Good service",
 		updatedLabel: "updated 2m ago",

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -63,9 +63,15 @@
   .tfl-nav-status { display: none; }
 }
 
-/* ---------- Right column: Disruption (capped at 50%) above Chat
-   (consumes the rest). Status occupies the full-height left column on
-   its own, so the two columns are no longer height-coupled via subgrid. */
+/* ---------- Right column: LineDetail and Chat split the column 50/50
+   regardless of content size. An earlier `max-height: 50%` cap on the
+   LineDetail card let short disruption bodies collapse and the chat
+   absorbed the slack — which meant the chat resized every time the
+   user switched lines. Locking both children to `flex: 1 1 0` makes
+   the split content-independent: each child gets `(right-col height -
+   gap) / 2` and content that overflows scrolls inside the pane via
+   the invisible scrollbars declared on `.tfl-right-col > .tfl-card`
+   and `.tfl-chat-transcript`. */
 .tfl-right-col {
   display: flex;
   flex-direction: column;
@@ -74,26 +80,20 @@
   min-height: 0;
 }
 .tfl-right-col > .tfl-card {
-  /* LineDetail base rules — the 50% cap is scoped to the two-column
-     layout only (see media query below). At ≤880px the grid collapses
-     to one column so the right column is content-sized and a percentage
-     cap would resolve against an undefined parent height, clipping the
-     card unpredictably. */
+  flex: 1 1 0;
   min-height: 0;
   overflow: auto;
+  /* Invisible scrollbar — content is still scrollable, just chromeless,
+     mirroring the pattern used by `.tfl-news-list`. */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
-@media (min-width: 881px) {
-  .tfl-right-col > .tfl-card {
-    /* Upper-bound only — short disruption bodies still collapse to
-       content and Chat keeps the freed slack. */
-    max-height: 50%;
-  }
-}
+.tfl-right-col > .tfl-card::-webkit-scrollbar { display: none; }
 .tfl-right-col > .tfl-chat-stack {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  flex: 1 1 auto;
+  flex: 1 1 0;
   min-height: 0;
 }
 .tfl-right-col .tfl-chat-stack .tfl-chat-card { flex: 1 1 auto; min-height: 0; }
@@ -115,7 +115,12 @@
   min-height: 0;
   overflow-y: auto;
   display: flex; flex-direction: column; gap: 12px;
+  /* Invisible scrollbar — keeps the transcript scrollable when long
+     conversations spill past the 50/50 right-col allocation. */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
+.tfl-chat-transcript::-webkit-scrollbar { display: none; }
 .tfl-msg { display: flex; align-items: flex-start; gap: 10px; }
 .tfl-msg-user { justify-content: flex-end; }
 .tfl-msg-bot  { justify-content: flex-start; }
@@ -235,9 +240,25 @@
 .tfl-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  /* Row height = max of children's min-content. `.tfl-left-col` is not
+     scrollable so its min-content equals its full content height (line
+     list + header); `.tfl-right-col` is `min-height: 0` with a
+     scrollable LineDetail card and a collapsible chat stack, so its
+     min-content resolves much smaller. The row therefore tracks the
+     left column's natural height, leaving no blank space inside the
+     line list while the right column stretches into the same height
+     and splits 50/50 between LineDetail and the chat stack. */
+  grid-template-rows: min-content;
+  grid-auto-rows: min-content;
   gap: var(--space-4);
   align-items: stretch;
 }
+
+/* Positional hook mirroring `.tfl-right-col` so the two-column layout
+   reads symmetrically in markup. Visual styling stays on `.tfl-card`;
+   the row-sizing strategy on `.tfl-grid` above is what makes the left
+   column render at its natural content height. */
+.tfl-left-col { min-height: 0; }
 
 .tfl-news-band,
 .tfl-bus-band {
@@ -390,24 +411,10 @@
 .tfl-news-title {
   font-family: var(--font-body); font-size: var(--ui-sm); font-weight: 500;
   color: var(--ink-primary); margin-bottom: 2px;
-  /* Clamp matches `.tfl-news-body` — a multi-station TfL summary would
-     otherwise push `<li>` past `--tfl-news-row-h: 64px` and silently
-     break the 5-visible-rows guarantee. */
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
-  overflow: hidden;
 }
 .tfl-news-body {
   font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary);
   line-height: 1.45; white-space: pre-line;
-  /* Cap the body to a single visible line so every row settles on the
-     fixed min-height — the full text remains in the accessibility tree
-     and is restored if `-webkit-line-clamp` is unsupported. */
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
-  overflow: hidden;
 }
 
 @media (max-width: 880px) {

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -418,6 +418,14 @@
 }
 
 @media (max-width: 880px) {
-  .tfl-grid { grid-template-columns: 1fr; }
+  /* Stacked layout — drop the min-content row caps so each pane can
+     claim its natural height instead of collapsing to the smallest
+     min-content contribution (the right-column card scrolls internally
+     and would otherwise resolve near zero on mobile). */
+  .tfl-grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    grid-auto-rows: auto;
+  }
   .tfl-bus-row { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
## Summary
- Lock dashboard pane heights so switching the selected line no longer rebalances LineDetail vs Chat (flex: 1 1 0 instead of max-height: 50% + flex: 1 1 auto).
- Drop the 1-line clamp on the News pane so TfL summaries wrap; existing row-floor and 5-row scroll window keep the pane footprint predictable.
- Add Overground (post-Nov-2024 split) metadata to LINE_META_BY_ID so the real /status/live payload renders six named lines with their 2024 brand colours.
- Refresh the offline mock fixture to mirror the new payload shape (1 OVG row -> 6 named lines).

## Test plan
- [x] pnpm --dir web lint (Biome clean)
- [x] pnpm --dir web test (99/99 green)
- [ ] Visual check on local dev with NEXT_PUBLIC_USE_MOCKS=true (verified manually before opening this PR)
- [ ] Visual check against production /status/live once the backend is healthy again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for six new London Overground lines: Liberty, Lioness, Mildmay, Suffragette, Weaver, and Windrush.

* **Style**
  * Improved dashboard layout with better height distribution between content panels.
  * Fixed text display in news sections to show full content without truncation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->