### PR TITLE
feat(web): LineDetail polish + mobile overflow fixes (TM-32)

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,5 @@
 import { Analytics } from "@vercel/analytics/next";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Inter, JetBrains_Mono } from "next/font/google";
 import localFont from "next/font/local";
 
@@ -65,6 +65,12 @@ const SITE_URL = "https://tfl-monitor.humbertolomeu.com";
 const SITE_TITLE = "TfL Monitor — London transport at a glance";
 const SITE_DESCRIPTION =
 	"Real-time London transport status dashboard — Tube, Overground, DLR, Elizabeth line, buses, and disruptions.";
+
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+	viewportFit: "cover",
+};
 
 export const metadata: Metadata = {
 	metadataBase: new URL(SITE_URL),

--- a/web/components/dashboard/__tests__/line-detail.test.tsx
+++ b/web/components/dashboard/__tests__/line-detail.test.tsx
@@ -16,7 +16,7 @@ const DISRUPTION: DisruptionSnapshot = {
 	headline: "Severe delays westbound between Paddington and Reading",
 	body: ["A faulty train at Hayes & Harlington is causing severe delays."],
 	reportedAtLabel: "17:58 BST",
-	stations: [{ name: "Paddington", code: "PAD", note: "interchange" }],
+	stations: [{ name: "Paddington", code: "PAD" }],
 	sourceLabel: "Source: TfL Unified API",
 	updatedAtLabel: "18:42:14 BST",
 };
@@ -34,7 +34,10 @@ describe("LineDetail", () => {
 			),
 		).toBeInTheDocument();
 		expect(screen.getByText("Affected stations")).toBeInTheDocument();
-		expect(screen.getByText(/PAD · interchange/)).toBeInTheDocument();
+		// Resolved station name renders; the raw NaPTAN code is no longer
+		// surfaced — the user-facing name carries all the signal.
+		expect(screen.getByText("Paddington")).toBeInTheDocument();
+		expect(screen.queryByText("PAD")).not.toBeInTheDocument();
 	});
 
 	it("surfaces the humanised relative updated label in the header", () => {
@@ -77,7 +80,7 @@ describe("LineDetail", () => {
 		expect(screen.queryByText("Affected stations")).not.toBeInTheDocument();
 	});
 
-	it("renders a closure banner when closureText is non-empty", () => {
+	it("never renders the closure_text alert (collapsed in the redesign)", () => {
 		render(
 			<LineDetail
 				line={LINE}
@@ -88,19 +91,10 @@ describe("LineDetail", () => {
 			/>,
 		);
 
-		const banner = screen.getByRole("alert");
-		expect(banner).toHaveTextContent(
-			/No service between Paddington and Reading/,
-		);
-	});
-
-	it("does not render a closure banner when closureText is absent", () => {
-		render(<LineDetail line={LINE} disruption={DISRUPTION} />);
-
 		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 	});
 
-	it("renders an affected-lines list when affectedRoutes is populated", () => {
+	it("renders co-affected lines when affectedRoutes includes other lines", () => {
 		render(
 			<LineDetail
 				line={LINE}
@@ -111,20 +105,52 @@ describe("LineDetail", () => {
 			/>,
 		);
 
-		const list = screen.getByRole("list", { name: /affected lines/i });
+		const list = screen.getByRole("list", { name: /also affected/i });
 		const items = list.querySelectorAll("li");
 		expect(items).toHaveLength(2);
 	});
 
-	it("does not render the affected-lines block when affectedRoutes is absent", () => {
-		render(<LineDetail line={LINE} disruption={DISRUPTION} />);
+	it("filters the current line out of the co-affected list", () => {
+		render(
+			<LineDetail
+				line={LINE}
+				disruption={{
+					...DISRUPTION,
+					// `elizabeth` is the current line; only `piccadilly` should
+					// surface as a chip — the header already names Elizabeth.
+					affectedRoutes: ["elizabeth", "piccadilly"],
+				}}
+			/>,
+		);
+
+		const list = screen.getByRole("list", { name: /also affected/i });
+		const items = list.querySelectorAll("li");
+		expect(items).toHaveLength(1);
+		expect(items[0]).toHaveTextContent(/PIC/);
+	});
+
+	it("hides the block entirely when only the current line is affected", () => {
+		render(
+			<LineDetail
+				line={LINE}
+				disruption={{ ...DISRUPTION, affectedRoutes: ["elizabeth"] }}
+			/>,
+		);
 
 		expect(
-			screen.queryByRole("list", { name: /affected lines/i }),
+			screen.queryByRole("list", { name: /also affected/i }),
 		).not.toBeInTheDocument();
 	});
 
-	it("does not render the affected-lines block when affectedRoutes is an empty array", () => {
+	it("does not render the co-affected block when affectedRoutes is absent", () => {
+		render(<LineDetail line={LINE} disruption={DISRUPTION} />);
+
+		expect(
+			screen.queryByRole("list", { name: /also affected/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("does not render the co-affected block when affectedRoutes is an empty array", () => {
 		render(
 			<LineDetail
 				line={LINE}
@@ -133,7 +159,7 @@ describe("LineDetail", () => {
 		);
 
 		expect(
-			screen.queryByRole("list", { name: /affected lines/i }),
+			screen.queryByRole("list", { name: /also affected/i }),
 		).not.toBeInTheDocument();
 	});
 });

--- a/web/components/dashboard/__tests__/line-detail.test.tsx
+++ b/web/components/dashboard/__tests__/line-detail.test.tsx
@@ -150,6 +150,24 @@ describe("LineDetail", () => {
 		).not.toBeInTheDocument();
 	});
 
+	it("dedupes affectedRoutes before rendering chips", () => {
+		render(
+			<LineDetail
+				line={LINE}
+				disruption={{
+					...DISRUPTION,
+					// TfL occasionally repeats the same line in `affected_routes`;
+					// the chip row should render each one once.
+					affectedRoutes: ["piccadilly", "piccadilly", "victoria"],
+				}}
+			/>,
+		);
+
+		const list = screen.getByRole("list", { name: /also affected/i });
+		const items = list.querySelectorAll("li");
+		expect(items).toHaveLength(2);
+	});
+
 	it("does not render the co-affected block when affectedRoutes is an empty array", () => {
 		render(
 			<LineDetail

--- a/web/components/dashboard/line-detail.tsx
+++ b/web/components/dashboard/line-detail.tsx
@@ -64,7 +64,11 @@ export function LineDetail({
 							<h5>Affected stations</h5>
 							<ul aria-label="Affected stations">
 								{disruption.stations.map((station) => (
-									<li key={station.code}>{station.name}</li>
+									// `title` surfaces the full name on hover for
+									// truncated rows (e.g. "Heathrow Terminals 2 & 3").
+									<li key={station.code} title={station.name}>
+										{station.name}
+									</li>
 								))}
 							</ul>
 						</div>
@@ -99,7 +103,9 @@ function AffectedRoutesChips({
 }: AffectedRoutesChipsProps) {
 	if (!routes || routes.length === 0) return null;
 	const currentCodeUpper = currentLineCode.toUpperCase();
-	const otherRoutes = routes.filter(
+	// Dedupe before filtering so a TfL payload that lists the same line
+	// twice doesn't render duplicate chips with colliding React keys.
+	const otherRoutes = Array.from(new Set(routes)).filter(
 		(lineId) => getLineMeta(lineId).code.toUpperCase() !== currentCodeUpper,
 	);
 	if (otherRoutes.length === 0) return null;

--- a/web/components/dashboard/line-detail.tsx
+++ b/web/components/dashboard/line-detail.tsx
@@ -48,11 +48,6 @@ export function LineDetail({
 				</div>
 			) : disruption ? (
 				<>
-					{disruption.closureText && (
-						<div className="tfl-closure" role="alert">
-							{disruption.closureText}
-						</div>
-					)}
 					<div className="tfl-disruption">
 						<div className="summary">{disruption.headline}</div>
 						{disruption.body.map((paragraph, index) => (
@@ -60,42 +55,16 @@ export function LineDetail({
 							<p key={`${index}-${paragraph}`}>{paragraph}</p>
 						))}
 					</div>
-					{disruption.affectedRoutes &&
-						disruption.affectedRoutes.length > 0 && (
-							<div className="tfl-affected-routes">
-								<h5>Affected lines</h5>
-								<ul aria-label="Affected lines">
-									{disruption.affectedRoutes.map((lineId) => {
-										const meta = getLineMeta(lineId);
-										return (
-											<li
-												key={lineId}
-												className="tfl-route-chip"
-												style={{ borderColor: meta.color }}
-											>
-												<span
-													className="tfl-route-chip-stripe"
-													style={{ background: meta.color }}
-												/>
-												{meta.code}
-											</li>
-										);
-									})}
-								</ul>
-							</div>
-						)}
+					<AffectedRoutesChips
+						currentLineCode={line.code}
+						routes={disruption.affectedRoutes}
+					/>
 					{disruption.stations.length > 0 && (
 						<div className="tfl-stations">
 							<h5>Affected stations</h5>
-							<ul>
+							<ul aria-label="Affected stations">
 								{disruption.stations.map((station) => (
-									<li key={station.code}>
-										{station.name}{" "}
-										<span className="code">
-											{station.code}
-											{station.note ? ` · ${station.note}` : ""}
-										</span>
-									</li>
+									<li key={station.code}>{station.name}</li>
 								))}
 							</ul>
 						</div>
@@ -111,5 +80,50 @@ export function LineDetail({
 				</div>
 			)}
 		</section>
+	);
+}
+
+interface AffectedRoutesChipsProps {
+	currentLineCode: string;
+	routes: readonly string[] | undefined;
+}
+
+/**
+ * Renders co-affected lines as chips, excluding the current line. The
+ * header card already names the line, so a single self-chip is pure
+ * noise — collapse the whole block when no *other* lines are involved.
+ */
+function AffectedRoutesChips({
+	currentLineCode,
+	routes,
+}: AffectedRoutesChipsProps) {
+	if (!routes || routes.length === 0) return null;
+	const currentCodeUpper = currentLineCode.toUpperCase();
+	const otherRoutes = routes.filter(
+		(lineId) => getLineMeta(lineId).code.toUpperCase() !== currentCodeUpper,
+	);
+	if (otherRoutes.length === 0) return null;
+	return (
+		<div className="tfl-affected-routes">
+			<h5>Also affected</h5>
+			<ul aria-label="Also affected">
+				{otherRoutes.map((lineId) => {
+					const meta = getLineMeta(lineId);
+					return (
+						<li
+							key={lineId}
+							className="tfl-route-chip"
+							style={{ borderColor: meta.color }}
+						>
+							<span
+								className="tfl-route-chip-stripe"
+								style={{ background: meta.color }}
+							/>
+							{meta.code}
+						</li>
+					);
+				})}
+			</ul>
+		</div>
 	);
 }

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -458,7 +458,11 @@
    Scrollbar is hidden in both Firefox (`scrollbar-width: none`) and
    WebKit/Blink (`::-webkit-scrollbar`) — overflow is still functional,
    only chromeless. */
-.tfl-news { display: flex; flex-direction: column; --tfl-news-row-h: 64px; }
+/* Row-height bump from 64 → 80px accommodates the body's 2-line clamp
+   below (title 1 line + body 2 lines ≈ 60px text + 20px vertical
+   padding). Keeps the 5-row max cap (`5 × 80 = 400px`) the only
+   dimension the news pane reserves vertically. */
+.tfl-news { display: flex; flex-direction: column; --tfl-news-row-h: 80px; }
 .tfl-news-list {
   list-style: none; margin: 0; padding: 0;
   display: flex; flex-direction: column;
@@ -482,24 +486,35 @@
 .tfl-news-list li.is-empty { color: var(--ink-tertiary); }
 .tfl-news-placeholder { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
 .tfl-news-time { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
-/* Title + body clamp to a single line each so a long TfL summary cannot
-   overflow its row's `--tfl-news-row-h` cap and overlap the next row
-   on narrow viewports. `min-width: 0` + `overflow: hidden` are required
-   inside a grid cell for `text-overflow: ellipsis` to take effect. */
+/* The 2nd grid column wrapping title + body is an unclassed `<div>` in
+   `news-reports.tsx`. Grid items default to `min-width: auto`, which
+   lets a long word refuse to shrink and overflow the `minmax(0, 1fr)`
+   track on iOS Safari — pin it to 0 explicitly so the ellipsis/clamp
+   chain below actually engages. */
+.tfl-news-list li > div { min-width: 0; }
+
+/* Title clamps to one line and the body to two — preserves enough
+   context to read a disruption summary while still respecting the row's
+   `--tfl-news-row-h` cap. `min-width: 0` + `overflow: hidden` are
+   required for the clamp to actually engage inside the grid cell. */
 .tfl-news-title,
 .tfl-news-body {
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .tfl-news-title {
   font-family: var(--font-body); font-size: var(--ui-sm); font-weight: 500;
   color: var(--ink-primary); margin-bottom: 2px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .tfl-news-body {
   font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary);
   line-height: 1.45;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
 }
 
 @media (max-width: 880px) {

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -235,6 +235,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+  /* Hard guard against any grandchild's `min-content` blowing past the
+     viewport on narrow screens — keeps cards from extending beyond the
+     visible width and dragging the footer in to match. */
+  min-width: 0;
 }
 
 .tfl-grid {
@@ -273,6 +277,10 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Prevent any descendant's min-content (long line name + status
+     pill) from dragging the card past the grid column's width on
+     narrow viewports. */
+  min-width: 0;
 }
 .tfl-card-h {
   display: flex; align-items: center; justify-content: space-between;
@@ -300,14 +308,27 @@
 /* ---------- Line list ---------------------------------------------- */
 .tfl-line-list { display: flex; flex-direction: column; }
 .tfl-line {
-  display: grid; grid-template-columns: 4px 1fr auto;
+  display: grid; grid-template-columns: 4px minmax(0, 1fr) auto;
   align-items: center; gap: 12px;
   padding: 8px var(--space-4);
   border-bottom: 1px solid var(--border-default);
   cursor: pointer;
   transition: background var(--dur-fast);
+  min-width: 0;
 }
-.tfl-line-name-wrap { display: flex; align-items: baseline; gap: 10px; min-width: 0; }
+.tfl-line-name-wrap {
+  display: flex; align-items: baseline; gap: 10px;
+  min-width: 0;
+  overflow: hidden;
+}
+.tfl-line-name-wrap .tfl-line-name,
+.tfl-line-name-wrap .tfl-line-updated {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.tfl-line-status { white-space: nowrap; }
 .tfl-line:last-child { border-bottom: none; }
 .tfl-line:hover, .tfl-line.active { background: var(--canvas-elevated); }
 .tfl-line-stripe { width: 4px; height: 22px; border-radius: 2px; }
@@ -341,18 +362,6 @@
 .tfl-disruption { padding: var(--space-4) var(--space-5); }
 .tfl-disruption .summary { color: var(--danger); font-weight: 500; margin-bottom: var(--space-3); font-size: var(--ui-sm); }
 .tfl-disruption p { font-size: var(--ui-sm); color: var(--ink-secondary); line-height: 1.55; max-width: none; margin-bottom: var(--space-3); }
-
-.tfl-closure {
-  margin: 0 var(--space-5) var(--space-3);
-  padding: var(--space-3) var(--space-4);
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  color: var(--danger);
-  font-family: var(--font-body);
-  font-size: var(--ui-sm);
-  font-weight: 500;
-}
 
 .tfl-affected-routes {
   padding: var(--space-3) var(--space-5);
@@ -400,14 +409,25 @@
   border-top: 1px solid var(--border-default);
 }
 .tfl-stations h5 { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); margin: 0 0 var(--space-3); text-transform: uppercase; letter-spacing: 0.08em; font-weight: 500; }
-.tfl-stations ul { list-style: none; padding: 0; margin: 0; }
-.tfl-stations li {
-  display: flex; align-items: center; gap: 10px;
-  padding: 6px 0; font-family: var(--font-body); font-size: var(--ui-sm);
-  color: var(--ink-primary); border-bottom: 1px dashed var(--border-default);
+/* Two-column grid packs long station lists into less vertical space.
+   `auto-fill` + min(220px, 100%) lets each row collapse to one column
+   when the card is narrower than ~440px without a media query. */
+.tfl-stations ul {
+  list-style: none; padding: 0; margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(220px, 100%), 1fr));
+  column-gap: var(--space-4);
 }
-.tfl-stations li:last-child { border-bottom: none; }
-.tfl-stations li .code { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); margin-left: auto; }
+.tfl-stations li {
+  padding: 6px 0;
+  font-family: var(--font-body); font-size: var(--ui-sm);
+  color: var(--ink-primary);
+  border-bottom: 1px dashed var(--border-default);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 .tfl-detail-foot {
   padding: var(--space-3) var(--space-5);
@@ -449,25 +469,37 @@
 }
 .tfl-news-list::-webkit-scrollbar { display: none; }
 .tfl-news-list li {
-  display: grid; grid-template-columns: 52px 1fr;
+  display: grid; grid-template-columns: 52px minmax(0, 1fr);
   gap: 12px;
   padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border-default);
   align-items: flex-start;
   min-height: var(--tfl-news-row-h);
   box-sizing: border-box;
+  min-width: 0;
 }
 .tfl-news-list li:last-child { border-bottom: none; }
 .tfl-news-list li.is-empty { color: var(--ink-tertiary); }
 .tfl-news-placeholder { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
 .tfl-news-time { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
+/* Title + body clamp to a single line each so a long TfL summary cannot
+   overflow its row's `--tfl-news-row-h` cap and overlap the next row
+   on narrow viewports. `min-width: 0` + `overflow: hidden` are required
+   inside a grid cell for `text-overflow: ellipsis` to take effect. */
+.tfl-news-title,
+.tfl-news-body {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .tfl-news-title {
   font-family: var(--font-body); font-size: var(--ui-sm); font-weight: 500;
   color: var(--ink-primary); margin-bottom: 2px;
 }
 .tfl-news-body {
   font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary);
-  line-height: 1.45; white-space: pre-line;
+  line-height: 1.45;
 }
 
 @media (max-width: 880px) {
@@ -481,4 +513,21 @@
     grid-auto-rows: auto;
   }
   .tfl-bus-row { grid-template-columns: 1fr; }
+}
+
+/* Tighten outer shell padding on small viewports so cards have room to
+   breathe within the actual visible width — `var(--space-5)` on the
+   sides leaves ~327px of content on a 375px iPhone, which is enough for
+   most rows but cramps the right-aligned status pills. */
+@media (max-width: 480px) {
+  .tfl-shell {
+    padding: 5rem var(--space-3) var(--space-7);
+  }
+  /* Pack the line list tighter horizontally too — the stripe + name
+     wrap + status pill triplet has the narrowest of the dashboard's
+     min-content budgets. */
+  .tfl-line {
+    padding: 8px var(--space-3);
+    gap: 8px;
+  }
 }


### PR DESCRIPTION
## Summary

Image-driven follow-up after TM-29 shipped. Two clusters of fixes:

### LineDetail card (desktop + mobile)
- **Drop `closure_text` alert** — redundant with the status pill in the header. The card no longer renders a separate banner when TfL ships a `partClosure` / `serviceClosed` enum string.
- **Filter current line out of `affectedRoutes`** — a Piccadilly card listing 'Affected lines: Piccadilly' is pure noise. Block now reads 'Also affected' and renders only when *other* lines are co-impacted; collapses entirely when the filtered list is empty.
- **Drop NaPTAN code from station list** — the resolved `name` (e.g. 'Surrey Quays') carries all the user-facing signal; the `910G…` code was visual debt from before TM-29 wired the resolver.
- **2-column station grid** — `auto-fill, minmax(min(220px, 100%), 1fr)` packs long lists into less vertical space and falls back to one column under ~440px without a media query.

### Mobile overflow (iPhone Safari, <481px)
- **Viewport meta** — Next.js `Viewport` export with `width=device-width`, `initialScale: 1`, `viewportFit: cover`. Without this, mobile defaults caused the cards to render at desktop width and overflow the viewport.
- **Narrower shell padding** — `var(--space-5)` (24px) → `var(--space-3)` (12px) on the side padding under 481px so the right-aligned status pills stay inside the card edge.
- **Grid track guards** — `grid-template-columns` now uses `minmax(0, 1fr)` instead of bare `1fr` on `.tfl-line` and `.tfl-news-list li`. Bare `1fr` defaults to `minmax(auto, 1fr)`, which lets a long line name / news title push the row past the viewport.
- **Single-line clamp on news rows** — `overflow: hidden` + `text-overflow: ellipsis` + `white-space: nowrap` on `.tfl-news-title` and `.tfl-news-body` so a long Piccadilly summary no longer collides with the next row (root cause of the overlap bug in the iPhone screenshot).
- **min-width: 0** added to `.tfl-shell`, `.tfl-card`, `.tfl-news-list li` so any descendant's `min-content` cannot drag the parent past its grid track width.

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 105/105 (3 new co-affected-routes filter cases, closure_text alert removal, NaPTAN code removal from station assertion)
- [ ] Manual: iPhone Safari at 375px viewport — status pill stays within card edge, news rows clamp to one line each
- [ ] Manual: 1440px desktop — station list renders as 2 columns, 'Also affected' chips appear only when other lines are co-impacted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive layout to prevent cards and content from overflowing on various screen sizes.
  * Cleaned up station information display for better clarity.
  * Optimized text truncation and wrapping across components.
  * Enhanced affected routes visibility in disruption details.
  * Improved mobile device experience with small-viewport optimizations.

* **Tests**
  * Updated test cases for disruption and station display components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->