### PR TITLE
fix(web): news row gap + iOS first-paint width flash (TM-33)

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -16,9 +16,12 @@
 /* Kill any momentary horizontal scroll on iOS Safari's first paint —
    a single overflowing descendant (e.g. a long word in a news row
    before fonts settle) would otherwise widen the document past the
-   viewport, making the cards look "too wide" on initial load. */
-html,
-body {
+   viewport, making the cards look "too wide" on initial load. Setting
+   on `html` is enough; the `hidden` line is a fallback for iOS Safari
+   < 16 where `clip` is dropped as an unrecognised value. */
+html {
+	overflow-x: hidden;
+	/* biome-ignore lint/suspicious/noDuplicateProperties: intentional progressive-enhancement fallback — iOS Safari <16 ignores `clip` and falls back to `hidden`, modern engines use `clip`. */
 	overflow-x: clip;
 }
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -13,6 +13,15 @@
 		sans-serif;
 }
 
+/* Kill any momentary horizontal scroll on iOS Safari's first paint —
+   a single overflowing descendant (e.g. a long word in a news row
+   before fonts settle) would otherwise widen the document past the
+   viewport, making the cards look "too wide" on initial load. */
+html,
+body {
+	overflow-x: clip;
+}
+
 /* ---------- Sticky-footer shell -------------------------------------- */
 .hl-shell {
 	min-height: 100vh;

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -453,15 +453,12 @@
 .tfl-bus-text  { font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary); line-height: 1.4; }
 
 /* ---------- News & reports
-   The list is the fixed-height scroll surface: --tfl-news-row-h drives
-   both each row's `min-height` and the list's `max-height` cap (5 rows).
-   Scrollbar is hidden in both Firefox (`scrollbar-width: none`) and
-   WebKit/Blink (`::-webkit-scrollbar`) — overflow is still functional,
-   only chromeless. */
-/* Rows are content-sized — a single short title no longer claims a
-   forced 80px row, which was leaving a big empty gap below every row
-   in the screenshot. `--tfl-news-row-h` now only sizes the empty-state
-   placeholder so a cold-DB pane keeps its visual footprint. */
+   Rows are content-sized so a single short title no longer claims a
+   forced row height (which was leaving a big empty gap below every row).
+   `--tfl-news-row-h` now only sizes the empty-state placeholder so a
+   cold-DB pane keeps its visual footprint. The list caps at 22rem and
+   scrolls internally; scrollbar is hidden in both Firefox
+   (`scrollbar-width: none`) and WebKit/Blink (`::-webkit-scrollbar`). */
 .tfl-news { display: flex; flex-direction: column; --tfl-news-row-h: 56px; }
 .tfl-news-list {
   list-style: none; margin: 0; padding: 0;
@@ -484,9 +481,11 @@
   box-sizing: border-box;
   min-width: 0;
 }
-.tfl-news-list li.is-empty { min-height: var(--tfl-news-row-h); }
 .tfl-news-list li:last-child { border-bottom: none; }
