### PR TITLE
fix(api): set DBT_PROFILES_DIR so docker-exec dbt finds its profile

### DIFF
--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -35,6 +35,13 @@ COPY --chown=app:app dbt ./dbt
 
 ENV PYTHONPATH=/app/src
 
+# dbt is invoked at runtime via `docker exec` from the host cron, which runs in
+# WORKDIR /app (not the dbt project dir) and as the `app` user, which has no
+# home (--no-create-home above). dbt's default profiles lookup at ~/.dbt then
+# resolves to a non-existent /home/app/.dbt and fails. Point it at the project
+# dir where profiles.yml is copied so every dbt invocation finds its profile.
+ENV DBT_PROFILES_DIR=/app/dbt
+
 USER app
 
 EXPOSE 8000


### PR DESCRIPTION
## Problem
The scheduled dbt cron (`*/15`, via `scripts/cron-dbt-run.sh` → `docker exec tfl-monitor-api-1 dbt build`) fails at startup-fresh containers with:

```
Error: Invalid value for '--profiles-dir': Path '/home/app/.dbt' does not exist.
```

## Root cause
The `app` user is created with `--no-create-home`, so `/home/app` does not exist. `docker exec` runs in `WORKDIR /app` (not the dbt project dir), and the cron does not pass `--profiles-dir`. dbt therefore falls back to its default `~/.dbt` → `/home/app/.dbt`, which is absent. `profiles.yml` actually ships at `/app/dbt/profiles.yml` (the project dir).

This is a latent pre-existing bug — it surfaced only when the latest deploy recreated the container from the current Dockerfile (the previously-running container predated `--no-create-home`).

## Fix
`ENV DBT_PROFILES_DIR=/app/dbt` so every dbt invocation (cron dbt build, manual, future rag jobs) resolves profiles without per-call-site flags.

## Verification
Confirmed in prod that with the profile resolved, `dbt build` is fully green after the #113 source fix:
```
Done. PASS=119 WARN=0 ERROR=0 SKIP=0 NO-OP=5 TOTAL=124
```
(was PASS=107 ERROR=7 SKIP=6 before #113).

## Test plan
- [ ] CI green
- [ ] Post-deploy: `bash /opt/tfl-monitor/scripts/cron-dbt-run.sh` (no `--profiles-dir`) → PASS, 0 errors