### PR TITLE
fix(dbt): resolve lines/stations sources to ref schema

### DIFF
--- a/contracts/dbt_sources.yml
+++ b/contracts/dbt_sources.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: tfl
-    description: "Raw Kafka-backed event streams and static reference tables for the TfL warehouse."
+    description: "Raw Kafka-backed event streams for the TfL warehouse."
     database: "{{ env_var('POSTGRES_DB', 'tflmonitor') }}"
     schema: raw
     tables:
@@ -69,9 +69,16 @@ sources:
             tests:
               - not_null
 
+  # Static reference tables live in the `ref` schema, not `raw`. dbt only
+  # honours `schema` at the source level (not per-table), so these need
+  # their own source block rather than a per-table override under `tfl`.
+  - name: tfl_ref
+    description: "Static reference tables (lines, stations) loaded into the ref schema by CSV seeds / batch jobs."
+    database: "{{ env_var('POSTGRES_DB', 'tflmonitor') }}"
+    schema: ref
+    tables:
       - name: lines
         description: "Canonical list of TfL lines with display metadata."
-        schema: ref
         columns:
           - name: line_id
             tests:
@@ -86,7 +93,6 @@ sources:
 
       - name: stations
         description: "Canonical list of TfL stop points with coordinates."
-        schema: ref
         columns:
           - name: station_id
             tests:

--- a/contracts/dbt_sources.yml
+++ b/contracts/dbt_sources.yml
@@ -73,7 +73,7 @@ sources:
   # honours `schema` at the source level (not per-table), so these need
   # their own source block rather than a per-table override under `tfl`.
   - name: tfl_ref
-    description: "Static reference tables (lines, stations) loaded into the ref schema by CSV seeds / batch jobs."
+    description: "External static reference tables (lines, stations) populated in the ref schema by the static-ingest batch job (TM-A2)."
     database: "{{ env_var('POSTGRES_DB', 'tflmonitor') }}"
     schema: ref
     tables:

--- a/dbt/models/marts/mart_bus_metrics_daily.sql
+++ b/dbt/models/marts/mart_bus_metrics_daily.sql
@@ -12,7 +12,7 @@
 
 with bus_lines as (
     select line_id
-    from {{ source('tfl', 'lines') }}
+    from {{ source('tfl_ref', 'lines') }}
     where mode = 'bus'
 ),
 

--- a/dbt/sources/tfl.yml
+++ b/dbt/sources/tfl.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: tfl
-    description: "Raw Kafka-backed event streams and static reference tables for the TfL warehouse."
+    description: "Raw Kafka-backed event streams for the TfL warehouse."
     database: "{{ env_var('POSTGRES_DB', 'tflmonitor') }}"
     schema: raw
     tables:
@@ -69,9 +69,16 @@ sources:
             tests:
               - not_null
 
+  # Static reference tables live in the `ref` schema, not `raw`. dbt only
+  # honours `schema` at the source level (not per-table), so these need
+  # their own source block rather than a per-table override under `tfl`.
+  - name: tfl_ref
+    description: "Static reference tables (lines, stations) loaded into the ref schema by CSV seeds / batch jobs."
+    database: "{{ env_var('POSTGRES_DB', 'tflmonitor') }}"
+    schema: ref
+    tables:
       - name: lines
         description: "Canonical list of TfL lines with display metadata."
-        schema: ref
         columns:
           - name: line_id
             tests:
@@ -86,7 +93,6 @@ sources:
 
       - name: stations
         description: "Canonical list of TfL stop points with coordinates."
-        schema: ref
         columns:
           - name: station_id
             tests:

--- a/dbt/sources/tfl.yml
+++ b/dbt/sources/tfl.yml
@@ -73,7 +73,7 @@ sources:
   # honours `schema` at the source level (not per-table), so these need
   # their own source block rather than a per-table override under `tfl`.
   - name: tfl_ref
-    description: "Static reference tables (lines, stations) loaded into the ref schema by CSV seeds / batch jobs."
+    description: "External static reference tables (lines, stations) populated in the ref schema by the static-ingest batch job (TM-A2)."
     database: "{{ env_var('POSTGRES_DB', 'tflmonitor') }}"
     schema: ref
     tables:


### PR DESCRIPTION
## Problem
Every production `dbt build` (host cron, every 15 min) failed with 7 errors and 6 skips:

```
relation "raw.lines" does not exist
relation "raw.stations" does not exist
```

## Root cause
The `lines` and `stations` tables were declared under the `tfl` source (schema `raw`) with a per-table `schema: ref` override. dbt only honours `schema` at the **source** level, not per-table (confirmed against dbt docs), so the override was silently ignored and both tables resolved to `raw.lines` / `raw.stations`. Those relations do not exist — the reference data lives in the `ref` schema (`ref.lines`, `ref.stations`). The result: 3 source tests on each table failed, plus `mart_bus_metrics_daily` (which reads `source('tfl','lines')`), with downstream models skipped.

This was unrelated to the `.dockerignore` change in #112 — that was a separate (valid) build-hygiene fix.

## Fix
- Move `lines` / `stations` into a dedicated `tfl_ref` source with source-level `schema: ref`.
- Point `mart_bus_metrics_daily` at `source('tfl_ref', 'lines')`.

## Note on data
`ref.lines` / `ref.stations` are currently empty in prod (static-ingest is TM-A2 follow-up). The source tests pass on empty tables and the bus mart returns zero rows by design (see the mart's header comment), so `dbt build` goes green now; real KPIs appear once the ref tables are populated.

## Test plan
- [x] `uv run task dbt-parse` — parses, `tfl_ref` resolves
- [x] `uv run task lint` — clean
- [ ] CI green
- [ ] Post-deploy: `docker exec tfl-monitor-api-1 dbt build --project-dir /app/dbt --target prod` → 0 errors, no `raw.stations`/`raw.lines`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized data source structure to better manage reference tables and improve data model organization.

* **Documentation**
  * Updated source configuration descriptions to reflect new data source structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->