### PR TITLE
contract: journey planning + arrivals tools + tier-1 DTOs (TM-30)

### DIFF
--- a/.claude/adrs/009-tfl-journey-arrivals-contracts.md
+++ b/.claude/adrs/009-tfl-journey-arrivals-contracts.md
@@ -1,0 +1,54 @@
+# 009 — Tier-1 contracts for TfL journey planning and stop search
+
+Status: accepted
+Date: 2026-05-27
+
+## Context
+
+TM-30 (PR-C) adds two LangGraph agent tools — `plan_journey_tool` and
+`get_arrivals_tool` — backed by two new `TflClient` methods that call TfL
+endpoints the ingestion layer did not previously touch:
+
+- `/Journey/JourneyResults/{from}/to/{to}` — multi-leg route planning.
+- `/StopPoint/Search/{query}` — free-text name → StopPoint/NaPTAN id,
+  used by the forward resolver `stations.resolve_name`.
+
+The house rule is that every method on `TflClient` returns a parsed
+tier-1 Pydantic model, never raw JSON (see `contracts/schemas/tfl_api.py`).
+Both new endpoints return shapes with no existing model, so new tier-1
+contracts are required. `AGENTS.md` requires any change under
+`contracts/` to be formalised in an ADR — hence this record.
+
+## Decision
+
+Append six additive tier-1 models to `contracts/schemas/tfl_api.py`, all
+reusing `_tfl_model_config()` (`alias_generator=to_camel`,
+`populate_by_name=True`, `extra="ignore"`, `frozen=True`):
+
+- `TflJourneyMode { name }` and `TflJourneyInstruction { summary }` —
+  modelled as explicit sub-models because `to_camel` aliasing does not
+  reach into nested objects.
+- `TflJourneyLeg { duration, mode, instruction, departure_time?,
+  arrival_time? }`.
+- `TflJourneyResult { start_date_time, arrival_date_time, duration,
+  legs[] }` — one entry of the response `journeys[]` array.
+- `TflStopSearchMatch { id, name, modes[] }` and
+  `TflStopSearchResponse { matches[] }`; `id` is the StopPoint/NaPTAN.
+
+These are **tier-1 ingestion DTOs** (raw TfL wire shapes), not the tier-2
+Kafka event schemas and not the public OpenAPI surface. No
+`contracts/openapi.yaml`, `contracts/sql/`, or `contracts/dbt_sources.yml`
+file is touched, so the CI source-mirror diff gate is unaffected and no
+`web/lib/types.ts` regeneration is needed.
+
+## Consequences
+
+- **Additive only.** No existing model changes; nothing downstream breaks.
+  `extra="ignore"` discards the ~20 noise fields TfL ships per record.
+- **No public API change.** Journey and arrivals are agent-internal tools,
+  not new REST endpoints — there is no OpenAPI drift and no frontend type
+  change. Rich `<JourneyCard>` rendering (which would add a structured SSE
+  frame to the public surface) is deliberately deferred to a follow-up WP.
+- **Future journey consumers** (e.g. a journey SSE frame, or a REST
+  `/journey` endpoint) must reuse this envelope or revisit this ADR if a
+  second shape variant is needed.

--- a/contracts/schemas/tfl_api.py
+++ b/contracts/schemas/tfl_api.py
@@ -111,3 +111,64 @@ class TflArrivalPrediction(BaseModel):
     time_to_station: int = Field(ge=0)
     vehicle_id: str | None = None
     mode_name: str
+
+
+class TflJourneyMode(BaseModel):
+    """Transport mode nested inside a journey leg (``leg.mode``)."""
+
+    model_config = _tfl_model_config()
+
+    name: str
+
+
+class TflJourneyInstruction(BaseModel):
+    """Human-readable instruction nested inside a journey leg."""
+
+    model_config = _tfl_model_config()
+
+    summary: str
+
+
+class TflJourneyLeg(BaseModel):
+    """Single leg of a planned journey returned by ``/Journey/JourneyResults``."""
+
+    model_config = _tfl_model_config()
+
+    duration: int
+    mode: TflJourneyMode
+    instruction: TflJourneyInstruction
+    departure_time: datetime | None = None
+    arrival_time: datetime | None = None
+
+
+class TflJourneyResult(BaseModel):
+    """One journey option from ``/Journey/JourneyResults`` ``journeys[]``."""
+
+    model_config = _tfl_model_config()
+
+    start_date_time: datetime
+    arrival_date_time: datetime
+    duration: int
+    legs: list[TflJourneyLeg] = Field(default_factory=list)
+
+
+class TflStopSearchMatch(BaseModel):
+    """Single match from ``/StopPoint/Search/{query}`` ``matches[]``.
+
+    ``id`` is the StopPoint/NaPTAN code used as an endpoint for journey
+    planning and arrival queries.
+    """
+
+    model_config = _tfl_model_config()
+
+    id: str
+    name: str
+    modes: list[str] = Field(default_factory=list)
+
+
+class TflStopSearchResponse(BaseModel):
+    """Top-level response from ``/StopPoint/Search/{query}``."""
+
+    model_config = _tfl_model_config()
+
+    matches: list[TflStopSearchMatch] = Field(default_factory=list)

--- a/src/api/agent/graph.py
+++ b/src/api/agent/graph.py
@@ -23,13 +23,16 @@ the SQL tools.
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import logfire
 from psycopg_pool import AsyncConnectionPool
 from pydantic import SecretStr
 
 from api.agent.prompts import render
