### PR TITLE
contract: resolve hub ids to rail child + harden journey/arrivals tools

### DIFF
--- a/.claude/adrs/010-tfl-hub-children.md
+++ b/.claude/adrs/010-tfl-hub-children.md
@@ -1,0 +1,53 @@
+# 010 — `TflStopPoint` carries hub children for forward resolution
+
+Status: accepted
+Date: 2026-05-27
+
+## Context
+
+TM-30 shipped a forward resolver (`stations.resolve_name`) that maps a
+free-text station name to a StopPoint id via TfL `/StopPoint/Search`. A
+prod smoke exposed a defect: for major interchanges (Bank, King's Cross,
+Paddington, Victoria, …) the top Search match is a **hub** id
+(`HUB*`, e.g. `HUBBAN`), and a hub id is **not** a usable endpoint:
+
+- `/Journey/JourneyResults/.../to/HUBBAN` returns **HTTP 300** (TfL falls
+  back to fuzzy text matching — `HUBBAN` matched "HUBBARD DRIVE" in
+  Kingston), which propagated as an uncaught `TflClientError` and crashed
+  the whole chat stream.
+- `/StopPoint/HUBBAN/Arrivals` returns **0 predictions**.
+
+The concrete child NaPTAN (e.g. `940GZZLUBNK`, Bank Underground) works for
+both endpoints. A hub's `/StopPoint/{id}` payload lists those children
+with their transport `modes`, so the resolver can dereference a hub to a
+concrete rail platform — but `TflStopPoint` did not model `children`.
+
+## Decision
+
+Extend the tier-1 contract in `contracts/schemas/tfl_api.py`:
+
+- Add `TflStopPointChild { naptan_id: str, modes: list[str] = [] }`.
+- Add `children: list[TflStopPointChild] = []` to `TflStopPoint`
+  (additive, default-empty, reusing `_tfl_model_config()`).
+
+`resolve_name` dereferences a hub top-match by fetching `/StopPoint/{hub}`
+and picking the highest-priority rail child by mode
+(`tube > elizabeth-line > dlr > overground > national-rail`), falling back
+to the hub id when no rail child is found. The journey/arrivals agent
+tools additionally wrap their TfL calls so an uncaught upstream error can
+never again crash the LangGraph stream (LangGraph's
+`_default_handle_tool_errors` re-raises non-`ToolException` errors).
+
+## Consequences
+
+- **Additive only.** Existing consumers (the reverse `resolve_naptans`
+  fallback reads only `common_name`) are unaffected; `children` defaults
+  to empty. No tier-2 Kafka, OpenAPI, SQL, or dbt-source change → the CI
+  source-mirror diff gate is untouched.
+- One extra `/StopPoint/{hub}` call per *uncached* hub-name resolution;
+  the existing `_NAME_CACHE` absorbs repeats, and non-hub names take no
+  extra call.
+- Child selection is a deterministic mode-priority heuristic, not an LLM
+  call — cheaper and not prone to NaPTAN hallucination. Revisit if a hub
+  ever lacks a rail child that callers expect (then the resolver returns
+  the hub id and the tool degrades with a friendly message).

--- a/contracts/schemas/tfl_api.py
+++ b/contracts/schemas/tfl_api.py
@@ -79,19 +79,36 @@ class TflLineResponse(BaseModel):
     line_statuses: list[TflLineStatusItem] = Field(default_factory=list)
 
 
+class TflStopPointChild(BaseModel):
+    """Constituent stop nested under a ``/StopPoint/{id}`` hub.
+
+    Hub stop points (ids prefixed ``HUB``) group several physical
+    stations; each child carries its own NaPTAN and transport modes,
+    which the forward resolver uses to pick a concrete rail platform a
+    hub id cannot stand in for on journey/arrival endpoints.
+    """
+
+    model_config = _tfl_model_config()
+
+    naptan_id: str
+    modes: list[str] = Field(default_factory=list)
+
+
 class TflStopPoint(BaseModel):
     """Stop-point record returned by ``/StopPoint/{naptan_id}``.
 
     Used by the station resolver fallback when a NaPTAN code surfaced
     in a disruption payload is not present in the static dim_stations
-    seed (e.g. bus stops, deprecated rail entries). Only the two fields
-    the resolver needs are typed; the rest of the payload is ignored.
+    seed (e.g. bus stops, deprecated rail entries), and to dereference a
+    hub id to a concrete rail child. Only the fields the resolver needs
+    are typed; the rest of the payload is ignored.
     """
 
     model_config = _tfl_model_config()
 
     naptan_id: str
     common_name: str
