### PR TITLE
fix(agent): stop tool-result JSON leaking into chat tokens

### DIFF
--- a/src/api/agent/streaming.py
+++ b/src/api/agent/streaming.py
@@ -35,6 +35,13 @@ def project(mode: str, payload: Any) -> list[dict[str, str]]:
         if not isinstance(payload, tuple) or len(payload) < 1:
             return []
         chunk = payload[0]
+        # Only the assistant's own tokens become text frames. The
+        # "messages" stream also replays ToolMessage chunks (the raw tool
+        # result, e.g. the query_tube_status JSON) — those must never leak
+        # into the chat bubble. The tool call itself is surfaced via the
+        # "updates" tool frame instead.
+        if getattr(chunk, "type", None) != "ai":
+            return []
         text = _extract_text(getattr(chunk, "content", None))
         f = frame_token(text)
         return [f] if f is not None else []

--- a/tests/api/test_chat_stream.py
+++ b/tests/api/test_chat_stream.py
@@ -49,8 +49,17 @@ class FakeAgent:
 
 
 def _token_chunk(text: str) -> tuple[str, tuple[Any, dict[str, Any]]]:
-    """Build a ``messages``-mode payload yielding a token frame."""
-    return ("messages", (SimpleNamespace(content=text), {}))
+    """Build a ``messages``-mode payload yielding a token frame.
+
+    ``type="ai"`` marks it as an assistant chunk; only those become
+    token frames (tool-result chunks are skipped).
+    """
+    return ("messages", (SimpleNamespace(content=text, type="ai"), {}))
+
+
+def _tool_message_chunk(content: str) -> tuple[str, tuple[Any, dict[str, Any]]]:
+    """Build a ``messages``-mode ToolMessage chunk (raw tool result)."""
+    return ("messages", (SimpleNamespace(content=content, type="tool"), {}))
 
 
 def _tool_event(tool_name: str) -> tuple[str, dict[str, Any]]:
@@ -147,6 +156,39 @@ def test_chat_stream_emits_tool_frame(
     # Only token content lands in the persisted assistant turn.
     assistant_insert = pool.conn.executed[1]
     assert assistant_insert[1]["content"] == "Looking up the data..."
+
+
+def test_chat_stream_skips_tool_message_content(
+    fake_pool_factory: Callable[..., Any],
+    attach_pool: Callable[[Any], None],
+    attach_agent: Callable[[Any], None],
+) -> None:
+    """ToolMessage chunks (raw tool-result JSON) must not leak as tokens."""
+    pool = fake_pool_factory([], [])
+    attach_pool(pool)
+    agent = FakeAgent(
+        frames=[
+            _tool_message_chunk('[{"line_id": "piccadilly", "status": "Severe Delays"}]'),
+            _token_chunk("Piccadilly has severe delays."),
+        ]
+    )
+    attach_agent(agent)
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/chat/stream",
+        json={"thread_id": "t-toolmsg", "message": "delays?"},
+    )
+
+    assert response.status_code == 200
+    frames = _parse_sse(response.text)
+    # The tool-result JSON is absent; only the assistant token + end remain.
+    assert frames == [
+        {"type": "token", "content": "Piccadilly has severe delays."},
+        {"type": "end", "content": ""},
+    ]
+    assistant_insert = pool.conn.executed[1]
+    assert assistant_insert[1]["content"] == "Piccadilly has severe delays."
 
 
 def test_chat_stream_503_when_agent_missing(


### PR DESCRIPTION
## Summary

Live browser verification of the now-working agent surfaced a UI bug: the **raw tool-result JSON** (e.g. the full `query_tube_status` array) rendered in the chat bubble **before** the assistant's answer.

Root cause: LangGraph's `messages` stream replays **ToolMessage** chunks (whose content is the raw tool result), and `streaming.project()` was turning every chunk's `content` into a `token` frame. Fix: only project chunks of `type == "ai"` (the assistant's own tokens) into token frames. The tool invocation is still surfaced via the `updates` → `tool` frame, so the "Using tool: …" status is unaffected.

Not caught earlier because the agent had never run in prod (was 503 on missing Bedrock model access), and the streaming unit-test fakes didn't replay a ToolMessage chunk.

## Test plan
- [x] New regression test `test_chat_stream_skips_tool_message_content` — a `type="tool"` chunk yields no token frame; the `type="ai"` token + `end` remain.
- [x] `make check` green (backend 335 passed, web 110 passed, ruff + mypy strict clean).
- [ ] Post-merge: re-verify in browser that the chat bubble shows only the prose answer.