+
+if TYPE_CHECKING:
+    from ingestion.tfl_client.client import TflClient
 
 DEFAULT_ANTHROPIC_MODEL = "claude-3-5-sonnet-latest"
 DEFAULT_BEDROCK_SONNET_MODEL = "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -95,12 +98,15 @@ def _build_retriever_or_none() -> Any | None:
 def compile_agent(
     *,
     pool: AsyncConnectionPool,
+    tfl_client: TflClient | None = None,
     model: Any | None = None,
 ) -> Any | None:
     """Build the agent or return ``None`` when no LLM backend is set.
 
     Args:
         pool: Shared ``AsyncConnectionPool`` reused by every SQL tool.
+        tfl_client: Optional ``TflClient`` powering the journey/arrivals
+            tools. When ``None`` those tools are omitted.
         model: Optional pre-built chat model. Tests inject a fake here
             so they never hit a live LLM provider.
 
@@ -118,7 +124,7 @@ def compile_agent(
     from api.agent.tools import make_tools  # noqa: PLC0415
 
     retriever = _build_retriever_or_none()
-    tools = make_tools(pool=pool, retriever=retriever)
+    tools = make_tools(pool=pool, tfl_client=tfl_client, retriever=retriever)
     return create_react_agent(
         model=chat_model,
         tools=tools,

--- a/src/api/agent/prompts.py
+++ b/src/api/agent/prompts.py
@@ -14,6 +14,10 @@ Tools:
 - query_bus_punctuality: per-bus-stop punctuality. Note: this is a
   proxy on prediction freshness, not a ground-truth on-time KPI;
   cite that caveat when you use it.
+- plan_journey_tool: plan a route between two stations (names or
+  NaPTAN). Use when the user asks how to get from A to B.
+- get_arrivals_tool: next arrivals at a stop (name or NaPTAN), grouped
+  by platform. Use for "when's the next train/bus at X".
 - search_tfl_docs: passages from TfL strategy docs (Business Plan,
   Mayor's Transport Strategy, Annual Report). Use for policy or
   forecast questions; cite by doc_title + page_start.

--- a/src/api/agent/tools.py
+++ b/src/api/agent/tools.py
@@ -14,6 +14,7 @@ smuggle unknown fields past the type system.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 import logfire
@@ -30,10 +31,15 @@ from api.db import (
     fetch_reliability,
 )
 from api.schemas import Mode
+from api.stations import resolve_name
 
 if TYPE_CHECKING:
     from langchain_core.tools import BaseTool
     from llama_index.core import VectorStoreIndex
+
+    from ingestion.tfl_client.client import TflClient
+
+_MAX_ARRIVALS_PER_PLATFORM = 5
 
 
 class LineReliabilityQuery(BaseModel):
@@ -82,23 +88,55 @@ class TflDocSearchQuery(BaseModel):
     top_k: int = Field(default=5, ge=1, le=20)
 
 
+class PlanJourneyQuery(BaseModel):
+    """Input schema for ``plan_journey_tool``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    origin: str = Field(min_length=1, max_length=128)
+    destination: str = Field(min_length=1, max_length=128)
+    departure_time: str | None = None
+
+
+class GetArrivalsQuery(BaseModel):
+    """Input schema for ``get_arrivals_tool``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    stop: str = Field(min_length=1, max_length=128)
+
+
+def _parse_departure_time(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 departure time, returning ``None`` on bad input."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
 def make_tools(
     *,
     pool: AsyncConnectionPool,
+    tfl_client: TflClient | None = None,
     retriever: VectorStoreIndex | None = None,
 ) -> list[BaseTool]:
-    """Build the LangGraph tools bound to a pool (+ optional retriever).
+    """Build the LangGraph tools bound to a pool (+ optional dependencies).
 
     Args:
         pool: Shared ``AsyncConnectionPool`` (TM-D2/D3 fetchers reuse it).
+        tfl_client: Optional ``TflClient``. When ``None`` the journey and
+            arrivals tools are omitted, since both call the live TfL API.
         retriever: pgvector index from ``build_retriever``. When ``None``
-            the RAG tool is omitted and only the four SQL tools are
-            exposed, so the agent still serves live operational data.
+            the RAG tool is omitted and only the SQL tools are exposed, so
+            the agent still serves live operational data.
 
     Returns:
         List of LangChain ``BaseTool`` instances ready for
-        ``create_react_agent`` — four SQL tools, plus ``search_tfl_docs``
-        when a retriever is supplied.
+        ``create_react_agent``: four SQL tools, plus the journey/arrivals
+        tools when a ``TflClient`` is supplied and ``search_tfl_docs`` when
+        a retriever is supplied.
     """
     from langchain_core.tools import tool  # noqa: PLC0415
 