+    children: list[TflStopPointChild] = Field(default_factory=list)
 
 
 class TflArrivalPrediction(BaseModel):

--- a/src/api/agent/tools.py
+++ b/src/api/agent/tools.py
@@ -237,11 +237,22 @@ def make_tools(
                         f"Couldn't understand the departure time '{departure_time}'. "
                         "Use an ISO time like 2026-05-27T09:00, or omit it to leave now."
                     )
-                journeys = await tfl_client.plan_journey(
-                    origin_id,
-                    destination_id,
-                    departure_time=parsed_departure,
-                )
+                try:
+                    journeys = await tfl_client.plan_journey(
+                        origin_id,
+                        destination_id,
+                        departure_time=parsed_departure,
+                    )
+                except Exception:  # noqa: BLE001 - never let an upstream error crash the stream
+                    logfire.exception(
+                        "agent.tool.plan_journey_failed",
+                        origin=origin,
+                        destination=destination,
+                    )
+                    return (
+                        f"Sorry, I couldn't plan a journey from '{origin}' "
+                        f"to '{destination}' right now."
+                    )
                 if not journeys:
                     return f"No journeys found from '{origin}' to '{destination}'."
                 best = journeys[0]
@@ -271,7 +282,11 @@ def make_tools(
                 stop_id = await resolve_name(tfl_client=tfl_client, query=stop)
                 if stop_id is None:
                     return f"Couldn't find stop '{stop}'."
-                predictions = await tfl_client.fetch_arrivals(stop_id)
+                try:
+                    predictions = await tfl_client.fetch_arrivals(stop_id)
+                except Exception:  # noqa: BLE001 - never let an upstream error crash the stream
+                    logfire.exception("agent.tool.get_arrivals_failed", stop=stop)
+                    return f"Sorry, I couldn't fetch arrivals for '{stop}' right now."
                 if not predictions:
                     return f"No arrivals found for '{stop}'."
                 grouped: dict[str, list[Any]] = {}

--- a/src/api/stations.py
+++ b/src/api/stations.py
@@ -19,6 +19,7 @@ import logfire
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 
+from contracts.schemas.tfl_api import TflStopPoint
 from ingestion.tfl_client.client import TflClient, TflClientError
 
 # Process-lifetime cache mapping NaPTAN → resolved name. ``None`` value
@@ -35,6 +36,12 @@ _NAPTAN_CACHE: dict[str, str | None] = {}
 # eviction to keep memory flat under high-cardinality chat traffic.
 _NAME_CACHE: dict[str, str | None] = {}
 _NAME_CACHE_MAX: Final = 512
+
+# TfL Search ranks a hub id (prefixed ``HUB``) top for major interchanges,
+# but a hub id is not a usable journey/arrival endpoint — it must be
+# dereferenced to a concrete rail child, preferred by this mode order.
+_HUB_PREFIX: Final = "HUB"
+_RAIL_MODE_PRIORITY: Final = ("tube", "elizabeth-line", "dlr", "overground", "national-rail")
 
 # Cap concurrent in-flight TfL lookups across all requests when several
 # NaPTANs miss the seed at the same time. The free-tier TfL rate limit
@@ -214,7 +221,35 @@ async def resolve_name(*, tfl_client: TflClient | None, query: str) -> str | Non
             return None
 
     resolved = response.matches[0].id if response.matches else None
+    if resolved is not None and resolved.startswith(_HUB_PREFIX):
+        resolved = await _deref_hub(tfl_client, resolved)
     if len(_NAME_CACHE) >= _NAME_CACHE_MAX:
         _NAME_CACHE.pop(next(iter(_NAME_CACHE)))
     _NAME_CACHE[cache_key] = resolved
     return resolved
+
+
+async def _deref_hub(tfl_client: TflClient, hub_id: str) -> str:
+    """Resolve a hub id to a concrete rail child NaPTAN.
+
+    Hub ids (``HUB*``) are rejected by journey planning and return no
+    arrivals, so fetch the hub stop point and pick the highest-priority
+    rail child. Falls back to the hub id when the lookup fails or the hub
+    exposes no rail child.
+    """
+    try:
+        async with _get_tfl_semaphore():
+            stop_point = await tfl_client.fetch_stop_point(hub_id)
+    except Exception:
+        logfire.exception("stations.hub_deref_failed", hub_id=hub_id)
+        return hub_id
+    return _pick_rail_child(stop_point) or hub_id
+
+
+def _pick_rail_child(stop_point: TflStopPoint) -> str | None:
+    """Return the NaPTAN of the highest-priority rail child, or ``None``."""
+    for mode in _RAIL_MODE_PRIORITY:
+        for child in stop_point.children:
+            if mode in child.modes:
+                return child.naptan_id
+    return None

--- a/src/api/stations.py
+++ b/src/api/stations.py
@@ -222,7 +222,15 @@ async def resolve_name(*, tfl_client: TflClient | None, query: str) -> str | Non
 
     resolved = response.matches[0].id if response.matches else None
     if resolved is not None and resolved.startswith(_HUB_PREFIX):
-        resolved = await _deref_hub(tfl_client, resolved)
+        try:
+            resolved = await _deref_hub(tfl_client, resolved)
+        except Exception:
+            # A transient hub lookup failure must NOT be cached: return the
+            # unusable hub id for this call but leave the cache untouched so
+            # the next request retries the dereference (mirrors the reverse
+            # resolver's "don't poison the cache on a hiccup" stance).
+            logfire.exception("stations.hub_deref_failed", hub_id=resolved)
+            return resolved
     if len(_NAME_CACHE) >= _NAME_CACHE_MAX:
         _NAME_CACHE.pop(next(iter(_NAME_CACHE)))
     _NAME_CACHE[cache_key] = resolved
@@ -234,15 +242,12 @@ async def _deref_hub(tfl_client: TflClient, hub_id: str) -> str:
 
     Hub ids (``HUB*``) are rejected by journey planning and return no
     arrivals, so fetch the hub stop point and pick the highest-priority
-    rail child. Falls back to the hub id when the lookup fails or the hub
-    exposes no rail child.
+    rail child. Returns the hub id unchanged when the hub exposes no rail
+    child (a definitive result, safe to cache). Propagates the underlying
+    error on a transient lookup failure so the caller can avoid caching.
     """
-    try:
-        async with _get_tfl_semaphore():
-            stop_point = await tfl_client.fetch_stop_point(hub_id)
-    except Exception:
-        logfire.exception("stations.hub_deref_failed", hub_id=hub_id)
-        return hub_id
+    async with _get_tfl_semaphore():
+        stop_point = await tfl_client.fetch_stop_point(hub_id)
     return _pick_rail_child(stop_point) or hub_id
 
 

--- a/tests/agent/test_journey_tools.py
+++ b/tests/agent/test_journey_tools.py
@@ -17,6 +17,7 @@ from contracts.schemas.tfl_api import (
     TflJourneyMode,
     TflJourneyResult,
 )
+from ingestion.tfl_client.client import TflClientError
 
 
 @dataclass
@@ -27,6 +28,8 @@ class FakeTflClient:
     arrivals: list[TflArrivalPrediction] = field(default_factory=list)
     plan_calls: list[tuple[str, str]] = field(default_factory=list)
     arrival_calls: list[str] = field(default_factory=list)
+    raise_on_plan: bool = False
+    raise_on_arrivals: bool = False
 
     async def plan_journey(
         self,
@@ -37,10 +40,14 @@ class FakeTflClient:
         modes: Any = None,
     ) -> list[TflJourneyResult]:
         self.plan_calls.append((from_id, to_id))
+        if self.raise_on_plan:
+            raise TflClientError("upstream journey failure")
         return self.journeys
 
     async def fetch_arrivals(self, stop_id: str) -> list[TflArrivalPrediction]:
         self.arrival_calls.append(stop_id)
+        if self.raise_on_arrivals:
+            raise TflClientError("upstream arrivals failure")
         return self.arrivals
 
 
@@ -197,3 +204,31 @@ async def test_get_arrivals_unresolved_stop(monkeypatch: pytest.MonkeyPatch) -> 
     assert isinstance(result, str)
     assert "Mordor" in result
     assert client.arrival_calls == []
+
+
+@pytest.mark.asyncio
+async def test_plan_journey_upstream_error_returns_message_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_resolver(monkeypatch, {"oxford circus": "940GZZLUOXC", "bank": "940GZZLUBNK"})
+    client = FakeTflClient(raise_on_plan=True)
+    tool = _tool(client, "plan_journey_tool")
+
+    result = await tool.ainvoke({"origin": "Oxford Circus", "destination": "Bank"})
+
+    assert isinstance(result, str)  # swallowed → friendly string, never propagates
+    assert "couldn't plan" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_arrivals_upstream_error_returns_message_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_resolver(monkeypatch, {"bank": "940GZZLUBNK"})
+    client = FakeTflClient(raise_on_arrivals=True)
+    tool = _tool(client, "get_arrivals_tool")
+
+    result = await tool.ainvoke({"stop": "Bank"})
+
+    assert isinstance(result, str)
+    assert "couldn't fetch arrivals" in result.lower()

--- a/tests/api/test_stations.py
+++ b/tests/api/test_stations.py
@@ -36,7 +36,7 @@ class FakeSearchClient:
     fail_times: int = 0
     calls: list[str] = field(default_factory=list)
     hub_children: dict[str, list[tuple[str, list[str]]]] = field(default_factory=dict)
-    hub_fail: set[str] = field(default_factory=set)
+    hub_fail_times: int = 0
     stop_point_calls: list[str] = field(default_factory=list)
 
     async def search_stop(self, query: str) -> TflStopSearchResponse:
@@ -48,8 +48,8 @@ class FakeSearchClient:
 
     async def fetch_stop_point(self, naptan_id: str) -> TflStopPoint:
         self.stop_point_calls.append(naptan_id)
-        if naptan_id in self.hub_fail:
-            raise TflClientError(f"hub lookup failed for {naptan_id}")
+        if len(self.stop_point_calls) <= self.hub_fail_times:
+            raise TflClientError(f"transient hub lookup failure for {naptan_id}")
         children = [
             TflStopPointChild(naptan_id=nid, modes=modes)
             for nid, modes in self.hub_children.get(naptan_id, [])
@@ -389,27 +389,38 @@ async def test_resolve_name_hub_prefers_mode_priority_order() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolve_name_hub_without_rail_child_falls_back_to_hub_id() -> None:
+async def test_resolve_name_hub_without_rail_child_caches_hub_id() -> None:
     client = FakeSearchClient(
         {"some hub": ["HUBXXX"]},
         hub_children={"HUBXXX": [("490G00001", ["bus"])]},
     )
 
-    resolved = await stations.resolve_name(tfl_client=client, query="some hub")  # type: ignore[arg-type]
+    first = await stations.resolve_name(tfl_client=client, query="some hub")  # type: ignore[arg-type]
+    second = await stations.resolve_name(tfl_client=client, query="some hub")  # type: ignore[arg-type]
 
-    assert resolved == "HUBXXX"  # no rail child → hub id retained
+    assert first == "HUBXXX"  # no rail child → hub id retained
+    assert second == "HUBXXX"
+    # A fetch that succeeds with no rail child is a DEFINITIVE result → cached.
+    assert client.stop_point_calls == ["HUBXXX"]
 
 
 @pytest.mark.asyncio
-async def test_resolve_name_hub_deref_failure_falls_back_to_hub_id() -> None:
+async def test_resolve_name_hub_deref_transient_failure_not_cached() -> None:
+    """A transient hub-dereference failure must not poison the cache: the
+    next request retries and resolves the concrete rail child."""
     client = FakeSearchClient(
         {"bank": ["HUBBAN"]},
-        hub_fail={"HUBBAN"},
+        hub_children={"HUBBAN": [("940GZZLUBNK", ["tube"])]},
+        hub_fail_times=1,
     )
 
-    resolved = await stations.resolve_name(tfl_client=client, query="Bank")  # type: ignore[arg-type]
+    first = await stations.resolve_name(tfl_client=client, query="Bank")  # type: ignore[arg-type]
+    second = await stations.resolve_name(tfl_client=client, query="Bank")  # type: ignore[arg-type]
 
-    assert resolved == "HUBBAN"  # transient hub lookup failure → hub id retained
+    assert first == "HUBBAN"  # deref failed transiently → unusable hub id, uncached
+    assert second == "940GZZLUBNK"  # retry succeeds → concrete rail child
+    assert client.stop_point_calls == ["HUBBAN", "HUBBAN"]  # retried, not cached
+    assert "bank" in stations._NAME_CACHE  # noqa: SLF001 - good result now cached
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_stations.py
+++ b/tests/api/test_stations.py
@@ -12,6 +12,7 @@ import pytest
 from api import stations
 from contracts.schemas.tfl_api import (
     TflStopPoint,
+    TflStopPointChild,
     TflStopSearchMatch,
     TflStopSearchResponse,
 )
@@ -20,18 +21,23 @@ from ingestion.tfl_client.client import TflClientError
 
 @dataclass
 class FakeSearchClient:
-    """Stand-in for ``TflClient`` covering ``search_stop``.
+    """Stand-in for ``TflClient`` covering ``search_stop`` + ``fetch_stop_point``.
 
     ``matches_by_query`` maps a lowercased query to the ordered ids the
     search returns (lookup mirrors TfL Search being case-insensitive);
-    ``fail_times`` raises on the first N calls to model a transient
+    ``fail_times`` raises on the first N search calls to model a transient
     upstream failure. ``calls`` records the raw query as received, so
     tests can assert the resolver preserves the caller's casing.
+    ``hub_children`` maps a hub id to ``(naptan_id, modes)`` tuples for the
+    hub-dereference path; ``hub_fail`` ids raise from ``fetch_stop_point``.
     """
 
     matches_by_query: dict[str, list[str]]
     fail_times: int = 0
     calls: list[str] = field(default_factory=list)
+    hub_children: dict[str, list[tuple[str, list[str]]]] = field(default_factory=dict)
+    hub_fail: set[str] = field(default_factory=set)
+    stop_point_calls: list[str] = field(default_factory=list)
 
     async def search_stop(self, query: str) -> TflStopSearchResponse:
         self.calls.append(query)
@@ -39,6 +45,16 @@ class FakeSearchClient:
             raise TflClientError(f"transient search failure for {query}")
         ids = self.matches_by_query.get(query.strip().lower(), [])
         return TflStopSearchResponse(matches=[TflStopSearchMatch(id=sid, name=sid) for sid in ids])
+
+    async def fetch_stop_point(self, naptan_id: str) -> TflStopPoint:
+        self.stop_point_calls.append(naptan_id)
+        if naptan_id in self.hub_fail:
+            raise TflClientError(f"hub lookup failed for {naptan_id}")
+        children = [
+            TflStopPointChild(naptan_id=nid, modes=modes)
+            for nid, modes in self.hub_children.get(naptan_id, [])
+        ]
+        return TflStopPoint(naptan_id=naptan_id, common_name=naptan_id, children=children)
 
 
 @dataclass
@@ -340,3 +356,67 @@ async def test_resolve_name_cache_is_bounded(monkeypatch: pytest.MonkeyPatch) ->
     assert len(stations._NAME_CACHE) == 2  # noqa: SLF001
     assert "a" not in stations._NAME_CACHE  # noqa: SLF001 - oldest evicted (FIFO)
     assert set(stations._NAME_CACHE) == {"b", "c"}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_dereferences_hub_to_rail_child() -> None:
+    client = FakeSearchClient(
+        {"bank": ["HUBBAN", "940GZZLUEMB"]},
+        hub_children={"HUBBAN": [("940GZZDLBNK", ["dlr"]), ("940GZZLUBNK", ["tube"])]},
+    )
+
+    resolved = await stations.resolve_name(tfl_client=client, query="Bank")  # type: ignore[arg-type]
+
+    assert resolved == "940GZZLUBNK"  # tube preferred over dlr
+    assert client.stop_point_calls == ["HUBBAN"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_hub_prefers_mode_priority_order() -> None:
+    client = FakeSearchClient(
+        {"paddington": ["HUBPAD"]},
+        hub_children={
+            "HUBPAD": [
+                ("910GPADTON", ["elizabeth-line", "national-rail"]),
+                ("940GZZLUPAC", ["tube"]),
+            ]
+        },
+    )
+
+    resolved = await stations.resolve_name(tfl_client=client, query="Paddington")  # type: ignore[arg-type]
+
+    assert resolved == "940GZZLUPAC"  # tube outranks elizabeth-line despite listing order
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_hub_without_rail_child_falls_back_to_hub_id() -> None:
+    client = FakeSearchClient(
+        {"some hub": ["HUBXXX"]},
+        hub_children={"HUBXXX": [("490G00001", ["bus"])]},
+    )
+
+    resolved = await stations.resolve_name(tfl_client=client, query="some hub")  # type: ignore[arg-type]
+
+    assert resolved == "HUBXXX"  # no rail child → hub id retained
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_hub_deref_failure_falls_back_to_hub_id() -> None:
+    client = FakeSearchClient(
+        {"bank": ["HUBBAN"]},
+        hub_fail={"HUBBAN"},
+    )
+
+    resolved = await stations.resolve_name(tfl_client=client, query="Bank")  # type: ignore[arg-type]
+
+    assert resolved == "HUBBAN"  # transient hub lookup failure → hub id retained
+
+
+@pytest.mark.asyncio
+async def test_resolve_name_non_hub_match_skips_deref() -> None:
+    client = FakeSearchClient({"oxford circus": ["940GZZLUOXC"]})
+
+    resolved = await stations.resolve_name(tfl_client=client, query="Oxford Circus")  # type: ignore[arg-type]
+
+    assert resolved == "940GZZLUOXC"
+    assert client.stop_point_calls == []  # concrete NaPTAN needs no dereference

--- a/tests/fixtures/tfl/stop_point_hub_bank.json
+++ b/tests/fixtures/tfl/stop_point_hub_bank.json
@@ -1,0 +1,30 @@
+{
+  "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+  "naptanId": "HUBBAN",
+  "commonName": "Bank",
+  "stopType": "TransportInterchange",
+  "modes": ["bus", "dlr", "tube"],
+  "children": [
+    {
+      "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+      "naptanId": "490G00007599",
+      "commonName": "Bank Station / Poultry",
+      "stopType": "NaptanOnstreetBusCoachStopPair",
+      "modes": ["bus"]
+    },
+    {
+      "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+      "naptanId": "940GZZDLBNK",
+      "commonName": "Bank DLR Station",
+      "stopType": "NaptanMetroStation",
+      "modes": ["dlr"]
+    },
+    {
+      "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+      "naptanId": "940GZZLUBNK",
+      "commonName": "Bank Underground Station",
+      "stopType": "NaptanMetroStation",
+      "modes": ["tube"]
+    }
+  ]
+}

--- a/tests/ingestion/conftest.py
+++ b/tests/ingestion/conftest.py
@@ -50,6 +50,11 @@ def stop_search_oxford_circus_fixture() -> dict[str, Any]:
 
 
 @pytest.fixture
+def stop_point_hub_bank_fixture() -> dict[str, Any]:
+    return _load_obj("stop_point_hub_bank.json")
+
+
+@pytest.fixture
 def line_status_tube_detailed_fixture() -> list[dict[str, Any]]:
     """``/Line/Mode/tube/Status?detail=true`` response with nested disruptions.
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -30,7 +30,11 @@ from contracts.schemas import (
     TflLineResponse,
     TransportMode,
 )
-from contracts.schemas.tfl_api import TflJourneyResult, TflStopSearchResponse
+from contracts.schemas.tfl_api import (
+    TflJourneyResult,
+    TflStopPoint,
+    TflStopSearchResponse,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -86,6 +90,19 @@ def test_stop_search_fixture_parses_matches() -> None:
 
     assert [match.id for match in response.matches] == ["940GZZLUOXC", "490G00251P"]
     assert response.matches[0].modes == ["tube"]
+
+
+def test_hub_stop_point_fixture_parses_children_with_modes() -> None:
+    hub = TflStopPoint.model_validate(_load_tfl_object("stop_point_hub_bank.json"))
+
+    assert hub.naptan_id == "HUBBAN"
+    assert {child.naptan_id for child in hub.children} == {
+        "490G00007599",
+        "940GZZDLBNK",
+        "940GZZLUBNK",
+    }
+    tube_child = next(c for c in hub.children if "tube" in c.modes)
+    assert tube_child.naptan_id == "940GZZLUBNK"
 
 
 # ---------- Tier-2: internal Kafka event contracts ----------


### PR DESCRIPTION
## Summary
Follow-up fix for the TM-30 journey/arrivals tools (PR #122), found by running the manual chat smokes against the live agent.

**Root cause:** for major interchanges (Bank, King's Cross, Paddington, Victoria, …) TfL `/StopPoint/Search` ranks a **hub id** (`HUB*`, e.g. `HUBBAN`) as the top match, and a hub id is not a usable endpoint:
- `/Journey/JourneyResults/.../to/HUBBAN` → **HTTP 300** (TfL fuzzy-matched `HUBBAN` to "HUBBARD DRIVE"), which propagated as an uncaught `TflClientError` and **crashed the whole chat stream** (`end:error`).
- `/StopPoint/HUBBAN/Arrivals` → **0 predictions** (silently wrong).

## Changes
- `stations.resolve_name` dereferences a hub top-match via `/StopPoint/{hub}` and picks the highest-priority **rail child** by mode (`tube > elizabeth-line > dlr > overground > national-rail`), falling back to the hub id when the lookup fails or no rail child exists.
- `TflStopPoint` gains `children: list[TflStopPointChild]` (additive tier-1 contract) — **[ADR 010](.claude/adrs/010-tfl-hub-children.md)**, `contract:` prefix per AGENTS.md.
- `plan_journey_tool` / `get_arrivals_tool` wrap their TfL calls so an uncaught upstream error returns a friendly message instead of crashing the stream. **This reverses the PR #122 rejection of Gemini's "unhandled exceptions in tools" comments — that rejection was wrong:** LangGraph's `_default_handle_tool_errors` re-raises non-`ToolException` errors.

## Verification
- [x] `uv run task lint` · `uv run task test` (365 passed, +8) · `uv run bandit -r src --severity-level high` · `make check`
- [x] **Live agent smoke (Bedrock + real TfL):** "plan a journey from Oxford Circus to Bank" → `plan_journey_tool`, narrates Central line 7 min (no crash); "next arrivals at Bank" → `get_arrivals_tool`, real platforms. Both previously crashed / returned empty.

Follow-up to TM-30 (#103).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed crashes when searching for London transport hub interchanges
  * Journey planning and arrivals tools now return user-friendly error messages instead of crashing on upstream API failures

* **Documentation**
  * Added architecture decision record documenting hub identifier resolution strategy

* **Tests**
  * Enhanced test coverage for hub dereferencing scenarios
  * Added test fixtures for transport hub stop points

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->