-.tfl-news-list li.is-empty { color: var(--ink-tertiary); }
+.tfl-news-list li.is-empty {
+  color: var(--ink-tertiary);
+  min-height: var(--tfl-news-row-h);
+}
 .tfl-news-placeholder { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
 .tfl-news-time { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
 /* The 2nd grid column wrapping title + body is an unclassed `<div>` in
@@ -500,11 +499,10 @@
    readable without truncating mid-sentence. Rows are content-sized
    (no forced min-height on the `li`), so a short single-line title
    collapses cleanly against the next row instead of leaving a 60px
-   gap. `min-width: 0` is required for the clamp to engage inside the
-   grid cell. */
+   gap. The parent grid wrapper already carries `min-width: 0`, so
+   these block-level boxes inherit the shrinkable track. */
 .tfl-news-title,
 .tfl-news-body {
-  min-width: 0;
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -458,15 +458,18 @@
    Scrollbar is hidden in both Firefox (`scrollbar-width: none`) and
    WebKit/Blink (`::-webkit-scrollbar`) — overflow is still functional,
    only chromeless. */
-/* Row-height bump from 64 → 80px accommodates the body's 2-line clamp
-   below (title 1 line + body 2 lines ≈ 60px text + 20px vertical
-   padding). Keeps the 5-row max cap (`5 × 80 = 400px`) the only
-   dimension the news pane reserves vertically. */
-.tfl-news { display: flex; flex-direction: column; --tfl-news-row-h: 80px; }
+/* Rows are content-sized — a single short title no longer claims a
+   forced 80px row, which was leaving a big empty gap below every row
+   in the screenshot. `--tfl-news-row-h` now only sizes the empty-state
+   placeholder so a cold-DB pane keeps its visual footprint. */
+.tfl-news { display: flex; flex-direction: column; --tfl-news-row-h: 56px; }
 .tfl-news-list {
   list-style: none; margin: 0; padding: 0;
   display: flex; flex-direction: column;
-  max-height: calc(5 * var(--tfl-news-row-h));
+  /* Cap the scroll surface at roughly 5 average rows worth so the pane
+     never grows unbounded. Rows are content-sized so this is approximate;
+     a heavier mix of long titles + bodies will show fewer rows. */
+  max-height: 22rem;
   overflow-y: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -478,10 +481,10 @@
   padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border-default);
   align-items: flex-start;
-  min-height: var(--tfl-news-row-h);
   box-sizing: border-box;
   min-width: 0;
 }
+.tfl-news-list li.is-empty { min-height: var(--tfl-news-row-h); }
 .tfl-news-list li:last-child { border-bottom: none; }
 .tfl-news-list li.is-empty { color: var(--ink-tertiary); }
 .tfl-news-placeholder { font-family: var(--font-mono); font-size: var(--ui-xs); color: var(--ink-tertiary); padding-top: 2px; }
@@ -493,28 +496,30 @@
    chain below actually engages. */
 .tfl-news-list li > div { min-width: 0; }
 
-/* Title clamps to one line and the body to two — preserves enough
-   context to read a disruption summary while still respecting the row's
-   `--tfl-news-row-h` cap. `min-width: 0` + `overflow: hidden` are
-   required for the clamp to actually engage inside the grid cell. */
+/* Title + body each clamp to 2 lines so a long TfL summary stays
+   readable without truncating mid-sentence. Rows are content-sized
+   (no forced min-height on the `li`), so a short single-line title
+   collapses cleanly against the next row instead of leaving a 60px
+   gap. `min-width: 0` is required for the clamp to engage inside the
+   grid cell. */
 .tfl-news-title,
 .tfl-news-body {
   min-width: 0;
   overflow: hidden;
-}
-.tfl-news-title {
-  font-family: var(--font-body); font-size: var(--ui-sm); font-weight: 500;
-  color: var(--ink-primary); margin-bottom: 2px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.tfl-news-body {
-  font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary);
-  line-height: 1.45;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   line-clamp: 2;
+  overflow-wrap: anywhere;
+}
+.tfl-news-title {
+  font-family: var(--font-body); font-size: var(--ui-sm); font-weight: 500;
+  color: var(--ink-primary); margin-bottom: 2px;
+  line-height: 1.35;
+}
+.tfl-news-body {
+  font-family: var(--font-body); font-size: var(--ui-sm); color: var(--ink-secondary);
+  line-height: 1.45;
 }
 
 @media (max-width: 880px) {


### PR DESCRIPTION
## Summary

Two image-driven follow-ups after PR #110 shipped:

- **News rows**: the forced `min-height: var(--tfl-news-row-h)` (bumped to 80px in #110) was leaving a ~60px empty band below every short-title-no-body row (visible in the user's screenshot — long WINDRUSH title at top, big gap, next row). Rows are now content-sized; `--tfl-news-row-h` cut to 56px and only sizes the empty-state placeholder. List max-height switched from `5 * row-h` to a flat `22rem` cap so the pane never grows unbounded even with variable row heights.
- **News text**: title switched from 1-line ellipsis (`white-space: nowrap`) to a 2-line `-webkit-line-clamp` matching the body. Title `line-height` tightened to 1.35 so two lines stack without crowding the body. Both use `overflow-wrap: anywhere` so a long URL or station name cannot push the row past the `minmax(0, 1fr)` track.
- **iOS first-paint width flash**: `html, body { overflow-x: clip }` in globals.css. iPhone Safari was briefly widening the document past viewport on initial paint (a single overflowing descendant before fonts settled), making cards look 'too wide' for a frame. `clip` kills horizontal scroll on every device without affecting in-card scroll surfaces.

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 106/106 (CSS-only, no test changes)
- [ ] Manual: iPhone Safari first load — no width flash
- [ ] Manual: 1440px desktop news pane — no big gaps between short rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed horizontal overflow on iOS Safari during initial paint for more stable early rendering.

* **Style**
  * Improved TFL monitor news list: consistent multi-line clamping for titles and bodies, better line-breaking, and cleaner overflow handling.
  * Adjusted news item sizing and reserved spacing to produce a tidier, more predictable list layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->