@@ -161,34 +199,121 @@ def make_tools(
                 return f"No punctuality data for stop {stop_id!r}."
             return result.model_dump(mode="json")
 
-    sql_tools: list[BaseTool] = [
+    tools: list[BaseTool] = [
         query_tube_status,
         query_line_reliability,
         query_recent_disruptions,
         query_bus_punctuality,
     ]
-    if retriever is None:
-        return sql_tools
 
-    @tool(args_schema=TflDocSearchQuery)
-    async def search_tfl_docs(
-        query: str,
-        doc_id: DocId | None = None,
-        top_k: int = 5,
-    ) -> list[dict[str, Any]]:
-        """Return passages from TfL strategy docs ranked by relevance.
+    if tfl_client is not None:
 
-        Cite each hit by ``doc_title`` and ``page_start``. Use this tool
-        for policy or forecast questions; reach for the SQL tools for
-        live operational data.
-        """
-        with logfire.span(
-            "agent.tool.search_tfl_docs",
-            doc_id=doc_id,
-            top_k=top_k,
-            query_chars=len(query),
-        ):
-            snippets = await retrieve(retriever, query=query, doc_id=doc_id, top_k=top_k)
-            return [s.model_dump(mode="json") for s in snippets]
+        @tool(args_schema=PlanJourneyQuery)
+        async def plan_journey_tool(
+            origin: str,
+            destination: str,
+            departure_time: str | None = None,
+        ) -> dict[str, Any] | str:
+            """Plan a route between two stations (names or NaPTAN codes).
 
-    return [*sql_tools, search_tfl_docs]
+            Use when the user asks how to get from A to B. ``departure_time``
+            is an optional ISO-8601 timestamp; omit it for "leave now".
+            Returns the best option's total duration and per-leg breakdown.
+            """
+            with logfire.span(
+                "agent.tool.plan_journey_tool",
+                origin=origin,
+                destination=destination,
+            ):
+                origin_id = await resolve_name(tfl_client=tfl_client, query=origin)
+                if origin_id is None:
+                    return f"Couldn't find station '{origin}'."
+                destination_id = await resolve_name(tfl_client=tfl_client, query=destination)
+                if destination_id is None:
+                    return f"Couldn't find station '{destination}'."
+                journeys = await tfl_client.plan_journey(
+                    origin_id,
+                    destination_id,
+                    departure_time=_parse_departure_time(departure_time),
+                )
+                if not journeys:
+                    return f"No journeys found from '{origin}' to '{destination}'."
+                best = journeys[0]
+                return {
+                    "total_minutes": best.duration,
+                    "start": best.start_date_time.isoformat(),
+                    "arrival": best.arrival_date_time.isoformat(),
+                    "legs": [
+                        {
+                            "mode": leg.mode.name,
+                            "summary": leg.instruction.summary,
+                            "minutes": leg.duration,
+                        }
+                        for leg in best.legs
+                    ],
+                }
+
+        @tool(args_schema=GetArrivalsQuery)
+        async def get_arrivals_tool(stop: str) -> dict[str, Any] | str:
+            """Return next arrivals at a stop, grouped by platform.
+
+            Use for "when's the next train/bus at X". ``stop`` is a station
+            name or NaPTAN code. Each platform lists up to five upcoming
+            vehicles ordered by time to arrival.
+            """
+            with logfire.span("agent.tool.get_arrivals_tool", stop=stop):
+                stop_id = await resolve_name(tfl_client=tfl_client, query=stop)
+                if stop_id is None:
+                    return f"Couldn't find stop '{stop}'."
+                predictions = await tfl_client.fetch_arrivals(stop_id)
+                if not predictions:
+                    return f"No arrivals found for '{stop}'."
+                grouped: dict[str, list[Any]] = {}
+                for prediction in predictions:
+                    grouped.setdefault(prediction.platform_name, []).append(prediction)
+                platforms = [
+                    {
+                        "platform": platform,
+                        "arrivals": [
+                            {
+                                "line": p.line_name,
+                                "destination": p.destination_name,
+                                "seconds": p.time_to_station,
+                            }
+                            for p in sorted(preds, key=lambda p: p.time_to_station)[
+                                :_MAX_ARRIVALS_PER_PLATFORM
+                            ]
+                        ],
+                    }
+                    for platform, preds in sorted(grouped.items())
+                ]
+                return {"station": predictions[0].station_name, "platforms": platforms}
+
+        tools.extend([plan_journey_tool, get_arrivals_tool])
+
+    if retriever is not None:
+
+        @tool(args_schema=TflDocSearchQuery)
+        async def search_tfl_docs(
+            query: str,
+            doc_id: DocId | None = None,
+            top_k: int = 5,
+        ) -> list[dict[str, Any]]:
+            """Return passages from TfL strategy docs ranked by relevance.
+
+            Cite each hit by ``doc_title`` and ``page_start``. Use this tool
+            for policy or forecast questions; reach for the SQL tools for
+            live operational data.
+            """
+            with logfire.span(
+                "agent.tool.search_tfl_docs",
+                doc_id=doc_id,
+                top_k=top_k,
+                query_chars=len(query),
+            ):
+                snippets = await retrieve(retriever, query=query, doc_id=doc_id, top_k=top_k)
+                return [s.model_dump(mode="json") for s in snippets]
+
+        tools.append(search_tfl_docs)
+
+    return tools

--- a/src/api/agent/tools.py
+++ b/src/api/agent/tools.py
@@ -231,10 +231,16 @@ def make_tools(
                 destination_id = await resolve_name(tfl_client=tfl_client, query=destination)
                 if destination_id is None:
                     return f"Couldn't find station '{destination}'."
+                parsed_departure = _parse_departure_time(departure_time)
+                if departure_time and parsed_departure is None:
+                    return (
+                        f"Couldn't understand the departure time '{departure_time}'. "
+                        "Use an ISO time like 2026-05-27T09:00, or omit it to leave now."
+                    )
                 journeys = await tfl_client.plan_journey(
                     origin_id,
                     destination_id,
-                    departure_time=_parse_departure_time(departure_time),
+                    departure_time=parsed_departure,
                 )
                 if not journeys:
                     return f"No journeys found from '{origin}' to '{destination}'."

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -87,7 +87,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # is unset (smoke tests, /health-only deploys).
     from api.agent.graph import compile_agent  # noqa: PLC0415
 
-    app.state.agent = compile_agent(pool=pool)
+    app.state.agent = compile_agent(pool=pool, tfl_client=app.state.tfl_client)
     logfire.info(
         "api_db_pool_opened",
         service="tfl-monitor-api",

--- a/src/api/stations.py
+++ b/src/api/stations.py
@@ -27,6 +27,12 @@ from ingestion.tfl_client.client import TflClient, TflClientError
 # *not* cached so the next request retries the lookup.
 _NAPTAN_CACHE: dict[str, str | None] = {}
 
+# Process-lifetime cache mapping a normalised free-text station query →
+# resolved StopPoint/NaPTAN id. ``None`` means the search returned no
+# matches (a definitive HTTP 200 miss). Transient failures (timeouts,
+# 5xx, network errors) are *not* cached so the next request retries.
+_NAME_CACHE: dict[str, str | None] = {}
+
 # Cap concurrent in-flight TfL lookups across all requests when several
 # NaPTANs miss the seed at the same time. The free-tier TfL rate limit
 # is 500 req/min per app-key; sharing one semaphore per process keeps
@@ -42,9 +48,10 @@ WHERE naptan_id = ANY(%(naptan_ids)s::text[])
 
 
 def _cache_clear() -> None:
-    """Reset the module-level cache and semaphore. Used by tests only."""
+    """Reset the module-level caches and semaphore. Used by tests only."""
     global _TFL_SEMAPHORE
     _NAPTAN_CACHE.clear()
+    _NAME_CACHE.clear()
     _TFL_SEMAPHORE = None
 
 
@@ -163,3 +170,42 @@ def _is_not_found(exc: TflClientError) -> bool:
     """True when the underlying httpx error was a 404 (vs transient failure)."""
     cause = exc.__cause__
     return isinstance(cause, httpx.HTTPStatusError) and cause.response.status_code == 404
+
+
+async def resolve_name(*, tfl_client: TflClient | None, query: str) -> str | None:
+    """Resolve a free-text station name to a StopPoint/NaPTAN id.
+
+    Searches TfL ``/StopPoint/Search`` and returns the top-ranked match's
+    id. A process-lifetime cache absorbs repeated queries: definitive
+    no-match results (empty matches) are cached as ``None`` so they cost
+    nothing to repeat, while transient failures are left uncached so the
+    next call retries.
+
+    Args:
+        tfl_client: Optional ``TflClient``. When ``None`` the function
+            returns ``None`` without caching.
+        query: Free-text station name (e.g. ``"Oxford Circus"``).
+
+    Returns:
+        The resolved StopPoint/NaPTAN id, or ``None`` when the query is
+        empty, unresolved, or no client is available.
+    """
+    if tfl_client is None:
+        return None
+    normalised = query.strip().lower()
+    if not normalised:
+        return None
+    if normalised in _NAME_CACHE:
+        return _NAME_CACHE[normalised]
+
+    semaphore = _get_tfl_semaphore()
+    async with semaphore:
+        try:
+            response = await tfl_client.search_stop(normalised)
+        except Exception:
+            logfire.exception("stations.name_search_failed", query=normalised)
+            return None
+
+    resolved = response.matches[0].id if response.matches else None
+    _NAME_CACHE[normalised] = resolved
+    return resolved

--- a/src/api/stations.py
+++ b/src/api/stations.py
@@ -31,7 +31,10 @@ _NAPTAN_CACHE: dict[str, str | None] = {}
 # resolved StopPoint/NaPTAN id. ``None`` means the search returned no
 # matches (a definitive HTTP 200 miss). Transient failures (timeouts,
 # 5xx, network errors) are *not* cached so the next request retries.
+# Keys are arbitrary user text, so the cache is bounded with simple FIFO
+# eviction to keep memory flat under high-cardinality chat traffic.
 _NAME_CACHE: dict[str, str | None] = {}
+_NAME_CACHE_MAX: Final = 512
 
 # Cap concurrent in-flight TfL lookups across all requests when several
 # NaPTANs miss the seed at the same time. The free-tier TfL rate limit
@@ -192,20 +195,26 @@ async def resolve_name(*, tfl_client: TflClient | None, query: str) -> str | Non
     """
     if tfl_client is None:
         return None
-    normalised = query.strip().lower()
-    if not normalised:
+    query = query.strip()
+    if not query:
         return None
-    if normalised in _NAME_CACHE:
-        return _NAME_CACHE[normalised]
+    # Lowercase only the cache key, never the value sent upstream: TfL
+    # Search is case-insensitive for names, but folding case on a NaPTAN
+    # id could break an exact-id lookup.
+    cache_key = query.lower()
+    if cache_key in _NAME_CACHE:
+        return _NAME_CACHE[cache_key]
 
     semaphore = _get_tfl_semaphore()
     async with semaphore:
         try:
-            response = await tfl_client.search_stop(normalised)
+            response = await tfl_client.search_stop(query)
         except Exception:
-            logfire.exception("stations.name_search_failed", query=normalised)
+            logfire.exception("stations.name_search_failed", query=cache_key)
             return None
 
     resolved = response.matches[0].id if response.matches else None
-    _NAME_CACHE[normalised] = resolved
+    if len(_NAME_CACHE) >= _NAME_CACHE_MAX:
+        _NAME_CACHE.pop(next(iter(_NAME_CACHE)))
+    _NAME_CACHE[cache_key] = resolved
     return resolved

--- a/src/ingestion/tfl_client/client.py
+++ b/src/ingestion/tfl_client/client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable
+from datetime import datetime
 from types import TracebackType
 from typing import Any, Self
 
@@ -19,8 +20,10 @@ from pydantic import TypeAdapter
 
 from contracts.schemas.tfl_api import (
     TflArrivalPrediction,
+    TflJourneyResult,
     TflLineResponse,
     TflStopPoint,
+    TflStopSearchResponse,
 )
 from ingestion.tfl_client.retry import TflClientError, with_retry
 
@@ -33,6 +36,8 @@ _DEFAULT_MAX_ATTEMPTS = 3
 _LINE_RESPONSE_ADAPTER: TypeAdapter[list[TflLineResponse]] = TypeAdapter(list[TflLineResponse])
 _ARRIVAL_ADAPTER: TypeAdapter[list[TflArrivalPrediction]] = TypeAdapter(list[TflArrivalPrediction])
 _STOP_POINT_ADAPTER: TypeAdapter[TflStopPoint] = TypeAdapter(TflStopPoint)
+_STOP_SEARCH_ADAPTER: TypeAdapter[TflStopSearchResponse] = TypeAdapter(TflStopSearchResponse)
+_JOURNEY_ADAPTER: TypeAdapter[list[TflJourneyResult]] = TypeAdapter(list[TflJourneyResult])
 
 
 class TflClient:
@@ -123,6 +128,57 @@ class TflClient:
             params={"detail": "true"},
         )
         return _LINE_RESPONSE_ADAPTER.validate_python(data)
+
+    async def search_stop(self, query: str) -> TflStopSearchResponse:
+        """Search stop points by free-text name via ``/StopPoint/Search/{query}``.
+
+        Returns the tier-1 search response whose ``matches`` are ranked by
+        TfL relevance; the first match is the best name resolution.
+        """
+        if not query:
+            raise TflClientError("query must be a non-empty string")
+        data = await self._request(f"/StopPoint/Search/{query}")
+        return _STOP_SEARCH_ADAPTER.validate_python(data)
+
+    async def plan_journey(
+        self,
+        from_id: str,
+        to_id: str,
+        *,
+        departure_time: datetime | None = None,
+        modes: Iterable[str] | None = None,
+    ) -> list[TflJourneyResult]:
+        """Plan journeys between two StopPoint/NaPTAN ids.
+
+        Hits ``/Journey/JourneyResults/{from_id}/to/{to_id}``. Passing
+        StopPoint ids (not names) avoids the TfL HTTP 300 disambiguation
+        flow. When ``departure_time`` is given it is sent as a departing
+        time in TfL's ``yyyyMMdd``/``HHmm`` format; ``modes`` restricts the
+        transport modes considered.
+
+        Args:
+            from_id: Origin StopPoint/NaPTAN id.
+            to_id: Destination StopPoint/NaPTAN id.
+            departure_time: Optional desired departure time.
+            modes: Optional iterable of TfL transport modes to allow.
+
+        Returns:
+            The tier-1 journey options from the response ``journeys`` array.
+        """
+        if not from_id or not to_id:
+            raise TflClientError("from_id and to_id must be non-empty strings")
+        params: dict[str, Any] = {}
+        if departure_time is not None:
+            params["date"] = departure_time.strftime("%Y%m%d")
+            params["time"] = departure_time.strftime("%H%M")
+            params["timeIs"] = "Departing"
+        if modes is not None:
+            params["mode"] = self._join_modes(modes)
+        data = await self._request(
+            f"/Journey/JourneyResults/{from_id}/to/{to_id}",
+            params=params or None,
+        )
+        return _JOURNEY_ADAPTER.validate_python(data.get("journeys", []))
 
     async def _request(self, path: str, *, params: dict[str, Any] | None = None) -> Any:
         """Issue a GET request with retry, returning the decoded JSON body."""

--- a/src/ingestion/tfl_client/client.py
+++ b/src/ingestion/tfl_client/client.py
@@ -13,6 +13,8 @@ from collections.abc import Iterable
 from datetime import datetime
 from types import TracebackType
 from typing import Any, Self
+from urllib.parse import quote
+from zoneinfo import ZoneInfo
 
 import httpx
 import logfire
@@ -32,6 +34,10 @@ __all__ = ["TflClient", "TflClientError"]
 _TFL_BASE_URL = "https://api.tfl.gov.uk"
 _DEFAULT_TIMEOUT_SECONDS = 30.0
 _DEFAULT_MAX_ATTEMPTS = 3
+
+# TfL journey planning expects wall-clock London local time (GMT/BST),
+# not UTC, in its ``date``/``time`` params.
+_TFL_TIMEZONE = ZoneInfo("Europe/London")
 
 _LINE_RESPONSE_ADAPTER: TypeAdapter[list[TflLineResponse]] = TypeAdapter(list[TflLineResponse])
 _ARRIVAL_ADAPTER: TypeAdapter[list[TflArrivalPrediction]] = TypeAdapter(list[TflArrivalPrediction])
@@ -137,7 +143,7 @@ class TflClient:
         """
         if not query:
             raise TflClientError("query must be a non-empty string")
-        data = await self._request(f"/StopPoint/Search/{query}")
+        data = await self._request(f"/StopPoint/Search/{quote(query, safe='')}")
         return _STOP_SEARCH_ADAPTER.validate_python(data)
 
     async def plan_journey(
@@ -169,8 +175,15 @@ class TflClient:
             raise TflClientError("from_id and to_id must be non-empty strings")
         params: dict[str, Any] = {}
         if departure_time is not None:
-            params["date"] = departure_time.strftime("%Y%m%d")
-            params["time"] = departure_time.strftime("%H%M")
+            # TfL wants London wall-clock time; convert tz-aware inputs
+            # (e.g. UTC) so a request never silently shifts by the BST offset.
+            local = (
+                departure_time.astimezone(_TFL_TIMEZONE)
+                if departure_time.tzinfo is not None
+                else departure_time
+            )
+            params["date"] = local.strftime("%Y%m%d")
+            params["time"] = local.strftime("%H%M")
             params["timeIs"] = "Departing"
         if modes is not None:
             params["mode"] = self._join_modes(modes)

--- a/tests/agent/test_journey_tools.py
+++ b/tests/agent/test_journey_tools.py
@@ -132,6 +132,26 @@ async def test_plan_journey_unresolved_origin(monkeypatch: pytest.MonkeyPatch) -
 
 
 @pytest.mark.asyncio
+async def test_plan_journey_rejects_unparseable_departure_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_resolver(
+        monkeypatch,
+        {"oxford circus": "940GZZLUOXC", "bank": "940GZZLUBNK"},
+    )
+    client = FakeTflClient(journeys=[_journey()])
+    tool = _tool(client, "plan_journey_tool")
+
+    result = await tool.ainvoke(
+        {"origin": "Oxford Circus", "destination": "Bank", "departure_time": "tomorrow 9am"}
+    )
+
+    assert isinstance(result, str)
+    assert "tomorrow 9am" in result
+    assert client.plan_calls == []  # never plans "now" on a bad time
+
+
+@pytest.mark.asyncio
 async def test_plan_journey_unresolved_destination(monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_resolver(monkeypatch, {"oxford circus": "940GZZLUOXC"})
     client = FakeTflClient(journeys=[_journey()])

--- a/tests/agent/test_journey_tools.py
+++ b/tests/agent/test_journey_tools.py
@@ -1,0 +1,179 @@
+"""Unit tests for the journey-planning and arrivals agent tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from api.agent import tools as tools_module
+from api.agent.tools import make_tools
+from contracts.schemas.tfl_api import (
+    TflArrivalPrediction,
+    TflJourneyInstruction,
+    TflJourneyLeg,
+    TflJourneyMode,
+    TflJourneyResult,
+)
+
+
+@dataclass
+class FakeTflClient:
+    """Stand-in exposing only the methods the journey/arrivals tools call."""
+
+    journeys: list[TflJourneyResult] = field(default_factory=list)
+    arrivals: list[TflArrivalPrediction] = field(default_factory=list)
+    plan_calls: list[tuple[str, str]] = field(default_factory=list)
+    arrival_calls: list[str] = field(default_factory=list)
+
+    async def plan_journey(
+        self,
+        from_id: str,
+        to_id: str,
+        *,
+        departure_time: datetime | None = None,
+        modes: Any = None,
+    ) -> list[TflJourneyResult]:
+        self.plan_calls.append((from_id, to_id))
+        return self.journeys
+
+    async def fetch_arrivals(self, stop_id: str) -> list[TflArrivalPrediction]:
+        self.arrival_calls.append(stop_id)
+        return self.arrivals
+
+
+def _leg(mode: str, summary: str, minutes: int) -> TflJourneyLeg:
+    return TflJourneyLeg(
+        duration=minutes,
+        mode=TflJourneyMode(name=mode),
+        instruction=TflJourneyInstruction(summary=summary),
+    )
+
+
+def _journey() -> TflJourneyResult:
+    return TflJourneyResult(
+        start_date_time=datetime(2026, 5, 27, 9, 0, tzinfo=UTC),
+        arrival_date_time=datetime(2026, 5, 27, 9, 12, tzinfo=UTC),
+        duration=12,
+        legs=[_leg("walking", "Walk to Oxford Circus", 3), _leg("tube", "Central line to Bank", 9)],
+    )
+
+
+def _arrival(platform: str, line: str, destination: str, seconds: int) -> TflArrivalPrediction:
+    return TflArrivalPrediction(
+        id=f"{line}-{seconds}",
+        naptan_id="940GZZLUBNK",
+        station_name="Bank Underground Station",
+        line_id=line.lower(),
+        line_name=line,
+        platform_name=platform,
+        destination_name=destination,
+        expected_arrival=datetime(2026, 5, 27, 9, 0, tzinfo=UTC),
+        time_to_station=seconds,
+        mode_name="tube",
+    )
+
+
+def _stub_resolver(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, str | None]) -> None:
+    async def fake_resolve_name(*, tfl_client: Any, query: str) -> str | None:
+        return mapping.get(query.strip().lower())
+
+    monkeypatch.setattr(tools_module, "resolve_name", fake_resolve_name)
+
+
+def _tool(tfl_client: Any, name: str) -> Any:
+    tools = make_tools(pool=object(), tfl_client=tfl_client)  # type: ignore[arg-type]
+    return next(t for t in tools if t.name == name)
+
+
+def test_make_tools_omits_tfl_tools_without_client() -> None:
+    names = [t.name for t in make_tools(pool=object())]  # type: ignore[arg-type]
+    assert "plan_journey_tool" not in names
+    assert "get_arrivals_tool" not in names
+
+
+def test_make_tools_includes_tfl_tools_with_client() -> None:
+    client = FakeTflClient()
+    names = [t.name for t in make_tools(pool=object(), tfl_client=client)]  # type: ignore[arg-type]
+    assert "plan_journey_tool" in names
+    assert "get_arrivals_tool" in names
+
+
+@pytest.mark.asyncio
+async def test_plan_journey_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_resolver(
+        monkeypatch,
+        {"oxford circus": "940GZZLUOXC", "bank": "940GZZLUBNK"},
+    )
+    client = FakeTflClient(journeys=[_journey()])
+    tool = _tool(client, "plan_journey_tool")
+
+    result = await tool.ainvoke({"origin": "Oxford Circus", "destination": "Bank"})
+
+    assert client.plan_calls == [("940GZZLUOXC", "940GZZLUBNK")]
+    assert result["total_minutes"] == 12
+    assert [leg["mode"] for leg in result["legs"]] == ["walking", "tube"]
+    assert result["legs"][1]["summary"] == "Central line to Bank"
+
+
+@pytest.mark.asyncio
+async def test_plan_journey_unresolved_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_resolver(monkeypatch, {"bank": "940GZZLUBNK"})
+    client = FakeTflClient(journeys=[_journey()])
+    tool = _tool(client, "plan_journey_tool")
+
+    result = await tool.ainvoke({"origin": "Nowhere", "destination": "Bank"})
+
+    assert isinstance(result, str)
+    assert "Nowhere" in result
+    assert client.plan_calls == []
+
+
+@pytest.mark.asyncio
+async def test_plan_journey_unresolved_destination(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_resolver(monkeypatch, {"oxford circus": "940GZZLUOXC"})
+    client = FakeTflClient(journeys=[_journey()])
+    tool = _tool(client, "plan_journey_tool")
+
+    result = await tool.ainvoke({"origin": "Oxford Circus", "destination": "Atlantis"})
+
+    assert isinstance(result, str)
+    assert "Atlantis" in result
+    assert client.plan_calls == []
+
+
+@pytest.mark.asyncio
+async def test_get_arrivals_groups_sorts_and_caps(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_resolver(monkeypatch, {"bank": "940GZZLUBNK"})
+    northbound = [
+        _arrival("Northbound - Platform 1", "Central", "Epping", s)
+        for s in (600, 60, 300, 480, 180, 720)
+    ]
+    southbound = [_arrival("Southbound - Platform 2", "Central", "Ealing", 240)]
+    client = FakeTflClient(arrivals=[*northbound, *southbound])
+    tool = _tool(client, "get_arrivals_tool")
+
+    result = await tool.ainvoke({"stop": "Bank"})
+
+    assert client.arrival_calls == ["940GZZLUBNK"]
+    assert result["station"] == "Bank Underground Station"
+    platforms = {p["platform"]: p for p in result["platforms"]}
+    north = platforms["Northbound - Platform 1"]
+    assert len(north["arrivals"]) == 5  # capped per platform
+    assert [a["seconds"] for a in north["arrivals"]] == [60, 180, 300, 480, 600]  # sorted ascending
+    assert platforms["Southbound - Platform 2"]["arrivals"][0]["destination"] == "Ealing"
+
+
+@pytest.mark.asyncio
+async def test_get_arrivals_unresolved_stop(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_resolver(monkeypatch, {})
+    client = FakeTflClient(arrivals=[_arrival("P1", "Central", "Epping", 60)])
+    tool = _tool(client, "get_arrivals_tool")
+
+    result = await tool.ainvoke({"stop": "Mordor"})
+
+    assert isinstance(result, str)
+    assert "Mordor" in result
+    assert client.arrival_calls == []

--- a/tests/api/test_stations.py
+++ b/tests/api/test_stations.py
@@ -22,9 +22,11 @@ from ingestion.tfl_client.client import TflClientError
 class FakeSearchClient:
     """Stand-in for ``TflClient`` covering ``search_stop``.
 
-    ``matches_by_query`` maps a normalised query to the ordered ids the
-    search returns; ``fail_times`` raises on the first N calls to model a
-    transient upstream failure.
+    ``matches_by_query`` maps a lowercased query to the ordered ids the
+    search returns (lookup mirrors TfL Search being case-insensitive);
+    ``fail_times`` raises on the first N calls to model a transient
+    upstream failure. ``calls`` records the raw query as received, so
+    tests can assert the resolver preserves the caller's casing.
     """
 
     matches_by_query: dict[str, list[str]]
@@ -35,7 +37,7 @@ class FakeSearchClient:
         self.calls.append(query)
         if len(self.calls) <= self.fail_times:
             raise TflClientError(f"transient search failure for {query}")
-        ids = self.matches_by_query.get(query, [])
+        ids = self.matches_by_query.get(query.strip().lower(), [])
         return TflStopSearchResponse(matches=[TflStopSearchMatch(id=sid, name=sid) for sid in ids])
 
 
@@ -281,7 +283,7 @@ async def test_resolve_name_returns_top_match_id() -> None:
     resolved = await stations.resolve_name(tfl_client=client, query="Oxford Circus")  # type: ignore[arg-type]
 
     assert resolved == "940GZZLUOXC"
-    assert client.calls == ["oxford circus"]
+    assert client.calls == ["Oxford Circus"]  # case preserved on the upstream call
 
 
 @pytest.mark.asyncio
@@ -293,7 +295,7 @@ async def test_resolve_name_no_match_returns_none_and_caches() -> None:
 
     assert first is None
     assert second is None
-    assert client.calls == ["nowhere"]  # cached miss short-circuits the second call
+    assert client.calls == ["Nowhere"]  # cached miss short-circuits the second call
 
 
 @pytest.mark.asyncio
@@ -310,7 +312,7 @@ async def test_resolve_name_cache_hit_avoids_second_call() -> None:
 
     assert first == "940GZZLUBNK"
     assert second == "940GZZLUBNK"
-    assert client.calls == ["bank"]  # normalisation collapses both queries to one lookup
+    assert client.calls == ["Bank"]  # case-insensitive cache key collapses both to one lookup
 
 
 @pytest.mark.asyncio
@@ -322,4 +324,19 @@ async def test_resolve_name_transient_failure_not_cached() -> None:
 
     assert first is None
     assert second == "940GZZLUBNK"
-    assert client.calls == ["bank", "bank"]
+    assert client.calls == ["Bank", "Bank"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_cache_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The free-text cache evicts oldest entries past its cap rather than
+    growing without bound under high-cardinality chat traffic."""
+    monkeypatch.setattr(stations, "_NAME_CACHE_MAX", 2)
+    client = FakeSearchClient({"a": ["1"], "b": ["2"], "c": ["3"]})
+
+    for query in ("a", "b", "c"):
+        await stations.resolve_name(tfl_client=client, query=query)  # type: ignore[arg-type]
+
+    assert len(stations._NAME_CACHE) == 2  # noqa: SLF001
+    assert "a" not in stations._NAME_CACHE  # noqa: SLF001 - oldest evicted (FIFO)
+    assert set(stations._NAME_CACHE) == {"b", "c"}  # noqa: SLF001

--- a/tests/api/test_stations.py
+++ b/tests/api/test_stations.py
@@ -10,8 +10,33 @@ import httpx
 import pytest
 
 from api import stations
-from contracts.schemas.tfl_api import TflStopPoint
+from contracts.schemas.tfl_api import (
+    TflStopPoint,
+    TflStopSearchMatch,
+    TflStopSearchResponse,
+)
 from ingestion.tfl_client.client import TflClientError
+
+
+@dataclass
+class FakeSearchClient:
+    """Stand-in for ``TflClient`` covering ``search_stop``.
+
+    ``matches_by_query`` maps a normalised query to the ordered ids the
+    search returns; ``fail_times`` raises on the first N calls to model a
+    transient upstream failure.
+    """
+
+    matches_by_query: dict[str, list[str]]
+    fail_times: int = 0
+    calls: list[str] = field(default_factory=list)
+
+    async def search_stop(self, query: str) -> TflStopSearchResponse:
+        self.calls.append(query)
+        if len(self.calls) <= self.fail_times:
+            raise TflClientError(f"transient search failure for {query}")
+        ids = self.matches_by_query.get(query, [])
+        return TflStopSearchResponse(matches=[TflStopSearchMatch(id=sid, name=sid) for sid in ids])
 
 
 @dataclass
@@ -242,3 +267,59 @@ async def test_definitive_404_is_cached(
     assert first == {"490DEPRECATED": None}
     assert second == {"490DEPRECATED": None}
     assert fake_client.calls == ["490DEPRECATED"]
+
+
+# ---------------------------------------------------------------------------
+# Forward resolver: resolve_name (name → StopPoint/NaPTAN id)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_returns_top_match_id() -> None:
+    client = FakeSearchClient({"oxford circus": ["940GZZLUOXC", "490G00251P"]})
+
+    resolved = await stations.resolve_name(tfl_client=client, query="Oxford Circus")  # type: ignore[arg-type]
+
+    assert resolved == "940GZZLUOXC"
+    assert client.calls == ["oxford circus"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_no_match_returns_none_and_caches() -> None:
+    client = FakeSearchClient({})
+
+    first = await stations.resolve_name(tfl_client=client, query="Nowhere")  # type: ignore[arg-type]
+    second = await stations.resolve_name(tfl_client=client, query="Nowhere")  # type: ignore[arg-type]
+
+    assert first is None
+    assert second is None
+    assert client.calls == ["nowhere"]  # cached miss short-circuits the second call
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_without_client_returns_none() -> None:
+    assert await stations.resolve_name(tfl_client=None, query="Oxford Circus") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_cache_hit_avoids_second_call() -> None:
+    client = FakeSearchClient({"bank": ["940GZZLUBNK"]})
+
+    first = await stations.resolve_name(tfl_client=client, query="Bank")  # type: ignore[arg-type]
+    second = await stations.resolve_name(tfl_client=client, query="  bank  ")  # type: ignore[arg-type]
+
+    assert first == "940GZZLUBNK"
+    assert second == "940GZZLUBNK"
+    assert client.calls == ["bank"]  # normalisation collapses both queries to one lookup
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_transient_failure_not_cached() -> None:
+    client = FakeSearchClient({"bank": ["940GZZLUBNK"]}, fail_times=1)
+
+    first = await stations.resolve_name(tfl_client=client, query="Bank")  # type: ignore[arg-type]
+    second = await stations.resolve_name(tfl_client=client, query="Bank")  # type: ignore[arg-type]
+
+    assert first is None
+    assert second == "940GZZLUBNK"
+    assert client.calls == ["bank", "bank"]

--- a/tests/fixtures/tfl/journey_oxford_circus_to_bank.json
+++ b/tests/fixtures/tfl/journey_oxford_circus_to_bank.json
@@ -1,0 +1,78 @@
+{
+  "$type": "Tfl.Api.Presentation.Entities.JourneyPlanner.ItineraryResult, Tfl.Api.Presentation.Entities",
+  "journeys": [
+    {
+      "$type": "Tfl.Api.Presentation.Entities.JourneyPlanner.Journey, Tfl.Api.Presentation.Entities",
+      "startDateTime": "2026-05-27T09:00:00",
+      "duration": 12,
+      "arrivalDateTime": "2026-05-27T09:12:00",
+      "legs": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.JourneyPlanner.Leg, Tfl.Api.Presentation.Entities",
+          "duration": 3,
+          "departureTime": "2026-05-27T09:00:00",
+          "arrivalTime": "2026-05-27T09:03:00",
+          "instruction": {
+            "$type": "Tfl.Api.Presentation.Entities.Instruction, Tfl.Api.Presentation.Entities",
+            "summary": "Walk to Oxford Circus Underground Station",
+            "detailed": "Walk to Oxford Circus Underground Station",
+            "steps": []
+          },
+          "mode": {
+            "$type": "Tfl.Api.Presentation.Entities.Mode, Tfl.Api.Presentation.Entities",
+            "id": "walking",
+            "name": "walking",
+            "type": "Mode",
+            "motType": "Walking"
+          }
+        },
+        {
+          "$type": "Tfl.Api.Presentation.Entities.JourneyPlanner.Leg, Tfl.Api.Presentation.Entities",
+          "duration": 9,
+          "departureTime": "2026-05-27T09:03:00",
+          "arrivalTime": "2026-05-27T09:12:00",
+          "instruction": {
+            "$type": "Tfl.Api.Presentation.Entities.Instruction, Tfl.Api.Presentation.Entities",
+            "summary": "Central line to Bank",
+            "detailed": "Central line towards Epping",
+            "steps": []
+          },
+          "mode": {
+            "$type": "Tfl.Api.Presentation.Entities.Mode, Tfl.Api.Presentation.Entities",
+            "id": "tube",
+            "name": "tube",
+            "type": "Mode",
+            "motType": "Tube"
+          }
+        }
+      ]
+    },
+    {
+      "$type": "Tfl.Api.Presentation.Entities.JourneyPlanner.Journey, Tfl.Api.Presentation.Entities",
+      "startDateTime": "2026-05-27T09:05:00",
+      "duration": 16,
+      "arrivalDateTime": "2026-05-27T09:21:00",
+      "legs": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.JourneyPlanner.Leg, Tfl.Api.Presentation.Entities",
+          "duration": 16,
+          "departureTime": "2026-05-27T09:05:00",
+          "arrivalTime": "2026-05-27T09:21:00",
+          "instruction": {
+            "$type": "Tfl.Api.Presentation.Entities.Instruction, Tfl.Api.Presentation.Entities",
+            "summary": "Victoria line then Northern line to Bank",
+            "detailed": "Victoria line towards Brixton, change at Euston",
+            "steps": []
+          },
+          "mode": {
+            "$type": "Tfl.Api.Presentation.Entities.Mode, Tfl.Api.Presentation.Entities",
+            "id": "tube",
+            "name": "tube",
+            "type": "Mode",
+            "motType": "Tube"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/tfl/stop_search_oxford_circus.json
+++ b/tests/fixtures/tfl/stop_search_oxford_circus.json
@@ -1,0 +1,23 @@
+{
+  "$type": "Tfl.Api.Presentation.Entities.SearchResponse, Tfl.Api.Presentation.Entities",
+  "query": "oxford circus",
+  "total": 2,
+  "matches": [
+    {
+      "$type": "Tfl.Api.Presentation.Entities.SearchMatch, Tfl.Api.Presentation.Entities",
+      "id": "940GZZLUOXC",
+      "name": "Oxford Circus Underground Station",
+      "lat": 51.515224,
+      "lon": -0.141903,
+      "modes": ["tube"]
+    },
+    {
+      "$type": "Tfl.Api.Presentation.Entities.SearchMatch, Tfl.Api.Presentation.Entities",
+      "id": "490G00251P",
+      "name": "Oxford Circus Station",
+      "lat": 51.515743,
+      "lon": -0.142244,
+      "modes": ["bus"]
+    }
+  ]
+}

--- a/tests/ingestion/conftest.py
+++ b/tests/ingestion/conftest.py
@@ -19,6 +19,11 @@ def _load(name: str) -> list[dict[str, Any]]:
     return data
 
 
+def _load_obj(name: str) -> dict[str, Any]:
+    data: dict[str, Any] = json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+    return data
+
+
 @pytest.fixture
 def line_status_tube_fixture() -> list[dict[str, Any]]:
     return _load("line_status_tube.json")
@@ -32,6 +37,16 @@ def line_status_multi_mode_fixture() -> list[dict[str, Any]]:
 @pytest.fixture
 def arrivals_oxford_circus_fixture() -> list[dict[str, Any]]:
     return _load("arrivals_oxford_circus.json")
+
+
+@pytest.fixture
+def journey_oxford_circus_to_bank_fixture() -> dict[str, Any]:
+    return _load_obj("journey_oxford_circus_to_bank.json")
+
+
+@pytest.fixture
+def stop_search_oxford_circus_fixture() -> dict[str, Any]:
+    return _load_obj("stop_search_oxford_circus.json")
 
 
 @pytest.fixture

--- a/tests/ingestion/test_tfl_client_journey.py
+++ b/tests/ingestion/test_tfl_client_journey.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import httpx
 
@@ -41,6 +42,59 @@ async def test_search_stop_returns_tier1_response(
     assert captured[0].url.path.startswith("/StopPoint/Search/")
     assert isinstance(result, TflStopSearchResponse)
     assert result.matches[0].id == "940GZZLUOXC"
+
+
+async def test_search_stop_url_encodes_reserved_characters(
+    stop_search_oxford_circus_fixture: dict[str, Any],
+    make_transport: Callable[[Callable[[httpx.Request], httpx.Response]], httpx.MockTransport],
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _json_response(stop_search_oxford_circus_fixture)
+
+    async with _client(make_transport(handler)) as client:
+        await client.search_stop("a/b c")
+
+    # The reserved '/' must stay percent-encoded on the wire (raw_path)
+    # so it cannot split the path into extra segments.
+    assert captured[0].url.raw_path.split(b"?")[0] == b"/StopPoint/Search/a%2Fb%20c"
+
+
+async def test_plan_journey_converts_tz_aware_time_to_london(
+    journey_oxford_circus_to_bank_fixture: dict[str, Any],
+    make_transport: Callable[[Callable[[httpx.Request], httpx.Response]], httpx.MockTransport],
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _json_response(journey_oxford_circus_to_bank_fixture)
+
+    # 12:00 UTC on 1 Jul is 13:00 BST in London.
+    async with _client(make_transport(handler)) as client:
+        await client.plan_journey(
+            "940GZZLUOXC",
+            "940GZZLUBNK",
+            departure_time=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
+        )
+
+    params = captured[0].url.params
+    assert params.get("date") == "20260701"
+    assert params.get("time") == "1300"
+
+    # A naive datetime is taken as already-London wall-clock, unchanged.
+    captured.clear()
+    async with _client(make_transport(handler)) as client:
+        await client.plan_journey(
+            "940GZZLUOXC",
+            "940GZZLUBNK",
+            departure_time=datetime(2026, 7, 1, 9, 5, tzinfo=ZoneInfo("Europe/London")).replace(
+                tzinfo=None
+            ),
+        )
+    assert captured[0].url.params.get("time") == "0905"
 
 
 async def test_plan_journey_without_options_omits_time_and_mode(

--- a/tests/ingestion/test_tfl_client_journey.py
+++ b/tests/ingestion/test_tfl_client_journey.py
@@ -1,0 +1,90 @@
+"""Behavioural tests for journey planning and stop search on :class:`TflClient`."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from contracts.schemas.tfl_api import TflJourneyResult, TflStopSearchResponse
+from ingestion.tfl_client import TflClient
+
+
+def _json_response(payload: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(
+        200,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
+    )
+
+
+def _client(transport: httpx.MockTransport, **kwargs: Any) -> TflClient:
+    return TflClient(app_key="test-key", transport=transport, **kwargs)
+
+
+async def test_search_stop_returns_tier1_response(
+    stop_search_oxford_circus_fixture: dict[str, Any],
+    make_transport: Callable[[Callable[[httpx.Request], httpx.Response]], httpx.MockTransport],
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _json_response(stop_search_oxford_circus_fixture)
+
+    async with _client(make_transport(handler)) as client:
+        result = await client.search_stop("oxford circus")
+
+    assert captured[0].url.path.startswith("/StopPoint/Search/")
+    assert isinstance(result, TflStopSearchResponse)
+    assert result.matches[0].id == "940GZZLUOXC"
+
+
+async def test_plan_journey_without_options_omits_time_and_mode(
+    journey_oxford_circus_to_bank_fixture: dict[str, Any],
+    make_transport: Callable[[Callable[[httpx.Request], httpx.Response]], httpx.MockTransport],
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _json_response(journey_oxford_circus_to_bank_fixture)
+
+    async with _client(make_transport(handler)) as client:
+        result = await client.plan_journey("940GZZLUOXC", "940GZZLUBNK")
+
+    assert captured[0].url.path == "/Journey/JourneyResults/940GZZLUOXC/to/940GZZLUBNK"
+    assert captured[0].url.params.get("date") is None
+    assert captured[0].url.params.get("time") is None
+    assert captured[0].url.params.get("mode") is None
+    assert all(isinstance(item, TflJourneyResult) for item in result)
+    assert len(result) == 2
+    assert [leg.mode.name for leg in result[0].legs] == ["walking", "tube"]
+
+
+async def test_plan_journey_with_departure_time_and_modes_sets_params(
+    journey_oxford_circus_to_bank_fixture: dict[str, Any],
+    make_transport: Callable[[Callable[[httpx.Request], httpx.Response]], httpx.MockTransport],
+) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return _json_response(journey_oxford_circus_to_bank_fixture)
+
+    async with _client(make_transport(handler)) as client:
+        await client.plan_journey(
+            "940GZZLUOXC",
+            "940GZZLUBNK",
+            departure_time=datetime(2026, 5, 27, 9, 5),
+            modes=["tube", "bus"],
+        )
+
+    params = captured[0].url.params
+    assert params.get("date") == "20260527"
+    assert params.get("time") == "0905"
+    assert params.get("timeIs") == "Departing"
+    assert params.get("mode") == "tube,bus"

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -30,6 +30,7 @@ from contracts.schemas import (
     TflLineResponse,
     TransportMode,
 )
+from contracts.schemas.tfl_api import TflJourneyResult, TflStopSearchResponse
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -45,6 +46,12 @@ def _load_or_skip(name: str) -> list[dict[str, object]]:
     return data
 
 
+def _load_tfl_object(name: str) -> dict[str, object]:
+    data = json.loads((FIXTURES / "tfl" / name).read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"expected a JSON object in {name}"
+    return data
+
+
 # ---------- Tier-1: raw TfL API fixtures ----------
 
 
@@ -56,6 +63,29 @@ def test_line_status_fixture_parses_as_tfl_line() -> None:
 def test_arrivals_fixture_parses_as_tfl_prediction() -> None:
     for item in _load_or_skip("arrivals_sample.json"):
         TflArrivalPrediction.model_validate(item)
+
+
+def test_journey_fixture_parses_with_nested_legs() -> None:
+    payload = _load_tfl_object("journey_oxford_circus_to_bank.json")
+    raw_journeys = payload["journeys"]
+    assert isinstance(raw_journeys, list)
+    journeys = [TflJourneyResult.model_validate(j) for j in raw_journeys]
+
+    assert len(journeys) == 2
+    first = journeys[0]
+    assert first.duration == 12
+    assert [leg.mode.name for leg in first.legs] == ["walking", "tube"]
+    assert first.legs[1].instruction.summary == "Central line to Bank"
+    assert first.legs[0].departure_time is not None
+
+
+def test_stop_search_fixture_parses_matches() -> None:
+    response = TflStopSearchResponse.model_validate(
+        _load_tfl_object("stop_search_oxford_circus.json")
+    )
+
+    assert [match.id for match in response.matches] == ["940GZZLUOXC", "490G00251P"]
+    assert response.matches[0].modes == ["tube"]
 
 
 # ---------- Tier-2: internal Kafka event contracts ----------

--- a/web/components/dashboard/__tests__/chat-panel.test.tsx
+++ b/web/components/dashboard/__tests__/chat-panel.test.tsx
@@ -56,6 +56,18 @@ describe("ChatPanel (TM-F2 SSE rewrite)", () => {
 		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 	});
 
+	it("pre-fills the textbox when a quick-prompt chip is clicked", () => {
+		render(<ChatPanel />);
+
+		for (const label of ["Plan a journey", "Next arrivals", "Line status"]) {
+			expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+		}
+
+		fireEvent.click(screen.getByRole("button", { name: "Next arrivals" }));
+
+		expect(screen.getByRole("textbox")).toHaveValue("Next arrivals at Bank");
+	});
+
 	it("streams tokens into the assistant bubble after Send", async () => {
 		const fetchMock = vi
 			.fn()

--- a/web/components/dashboard/chat-panel.tsx
+++ b/web/components/dashboard/chat-panel.tsx
@@ -29,12 +29,12 @@ const DEFAULT_PLACEHOLDER =
 	"what is the next train leaving Baker Street to Uxbridge?";
 
 const DEFAULT_QUICK_PROMPTS: QuickPrompt[] = [
-	{ label: "Next train", value: "Next train Baker Street → Uxbridge" },
-	{ label: "Why delayed?", value: "Why is the Elizabeth line delayed?" },
 	{
-		label: "Ticket acceptance",
-		value: "Tickets accepted on which lines?",
+		label: "Plan a journey",
+		value: "Plan a journey from Oxford Circus to Bank",
 	},
+	{ label: "Next arrivals", value: "Next arrivals at Bank" },
+	{ label: "Line status", value: "What's the status of the Central line?" },
 ];
 
 export function ChatPanel({


### PR DESCRIPTION
## Summary
- Add two LangGraph tools — `plan_journey_tool` and `get_arrivals_tool` — exposed to the chat agent only when a `TflClient` is configured (graceful degradation when `TFL_APP_KEY` is unset).
- Add `TflClient.search_stop` (`/StopPoint/Search`) + `plan_journey` (`/Journey/JourneyResults`) and a forward name→NaPTAN resolver `stations.resolve_name` with a bounded process-level cache.
- Thread the optional `TflClient` through `compile_agent` and the FastAPI lifespan; add tier-1 journey + stop-search contracts and prompt guidance for both tools.
- Refresh the chat quick-prompt chips to "Plan a journey", "Next arrivals", "Line status".

## Contracts / ADR
- Adds six additive tier-1 ingestion DTOs to `contracts/schemas/tfl_api.py`. Formalised in **[ADR 009](.claude/adrs/009-tfl-journey-arrivals-contracts.md)** per `AGENTS.md` (any `contracts/` change requires an ADR + `contract:` PR prefix). Additive only — no tier-2 Kafka, OpenAPI, SQL, or dbt-source change, so the CI source-mirror diff gate is unaffected.

## Design notes
- Tools resolve names to StopPoint ids ourselves and pass ids to `JourneyResults`, avoiding the TfL HTTP 300 disambiguation flow.
- Tools return compact typed JSON; the agent narrates it as text (no streaming-frame changes). Rich `<JourneyCard>` rendering is deferred to a follow-up WP.
- No Pydantic AI extraction layer (TfL Search is fuzzy-tolerant; the tool `args_schema` already extracts args).
- Review round 1 (`301a640`): URL-encode the search query, convert tz-aware journey times to Europe/London, preserve caller casing on the upstream search, bound the resolver cache. Round 2: reject unparseable `departure_time` instead of silently planning "now".

## Test plan
- [x] `uv run task lint` (ruff + mypy strict)
- [x] `uv run task test` (+ new tests: contracts, TfL client journey/search/encode/tz, resolver, agent tools)
- [x] `uv run bandit -r src --severity-level high`
- [x] `make check` (Python + `pnpm --dir web lint` + `pnpm --dir web test` + build + dbt-parse)
- [ ] Manual chat smokes (require live TfL key + LLM creds + running dashboard): "plan a journey from Oxford Circus to Bank", "next arrivals at Bank", chained status→journey, chip click pre-fill.

Closes TM-30.