### PR TITLE
docs: sync mkdocs site with live-proxy architecture (TM-35)

### DIFF
--- a/.claude/specs/TM-35-plan.md
+++ b/.claude/specs/TM-35-plan.md
@@ -1,0 +1,55 @@
+# TM-35 — Sync mkdocs site with live-proxy architecture (ADR 014)
+
+Docs-only sweep. The published site under `docs/` still documents the streaming
+pipeline removed by ADR 014 (Kafka/Redpanda broker, producers/consumers, the
+`raw.*` warehouse with staging/marts, and the `/reliability`, `/status/history`,
+`/bus` endpoints). TM-34 already fixed `docs/stack.md`, `docs/adrs.md`, and the
+package READMEs; this WP closes the rest.
+
+## Source of truth
+
+ADR 014 (`.claude/adrs/014-decommission-warehouse-live-proxy.md`, supersedes 001
++ 005). The app is a **live TfL proxy + RAG chat**:
+
+- `GET /api/v1/status/live` → TfL `/Line/Mode/{modes}/Status` via `TflClient`.
+- `GET /api/v1/disruptions/recent` → TfL `/Line/Mode/{modes}/Status?detail=true`.
+- Chat agent tools: `query_tube_status`, `query_recent_disruptions`,
+  `search_tfl_docs` (RAG), `plan_journey_tool`, `get_arrivals_tool`, plus the
+  `stations` resolver / search. **No** `query_line_reliability`,
+  `query_bus_punctuality`.
+- Postgres holds only: pgvector RAG store, `analytics.chat_messages`,
+  `ref.lines`, `ref.stations`, `analytics.dim_stations`. No `raw.*`, no
+  staging/marts. dbt = seeds + `dim_stations` model, built one-shot on deploy.
+- No broker. RAG ingest is host cron (not Airflow — removed ADR 008).
+
+## Decisions (author-confirmed)
+
+1. Rewrite the two dead pages in-place (keep URLs + nav slots):
+   - `pipelines/ingestion.md` "Streaming ingestion" → "Live TfL proxy".
+   - `pipelines/warehouse.md` "dbt warehouse" → "Reference data" (seeds +
+     `dim_stations`).
+2. Tracked as its own Linear issue TM-35; standalone docs-only PR.
+
+## Files
+
+Rewrite: `architecture.md`, `pipelines/ingestion.md`, `pipelines/warehouse.md`.
+Surgical: `index.md`, `engineering.md`, `observability.md`, `roadmap.md`,
+`glossary.md`, `deployment.md`, `pipelines/{index,agent,api,rag,frontend}.md`,
+`mkdocs.yml` (`site_description` + nav labels).
+Leave: `stack.md`, `adrs.md` (already correct); `docs/superpowers/*`
+(point-in-time design docs, outside nav).
+
+## Acceptance
+
+- `uv run task docs-build` (`mkdocs build --strict`) passes.
+- No residual reference to Kafka/Redpanda/broker/producer/consumer/`raw.*`/
+  staging/marts or the `/reliability`//`/status/history`//`/bus` endpoints in any
+  nav page (grep clean).
+- `make check` green; PR opened referencing TM-35.
+
+## What we're NOT doing
+
+- No README / demo video (that stays TM-F1).
+- No nav-page deletions or new pages.
+- No code, contract, or dbt changes — docs only.
+- No edits to `docs/superpowers/*` historical artifacts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,9 @@
 # Architecture
 
-A bird's-eye view of how data flows from TfL into the dashboard, with every
-component pinned to a directory in the repo.
+A bird's-eye view of how a request flows from the dashboard to TfL and back,
+with every component pinned to a directory in the repo. The app is a **live TfL
+proxy + RAG chat** — it reads through to TfL on demand and serves a LangGraph
+agent over TfL strategy documents (ADR 014; no broker, no feed warehouse).
 
 ## System diagram
 
@@ -12,36 +14,21 @@ flowchart LR
       PDF[TfL strategy PDFs]
     end
 
-    subgraph INGEST[Streaming ingestion]
-      P1[line-status producer]
-      P2[arrivals producer]
-      P3[disruptions producer]
-      KAFKA[(Redpanda<br/>Kafka topics)]
-      C1[line-status consumer]
-      C2[arrivals consumer]
-      C3[disruptions consumer]
-    end
-
-    subgraph WAREHOUSE[Postgres warehouse]
-      RAW[(raw.*<br/>JSONB)]
-      ANALYTICS[(analytics.*<br/>marts)]
-    end
-
-    subgraph DBT[dbt transformations]
-      STG[staging]
-      MART[marts + exposures]
-    end
-
-    subgraph RAG[RAG layer]
-      DOCLING[Docling parser]
-      EMB[OpenAI embeddings]
-      PINE[(Pinecone<br/>tfl-strategy-docs)]
-    end
-
     subgraph SERVE[Serving layer]
+      CLIENT[TflClient<br/>httpx + retry]
       AGENT[LangGraph agent<br/>5 typed tools]
-      API[FastAPI<br/>/status /reliability<br/>/disruptions /bus<br/>/chat/stream SSE]
+      API[FastAPI<br/>/status/live /disruptions/recent<br/>/chat/stream SSE]
       WEB[Next.js dashboard]
+    end
+
+    subgraph DATA[Postgres + pgvector]
+      PG[(ref.* seeds<br/>analytics.dim_stations<br/>analytics.chat_messages)]
+      VEC[(pgvector<br/>tfl_strategy_docs)]
+    end
+
+    subgraph RAG[RAG ingestion · off-box]
+      PYMU[PyMuPDF parse]
+      EMB[Bedrock Titan v2]
     end
 
     subgraph OBS[Observability]
@@ -49,124 +36,97 @@ flowchart LR
       LF[Logfire]
     end
 
-    TFL -->|httpx async polling| P1
-    TFL -->|httpx async polling| P2
-    TFL -->|httpx async polling| P3
-    P1 -->|Pydantic event| KAFKA
-    P2 -->|Pydantic event| KAFKA
-    P3 -->|Pydantic event| KAFKA
-    KAFKA --> C1 --> RAW
-    KAFKA --> C2 --> RAW
-    KAFKA --> C3 --> RAW
-    RAW --> STG --> MART --> ANALYTICS
-    PDF --> DOCLING --> EMB --> PINE
-    ANALYTICS --> AGENT
-    PINE --> AGENT
+    TFL -->|httpx on demand| CLIENT
+    CLIENT --> API
+    CLIENT --> AGENT
+    VEC --> AGENT
+    PG --> API
     AGENT --> API
     API -->|REST + SSE| WEB
 
+    PDF --> PYMU --> EMB --> VEC
+
     AGENT -.traces.-> LS
     API -.spans.-> LF
-    INGEST -.spans.-> LF
-    WAREHOUSE -.queries.-> LF
+    CLIENT -.spans.-> LF
 ```
 
 ## Component-to-directory map
 
 | Layer | Directory | Runtime |
 |-------|-----------|---------|
-| Async TfL client | [`src/ingestion/tfl_client/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/ingestion/tfl_client) | Python 3.12 |
-| Producers (×3) | [`src/ingestion/producers/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/ingestion/producers) | aiokafka |
-| Consumers (×3) | [`src/ingestion/consumers/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/ingestion/consumers) | aiokafka + psycopg |
-| Broker | [`docker-compose.yml`](https://github.com/hcslomeu/tfl-monitor/blob/main/docker-compose.yml) | Redpanda local; Redpanda Cloud prod |
-| Warehouse | `raw.*`, `ref.*`, `analytics.*` schemas | Postgres 16 / Supabase |
-| dbt project | [`dbt/`](https://github.com/hcslomeu/tfl-monitor/tree/main/dbt) | dbt-core 1.9 |
-| Orchestration | [`airflow/dags/`](https://github.com/hcslomeu/tfl-monitor/tree/main/airflow/dags) | Airflow 2.10 LocalExecutor |
-| RAG ingestion | [`src/rag/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/rag) | Docling + OpenAI + Pinecone |
+| Async TfL client | [`src/ingestion/tfl_client/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/ingestion/tfl_client) | Python 3.12 · httpx |
+| Read-through endpoints | [`src/api/live.py`](https://github.com/hcslomeu/tfl-monitor/blob/main/src/api/live.py) | FastAPI |
+| Station resolver | [`src/api/stations.py`](https://github.com/hcslomeu/tfl-monitor/blob/main/src/api/stations.py) | psycopg + TfL fallback |
+| dbt project (seed + `dim_stations`) | [`dbt/`](https://github.com/hcslomeu/tfl-monitor/tree/main/dbt) | dbt-core + dbt-postgres |
+| RAG ingestion | [`src/rag/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/rag) | PyMuPDF + Bedrock Titan + pgvector |
 | Agent | [`src/api/agent/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/api/agent) | LangGraph + Pydantic AI |
 | API | [`src/api/`](https://github.com/hcslomeu/tfl-monitor/tree/main/src/api) | FastAPI + sse-starlette |
 | Frontend | [`web/`](https://github.com/hcslomeu/tfl-monitor/tree/main/web) | Next.js 16 + shadcn |
 | Contracts | [`contracts/`](https://github.com/hcslomeu/tfl-monitor/tree/main/contracts) | OpenAPI + Pydantic + SQL DDL |
+| Deploy | [`infra/`](https://github.com/hcslomeu/tfl-monitor/tree/main/infra) | docker compose on shared Lightsail |
 
 ## Data flow walkthrough
 
-### 1. Producers poll TfL and emit Pydantic events
+### 1. The API reads TfL on demand
 
-Each producer is an async daemon that wakes on a fixed cadence
-(`LineStatusProducer` every 30 s, `ArrivalsProducer` every 30 s across 5 NaPTAN
-hubs, `DisruptionsProducer` every 300 s across 4 modes), normalises the tier-1
-TfL payload into a tier-2 [Pydantic event](pipelines/ingestion.md#contracts),
-and publishes to Kafka with `acks="all"` and a stable partition key.
+`/status/live` and `/disruptions/recent` call `TflClient` directly
+(`src/api/live.py`), normalise the tier-1 payload into the tier-2 response
+shape, and return it. Nothing is persisted; an upstream failure surfaces as
+RFC 7807 `502`. See [Live TfL proxy](pipelines/ingestion.md).
 
-### 2. Consumers idempotently land into `raw.*`
+### 2. Reference data is a static dbt layer
 
-`RawEventConsumer[E]` is generic over the event type; `RawEventWriter(table)`
-runs `INSERT … ON CONFLICT (event_id) DO NOTHING` over a single async psycopg
-connection with reconnect-on-`OperationalError`. Lag is traced on every span.
+The only dbt artifacts are the `tfl_stations` seed and the
+`analytics.dim_stations` mart built from it — the fast path for the NaPTAN →
+station-name resolver. Built one-shot on deploy, never on a schedule. See
+[Reference data](pipelines/warehouse.md).
 
-### 3. dbt stages and marts
-
-Staging models (`stg_line_status`, `stg_arrivals`, `stg_disruptions`) unnest
-JSONB into typed columns with defensive `row_number()` dedup. Marts are
-incremental `merge` on stable composite grains and ship with generic + singular
-tests.
-
-```mermaid
-flowchart TB
-    raw_line_status[(raw.line_status<br/>JSONB)] --> stg_line_status[stg_line_status]
-    raw_arrivals[(raw.arrivals)] --> stg_arrivals[stg_arrivals]
-    raw_disruptions[(raw.disruptions)] --> stg_disruptions[stg_disruptions]
-
-    stg_line_status --> reli_daily[mart_tube_reliability_daily]
-    reli_daily --> reli_summary[mart_tube_reliability_daily_summary]
-    stg_disruptions --> disruption_mart[mart_disruptions_daily]
-    stg_arrivals --> bus_mart[mart_bus_metrics_daily]
-```
-
-### 4. RAG ingest is conditional and idempotent
+### 3. RAG ingest is conditional and idempotent
 
 `uv run python -m rag.ingest` resolves the live PDF URL on each landing page,
-issues conditional `If-None-Match` / `If-Modified-Since` GETs, parses with
-Docling's `HybridChunker`, async-batches OpenAI embeddings (100/req, retry on
-429), and upserts into Pinecone with `sha256("{url}::{idx}")` ids — one
-namespace per document, delete-namespace-on-rollover for clean idempotency.
+issues conditional `If-None-Match` / `If-Modified-Since` GETs, extracts text
+with PyMuPDF, chunks with LlamaIndex's `SentenceSplitter`, embeds with AWS
+Bedrock Titan v2 (1024-dim), and upserts into the pgvector `tfl_strategy_docs`
+table with stable ids — keyed by `doc_id` metadata for per-document targeting.
+See [RAG ingestion](pipelines/rag.md).
 
-### 5. Agent fans out across five typed tools
+### 4. The agent fans out across five typed tools
 
 ```mermaid
 graph TD
     Q[User question] --> ROUTER{LangGraph<br/>create_react_agent}
-    ROUTER -->|live ops| T1[query_tube_status]
-    ROUTER -->|reliability| T2[query_line_reliability]
-    ROUTER -->|disruptions| T3[query_recent_disruptions]
-    ROUTER -->|bus| T4[query_bus_punctuality]
+    ROUTER -->|live status| T1[query_tube_status]
+    ROUTER -->|disruptions| T2[query_recent_disruptions]
+    ROUTER -->|journey| T3[plan_journey_tool]
+    ROUTER -->|arrivals| T4[get_arrivals_tool]
     ROUTER -->|strategy| T5[search_tfl_docs]
 
-    T1 --> WH[(warehouse)]
-    T2 --> WH
-    T3 --> WH
-    T4 --> WH
-    T5 --> PC[(Pinecone)]
-
-    T2 -.normalisation.-> PA[Pydantic AI<br/>Haiku LineId extractor]
+    T1 --> CLIENT[(TflClient → live TfL)]
+    T2 --> CLIENT
+    T3 --> CLIENT
+    T4 --> CLIENT
+    T5 --> VEC[(pgvector)]
 ```
 
-`compile_agent` returns `None` if any of `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
-/ `PINECONE_API_KEY` is missing, so `/chat/stream` 503s while the history
-endpoint keeps working off `DATABASE_URL` alone.
+The live and journey/arrivals tools register only when a `TflClient` is wired;
+`search_tfl_docs` registers only when a retriever is available. `compile_agent`
+returns `None` if the LLM credentials are missing, so `/chat/stream` 503s while
+`/chat/{thread_id}/history` keeps working off `DATABASE_URL` alone. See
+[LangGraph agent](pipelines/agent.md).
 
-### 6. SSE projection over LangGraph events
+### 5. SSE projection over LangGraph events
 
 ```mermaid
 sequenceDiagram
-  participant W as Web (chat-view)
+  participant W as Web (chat panel)
   participant A as FastAPI /chat/stream
   participant G as LangGraph
   participant DB as analytics.chat_messages
   W->>A: POST {thread_id, message}
   A->>DB: INSERT user turn
   A->>G: agent.astream(stream_mode=["messages","updates"])
-  G-->>A: token / tool / token …
+  G-->>A: token / tool / journey / arrivals …
   A-->>W: data: {"type":"token",...}\n\n
   G-->>A: end
   A->>DB: INSERT assistant turn (concatenated tokens)
@@ -183,28 +143,28 @@ graph LR
       OAPI[openapi.yaml]
       PYD[schemas/*.py]
       SQL[sql/*.sql]
-      DBTSRC[dbt_sources.yml]
     end
 
     OAPI --> WEB[web/lib/types.ts<br/>via openapi-typescript]
     OAPI --> API[FastAPI route signatures]
-    PYD --> PROD[producers]
-    PYD --> CONS[consumers]
+    PYD --> CLIENT[TflClient tier-1 / tier-2]
     SQL --> PG[Postgres DDL]
-    SQL --> DBTSRC
-    DBTSRC --> DBT[dbt sources]
 ```
 
 Two tiers of Pydantic schemas separate the messy outside world from the clean
-internal wire format — see [tier-1 vs tier-2](pipelines/ingestion.md#contracts).
+internal shape — see [tier-1 vs tier-2](pipelines/ingestion.md#contracts).
 
 ## Related ADRs
 
-The handful of cross-cutting decisions worth a paper trail:
+The cross-cutting decisions worth a paper trail (full set under
+[`.claude/adrs/`](https://github.com/hcslomeu/tfl-monitor/tree/main/.claude/adrs)):
 
-- [001 — Redpanda over Apache Kafka](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/001-redpanda-over-kafka.md)
 - [002 — Contracts-first parallelism](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/002-contracts-first.md)
-- [003 — Airflow on Railway](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/003-airflow-on-railway.md) (superseded by 006)
 - [004 — Logfire + LangSmith split](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/004-logfire-langsmith-split.md)
-- [005 — Raw-table defaults](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/005-raw-table-defaults.md)
-- 006 — AWS Bedrock + single-EC2 deploy *(landing with TM-A5)*
+- [006 — AWS Bedrock + shared-box deploy](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/006-aws-deploy.md)
+- [007 — Disruption affected-stops shape](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/007-disruption-affected-stops-shape.md)
+- [008 — Remove Airflow for SQLAlchemy 2.0](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/008-remove-airflow-for-sqlalchemy2.md)
+- [010 — TfL hub → rail-child dereference](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/010-tfl-hub-children.md)
+- [011 — Structured journey/arrivals SSE frames](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/011-structured-journey-arrivals-sse-frames.md)
+- [013 — PyMuPDF over Docling](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/013-pymupdf-over-docling.md)
+- [014 — Decommission the warehouse → live proxy](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/014-decommission-warehouse-live-proxy.md) *(supersedes 001 + 005)*

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,28 +1,30 @@
 # Deployment
 
-The production stack is intentionally minimalist: **one EC2 spot instance**
-runs the existing docker-compose layout, **AWS Bedrock** powers the LLM, and
-every other tier rides on a free plan. The full design is locked in
-[`.claude/specs/TM-A5-plan.md`](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/specs/TM-A5-plan.md).
+The production stack is intentionally minimalist: the API runs as a **single
+container on a shared AWS Lightsail box**, **AWS Bedrock** powers the LLM, and
+every other tier rides on a free plan. There is no broker and no ingestion
+worker — the app reads TfL live (ADR 014). The infra is locked in
+[`infra/README.md`](https://github.com/hcslomeu/tfl-monitor/blob/main/infra/README.md)
+and ADR 006.
 
 ## Cost lock
 
+tfl-monitor is a **second tenant** on a Lightsail box it shares with
+`alpha-whale` and future portfolio projects, so the $10/mo box splits roughly
+three ways.
+
 | Layer | Host | Tier | $/mo |
 |-------|------|------|------|
-| Backend compute | AWS EC2 t4g.small **spot** (`us-east-1`) via ASG min=max=1 | persistent spot | ~3-4 |
-| LLM | AWS Bedrock — `claude-3-5-sonnet-20241022-v2:0` + `claude-3-5-haiku-20241022-v1:0` | on-demand | ~2-3 |
-| Postgres warehouse + Airflow metadata | Supabase | free | 0 |
-| Kafka broker | Redpanda Cloud Serverless | free | 0 |
+| Backend compute | Shared AWS Lightsail (eu-west-2, 2 GB RAM, 60 GB SSD) | shared $10 box | ~3.50 effective |
+| LLM | AWS Bedrock — Claude Sonnet 4.5 + Haiku 4.5 (`eu.anthropic.*` inference profiles) | on-demand | ~2-3 |
+| Postgres + pgvector | Supabase | free | 0 |
 | Frontend | Vercel | hobby | 0 |
-| Vector DB | Pinecone serverless | free | 0 |
-| HTTPS termination | DuckDNS subdomain + Caddy auto Let's Encrypt | — | 0 |
-| Image registry | GHCR (public repo) | free | 0 |
+| HTTPS termination | shared Caddy + Let's Encrypt + Cloudflare DNS-only | — | 0 |
+| Image build | on-box `docker compose --build` | — | 0 |
 | Observability | Logfire + LangSmith | free | 0 |
-| Bandwidth (≈1 GB egress/mo) | AWS | — | ~0.10 |
-| **Steady-state target** | | | **~$5-8** |
+| **Steady-state target** | | | **~$5-7** |
 
-A CloudWatch billing alarm fires at $20/mo as the safety net (~10× the
-expected burn).
+A CloudWatch billing alarm guards the Bedrock spend.
 
 ## Topology on the box
 
@@ -30,155 +32,119 @@ expected burn).
 flowchart TB
     INET((Internet))
     INET -->|443 / 80| CADDY
-    subgraph EC2["EC2 t4g.small spot · Amazon Linux 2023 ARM64"]
+    subgraph LS["AWS Lightsail · Ubuntu 24.04 · eu-west-2 · 13.41.145.33"]
       direction TB
-      subgraph DOCKER["docker compose -f infra/docker-compose.prod.yml"]
-        CADDY[Caddy<br/>auto Let's Encrypt]
-        API[api<br/>FastAPI :8000]
-        PROD[producers<br/>3 daemons in 1 process]
-        CONS[consumers<br/>3 daemons in 1 process]
-        SCH[airflow-scheduler]
-        WEB[airflow-webserver]
+      CADDY[shared Caddy<br/>/opt/caddy/ · caddy_net]
+      subgraph INFRA["docker compose -p infra -f infra/docker-compose.prod.yml"]
+        API[api<br/>tfl-monitor-api-1 · FastAPI :8000]
       end
+      ALPHA[alpha-whale<br/>other tenant]
     end
     subgraph CLOUD[Managed services]
-      SB[(Supabase Postgres)]
-      RP[(Redpanda Cloud)]
-      PC[(Pinecone)]
+      SB[(Supabase Postgres<br/>+ pgvector)]
       BR[AWS Bedrock]
     end
     subgraph EDGE[Edge]
       VER[Vercel<br/>tfl-monitor.vercel.app]
     end
-    CADDY --> API
-    CADDY --> WEB
+    TFL[TfL Unified API]
+
+    CADDY -->|tfl-monitor-api.humbertolomeu.com| API
+    CADDY --> ALPHA
+    API -->|read-through| TFL
     API --> SB
     API --> BR
-    API --> PC
-    PROD --> RP
-    CONS --> RP
-    CONS --> SB
-    SCH --> SB
-    SCH --> RP
     VER -.fetch.-> CADDY
 ```
 
-Six long-running services on one box (down from 9 in local dev): three
-ingestion producers and three consumers each collapsed into one `asyncio.gather`
-process, plus Airflow (scheduler + webserver), the FastAPI process, and
-Caddy.
+One long-running container for tfl-monitor (`tfl-monitor-api-1`, compose project
+`infra`). The producers, consumers, broker, and Airflow that the original design
+ran are all gone (ADR 014 / ADR 008).
 
-## What changed from the original plan
+## DNS + reverse proxy
 
-The first iteration of TM-A5 targeted Railway for the backend. Two budget
-constraints flipped the design:
+- **DNS:** a Cloudflare A record `tfl-monitor-api.humbertolomeu.com` → the static
+  IP, **DNS-only** (gray cloud) — no Cloudflare proxy, no Origin Cert.
+- **TLS:** the shared Caddy at `/opt/caddy/` joins the external `caddy_net`
+  docker network and reverse-proxies the hostname to `tfl-monitor-api-1:8000`,
+  issuing a Let's Encrypt cert via HTTP-01. `infra/caddyfile.snippet` is the
+  source of truth for the tfl-monitor site block, merged once into
+  `/opt/caddy/Caddyfile`.
 
-1. The author has **$100 of AWS credit** to spread across two portfolio
-   projects, so AWS-only compute is now essentially free.
-2. Anthropic-direct API spend is real money; **Bedrock pricing** for the same
-   models lands in the same $100 credit envelope.
+SSE needs `flush_interval -1` in the Caddy site block — Caddy buffers by
+default, which times out the chat stream.
 
-Hence:
+## LLM access
 
-- Single EC2 spot replaces Railway's API + worker boxes.
-- Bedrock replaces Anthropic-direct in production (`ChatBedrockConverse` +
-  `pydantic-ai "bedrock:..."` model strings).
-- Anthropic-direct stays as an opt-in **local-dev fallback** so contributors
-  who only have an Anthropic key can still run the agent.
+AWS Bedrock cross-region inference profiles serve Claude Sonnet 4.5 (answers)
+and Haiku 4.5 (extraction), authenticated through a scoped `tfl-monitor-bedrock`
+IAM user — Lightsail has no native instance role, so the access keys live in
+`/opt/tfl-monitor/.env` (chmod 600). Anthropic-direct stays as an opt-in
+local-dev fallback for contributors who only have an Anthropic key.
 
-ADR 003 (Airflow on Railway) becomes superseded by ADR 006 (Bedrock +
-single-EC2 deploy), committed alongside TM-A5.
-
-## Provisioning runbook (high-level)
-
-The full step-by-step runbook lives in
-[`.claude/specs/TM-A5-plan.md` §3](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/specs/TM-A5-plan.md).
-
-```mermaid
-flowchart LR
-    PRE[Step 0<br/>Laptop prereqs] --> BR[Step 1<br/>Bedrock model access]
-    BR --> SAAS[Step 2<br/>Supabase + Redpanda<br/>+ Pinecone + DuckDNS]
-    SAAS --> PR1[PR-1<br/>Bedrock swap +<br/>ingestion collapse]
-    PR1 --> PR2[PR-2<br/>Terraform +<br/>compose.prod +<br/>Caddy + GHA OIDC]
-    PR2 --> FIRST[First deploy<br/>SSM session →<br/>paste .env →<br/>bootstrap]
-    FIRST --> SMOKE[Smoke<br/>curl /health<br/>/status/live<br/>/chat/stream]
-    SMOKE --> PR3[PR-3<br/>ADR 006 +<br/>doc updates]
-```
-
-## Three PRs under the TM-A5 banner
-
-| # | Branch | Tracks | Approx LoC |
-|---|--------|--------|-----------|
-| **PR-1** | `feature/TM-A5-bedrock-swap` | D-api-agent + B-ingestion (declared cross-track) | ~200 src + 80 tests |
-| **PR-2** | `feature/TM-A5-aws-deploy` | A-infra | ~450 |
-| **PR-3** | `feature/TM-A5-adr-progress` | meta (ADRs + ARCHITECTURE / README / PROGRESS) | ~250 markdown |
-
-## Image build + deploy pipeline
+## Deploy pipeline
 
 ```mermaid
 sequenceDiagram
-    participant Dev as Author push
+    participant Dev as push to main
     participant GHA as GitHub Actions
-    participant GHCR as GHCR
-    participant SSM as AWS SSM
-    participant EC2 as EC2 spot
+    participant BOX as Lightsail box
+    participant TFL as deploy.sh
 
-    Dev->>GHA: push to main
-    GHA->>GHA: matrix build (api, ingestion, airflow)
-    GHA->>GHCR: docker buildx push --platform linux/arm64
-    GHA->>SSM: aws ssm send-command (OIDC role)
-    SSM->>EC2: cd repo && docker compose pull && up -d
-    EC2-->>Dev: services restart, health checks pass
+    Dev->>GHA: push (backend paths only)
+    GHA->>BOX: rsync source (pinned host key)
+    GHA->>BOX: ssh (keepalive) → bash scripts/deploy.sh
+    TFL->>TFL: docker compose -p infra up -d --build
+    TFL->>TFL: internal + external healthcheck
+    TFL->>TFL: one-shot dbt seed + dim_stations build
+    BOX-->>Dev: /health 200
 ```
 
-Authentication chain:
+`.github/workflows/deploy.yml` triggers on push to `main`, ignoring
+markdown / `web/` / `.claude/` / `docs/` changes. Hardening learned the hard way
+(see the napkin): `set -o pipefail` through every pipe so `docker compose … | tail`
+can't mask a build failure; `ssh -o ServerAliveInterval=60` so buildkit's silent
+unpack phase doesn't drop the connection; a pinned `LIGHTSAIL_HOST_KEY` to close
+the keyscan TOFU window.
 
-1. GitHub OIDC token → IAM role with `ssm:SendCommand`.
-2. EC2 instance profile with `bedrock:InvokeModel*` scoped to the two model
-   ARNs only — no AWS access keys live anywhere on disk.
-3. GHCR pull on the box uses a short-lived `read:packages` PAT pasted once
-   into `.env`.
+`scripts/deploy.sh` also removes any legacy cron schedule (ADR 014 dropped the
+recurring dbt + retention cron) and runs a **one-shot** `dbt seed` +
+`dim_stations` build after the health check — non-fatal, because the
+station-name resolver falls back to a live TfL `/StopPoint` lookup when
+`dim_stations` is absent.
 
-## Reverse proxy + TLS
+## Operations
 
-```caddy
-{
-    email tflmonitor@example.com
-}
+| Action | Command |
+|--------|---------|
+| SSH to the box | `ssh ubuntu@13.41.145.33` |
+| Public smoke | `curl -fsS https://tfl-monitor-api.humbertolomeu.com/health` |
+| Recreate the API container | `cd /opt/tfl-monitor && docker compose -p infra -f infra/docker-compose.prod.yml up -d --force-recreate` |
+| Manual dbt rebuild | `ssh ubuntu@13.41.145.33 '/opt/tfl-monitor/scripts/cron-dbt-run.sh'` |
+| Reload Caddy | `docker exec shared-caddy caddy reload --config /etc/caddy/Caddyfile` |
 
-tflmonitor.duckdns.org {
-    handle_path /airflow* {
-        reverse_proxy airflow-webserver:8080
-    }
-    reverse_proxy api:8000 {
-        flush_interval -1   # disable buffering for SSE
-    }
-}
-```
+!!! warning "Shared box etiquette"
+    The box is a noisy-neighbour to two other tenants on 2 GB of RAM. Never run
+    a multi-GB-RAM job (RAG ingest, torch) on it — that OOMs the guest kernel and
+    takes every tenant down. Run RAG ingest off-box against the same Supabase
+    pgvector DSN. Use the `-p infra` project name for every compose op so it
+    targets `tfl-monitor-api-1` and not the local-dev stack.
 
-`flush_interval -1` is the difference between SSE working and timing out —
-Caddy buffers by default, which breaks the chat stream.
+## What changed from the original plan
 
-DuckDNS keeps `tflmonitor.duckdns.org` pointed at the EIP via a 5-minute cron
-on the box. Re-pointing to a custom domain in TM-F1 is one Caddyfile line.
+The first TM-A5 iteration targeted a dedicated EC2 spot box on DuckDNS with a
+full 6-service compose (producers, consumers, Airflow). Two shifts collapsed it:
 
-## Disaster scenarios
-
-| Risk | Response |
-|------|----------|
-| Spot interruption | ASG re-launches on `persistent` spot; ~5 min downtime per event, ~1-2× / week |
-| EBS volume loss on spot reclaim | `delete_on_termination = false` preserves the volume; ASG re-attaches |
-| Bedrock model access denied | Fall back to Anthropic-direct via `.env` (`unset BEDROCK_REGION` + set `ANTHROPIC_API_KEY`) |
-| RAM saturation on t4g.small | Drop Airflow webserver (CLI-only operations) — saves ~250 MB |
-| Free-tier expiry on Supabase / Redpanda / Pinecone | All three are indefinite at portfolio scale; documented limits in README |
-| Bedrock cost spike | CloudWatch billing alarm @ $20/mo notifies via SNS |
+1. An existing 2 GB Lightsail box had spare capacity, so tfl-monitor became a
+   second tenant behind a shared Caddy — cheaper than a dedicated instance
+   (ADR 006 supersedes ADR 003).
+2. ADR 014 removed the broker, ingestion workers, and warehouse entirely, so the
+   box now runs a single API container reading TfL live.
 
 ## Rollback paths
 
-Three granularities:
-
-1. **Per-image** — `docker compose pull` against a previous SHA tag (GHCR
-   retains all SHA tags).
-2. **Per-PR** — `git revert -m 1 <merge-sha>` then `terraform apply`.
-3. **Whole-pivot** — revert the three TM-A5 PRs and ship ADR 003's Railway
-   plan (preserved in git history).
+1. **Per-image** — `docker compose -p infra up -d` against a previous build /
+   git checkout on the box.
+2. **Per-PR** — `git revert -m 1 <merge-sha>`; the next push redeploys.
+3. **LLM fallback** — unset the Bedrock vars and set `ANTHROPIC_API_KEY` in
+   `/opt/tfl-monitor/.env` to fall back to Anthropic-direct.

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -17,7 +17,7 @@ quadrantChart
     "1 pyproject + flat compose": [0.85, 0.25]
     "Sub-packages with own toml": [0.20, 0.75]
     "Single AbstractVectorStore": [0.30, 0.65]
-    "Plain pinecone client": [0.85, 0.30]
+    "Plain pgvector client": [0.85, 0.30]
     "Custom Typer CLI": [0.30, 0.55]
     "python -m module entry": [0.80, 0.25]
 ```
@@ -40,65 +40,59 @@ now?"* If no — the abstraction can wait.
 ## Contracts-first parallelism
 
 Every cross-service interface lives in `contracts/`. Two tiers of Pydantic
-schemas separate the messy outside world from the clean internal wire format,
-so producers, consumers, FastAPI, and the frontend can be built in parallel by
-separate agents without colliding.
+schemas separate the messy outside world from the clean internal shape, so the
+TfL client, FastAPI, and the frontend can be built in parallel by separate
+agents without colliding.
 
 ```mermaid
 flowchart TB
     subgraph SOURCE[contracts/]
       OAPI[openapi.yaml<br/>OpenAPI 3.1]
       T1[schemas/tfl_api.py<br/>tier-1 raw shapes]
-      T2[schemas/{line_status,arrivals,disruptions}.py<br/>tier-2 frozen events]
-      DDL[sql/00*.sql<br/>raw + ref + analytics]
-      DBTSRC[dbt_sources.yml]
+      T2[schemas/*.py<br/>tier-2 typed models]
+      DDL[sql/00*.sql<br/>ref + analytics + chat]
     end
 
     OAPI -->|openapi-typescript| TS[web/lib/types.ts]
     OAPI -->|FastAPI route shapes| API[src/api]
-    T1 -->|tfl_client normalises| ING[src/ingestion]
-    T2 -->|wire format| KAFKA[(Kafka)]
+    T1 -->|tfl_client normalises| ING[src/ingestion/tfl_client]
+    T2 -->|FastAPI response| API
     DDL -->|psql -f| PG[(Postgres)]
-    DBTSRC -->|copied to| DBTSOURCES[dbt/sources/tfl.yml]
 ```
 
-CI enforces the source-of-truth via `diff contracts/dbt_sources.yml
-dbt/sources/tfl.yml` and a bidirectional OpenAPI ↔ Python drift test.
+CI enforces the source-of-truth via a bidirectional OpenAPI ↔ Python drift
+test — the emitted schema must equal the committed contract, both directions.
 
-## Kafka earns its place
+## Live proxy over a warehouse
 
-A cron-to-Postgres pipeline would technically deliver the same rows. Kafka is
-worth its operational cost only because we exploit three properties:
+Hoarding TfL's feeds as warehouse history bought nothing but disk-full
+incidents — the free-tier database was bricked three times before ADR 014
+turned the app into a live proxy. The principle is YAGNI applied to data: TfL
+already exposes the live API, so reading through on demand is simpler, cheaper,
+and removes an entire failure class. A bounded-retention warehouse can return
+under a future ADR if analytics ever justify it.
 
-1. **Decoupling** — producers keep polling while consumers redeploy.
-2. **Replay** — rewinding `line-status` re-hydrates `stg_line_status` without a
-   re-poll.
-3. **Fan-out** — the same `arrivals` topic feeds `mart_bus_metrics_daily` and
-   could feed a future live-dashboard pusher with no producer change.
-
-If the WP only needed (1), we would skip Kafka. We exploit all three.
-
-## dbt over raw SQL
+## dbt for the reference layer
 
 ```mermaid
 graph LR
-    raw[(raw.*<br/>JSONB landing)] --> stg[stg_*<br/>incremental merge<br/>defensive dedup]
-    stg --> ints[int_* if needed]
-    ints --> marts[mart_*<br/>composite-grain<br/>generic + singular tests]
-    marts --> exposures[Exposures<br/>→ /reliability /disruptions /bus]
+    script[scripts/build_stations_seed.py] --> seed[(tfl_stations seed)]
+    seed -->|dbt build| dim[analytics.dim_stations<br/>generic tests + docs]
+    dim --> resolver[NaPTAN → name resolver]
 ```
 
-Raw SQL would also work — until a second person reads the codebase. dbt buys
-us tests, lineage, and one-line documentation that ships with the code.
+For one seed and one model, raw SQL would also work — until a second person
+reads the codebase. dbt buys us tests, lineage, and one-line documentation that
+ships with the code, plus a one-command rebuild from an empty database.
 
 ## Agent that does not hallucinate
 
 Two design choices keep the agent honest:
 
-1. **All five tools have typed Pydantic input/output.** The model cannot call
-   `query_line_reliability` with a malformed `line_id` — Pydantic AI's Haiku
-   normaliser canonicalises free text first.
-2. **Retrieval cites chunks.** The RAG tool returns Pinecone chunks with their
+1. **Every tool has typed Pydantic input/output.** The model cannot call a tool
+   with malformed arguments — a Pydantic AI Haiku normaliser canonicalises free
+   text (e.g. a line name) into a validated struct first.
+2. **Retrieval cites chunks.** The RAG tool returns pgvector chunks with their
    `doc_id` and `page` so any answer is traceable to a paragraph in a public
    document. LangSmith records the exact chunks that made it into the context.
 
@@ -112,9 +106,9 @@ prunes the bad retrieval, not "the LLM."
 | How did the agent arrive at that answer? | LangSmith |
 | Which chunks made it into the prompt? | LangSmith |
 | How many tokens did this conversation cost? | LangSmith |
-| Is the Kafka consumer keeping up? | Logfire |
-| Why is `/reliability/{line_id}` p99 latency high? | Logfire |
+| Why is `/disruptions/recent` p99 latency high? | Logfire |
 | Is TfL throttling us with 429s? | Logfire |
+| Did the `dim_stations` resolver fall back to a live lookup? | Logfire |
 
 Two hosted tools, zero self-hosted telemetry. ADR 004 has the full rationale.
 
@@ -166,7 +160,7 @@ This ships small, intentional PRs and avoids drift.
 |------|-----------|
 | Typo, one-line fix, dependency bump | Direct PR, tests already cover it |
 | New endpoint with one query | Plan inline, implement, ship |
-| New ingestion topic, new mart, new agent tool | Three phases, fresh context per phase |
+| New live endpoint, new dbt model, new agent tool | Three phases, fresh context per phase |
 | Anything touching `contracts/` | Mandatory ADR + cross-track broadcast |
 
 Track boundaries (A-infra / B-ingestion / C-dbt / D-api-agent / E-frontend /

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,9 +20,9 @@ Project-specific vocabulary and TfL-specific terms a reviewer might not know.
     these on the wire.
 
 `Tier-2 schema`
-:   Pydantic model in **internal Kafka wire format** — snake_case, frozen,
-    flat. Lives in `contracts/schemas/{line_status,arrivals,disruptions}.py`.
-    Producers emit these; consumers and downstream services speak only this.
+:   Pydantic model in the **internal response shape** — snake_case, flat, typed.
+    Lives in `contracts/schemas/`. `tfl_client/normalise.py` maps tier-1 →
+    tier-2; FastAPI and the frontend speak only this.
 
 `ADR`
 :   Architecture Decision Record. Markdown file under `.claude/adrs/` with
@@ -37,7 +37,8 @@ Project-specific vocabulary and TfL-specific terms a reviewer might not know.
 
 `NaPTAN`
 :   National Public Transport Access Node. The UK-wide identifier for stops
-    and stations. Five NaPTAN hubs are sampled by the arrivals producer.
+    and stations. The `get_arrivals_tool` resolves a station name to a NaPTAN
+    before querying live arrivals.
 
 `ATCO`
 :   Association of Transport Coordinating Officers. ATCO codes are the
@@ -50,13 +51,13 @@ Project-specific vocabulary and TfL-specific terms a reviewer might not know.
 
 `Mode`
 :   TfL's transport-mode classifier — `tube`, `bus`, `dlr`, `overground`,
-    `elizabeth-line`, `tram`, `cable-car`. The disruptions producer polls
-    four modes.
+    `elizabeth-line`, `tram`, `cable-car`. `/status/live` and
+    `/disruptions/recent` query TfL across the rail modes.
 
 `Status severity`
 :   TfL's enum: `Good Service`, `Minor Delays`, `Severe Delays`, `Part Closure`,
-    `Suspended`, etc. `mart_tube_reliability_daily` aggregates per
-    `(line_id, calendar_date, status_severity)`.
+    `Suspended`, etc. Returned per line by `/status/live`; severity 10 is Good
+    Service, higher values map to delays / closures.
 
 ## Stack terms
 
@@ -81,6 +82,6 @@ Project-specific vocabulary and TfL-specific terms a reviewer might not know.
 :   A typed Python agent framework from the Pydantic team; we use it inside one tool (`LineId`
     extraction with Haiku). LangGraph remains the main agent.
 
-`HybridChunker`
-:   Docling 2.x utility that chunks a parsed document by sections + tables
-    rather than by raw character count, preserving semantic structure.
+`SentenceSplitter`
+:   LlamaIndex utility that splits PyMuPDF-extracted text into overlapping
+    chunks on sentence boundaries before embedding.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@ hide:
 
 # tfl-monitor
 
-> A real-time data + AI engineering portfolio: streaming Transport for London
-> feeds into a dbt-modelled warehouse, with a LangGraph agent that routes
-> between SQL over the warehouse and RAG over TfL strategy documents.
+> A real-time data + AI engineering portfolio: a **live Transport for London
+> proxy** with a LangGraph agent that routes between live TfL queries and RAG
+> over TfL strategy documents.
 
 <div class="grid cards" markdown>
 
@@ -16,26 +16,26 @@ hide:
 
     ---
 
-    Async pollers fan TfL line-status, arrivals, and disruptions onto Kafka
-    topics every 30 s — replayable, decoupled from consumers.
+    `/status/live` and `/disruptions/recent` read through to the TfL Unified
+    API on demand — no broker, no feed warehouse to keep fresh (ADR 014).
 
-    [:octicons-arrow-right-24: Streaming ingestion](pipelines/ingestion.md)
+    [:octicons-arrow-right-24: Live TfL proxy](pipelines/ingestion.md)
 
--   :material-database-outline:{ .lg .middle } **dbt-modelled warehouse**
+-   :material-database-outline:{ .lg .middle } **Reference data in dbt**
 
     ---
 
-    Staging + mart models with `merge` incrementality, generic + singular
-    tests, and exposures wiring marts to API endpoints.
+    One station seed and a `dim_stations` mart, built one-shot on deploy — with
+    dbt tests, lineage, and docs for near-zero cost.
 
-    [:octicons-arrow-right-24: dbt warehouse](pipelines/warehouse.md)
+    [:octicons-arrow-right-24: Reference data](pipelines/warehouse.md)
 
 -   :material-robot-outline:{ .lg .middle } **Agent that doesn't hallucinate**
 
     ---
 
-    LangGraph routes between five typed tools (4 SQL + 1 RAG). Pydantic AI
-    extracts structured arguments. Every step traced in LangSmith.
+    LangGraph routes between typed tools — live status, disruptions, journey,
+    arrivals, and RAG. Every step traced in LangSmith.
 
     [:octicons-arrow-right-24: LangGraph agent](pipelines/agent.md)
 
@@ -48,12 +48,12 @@ hide:
 
     [:octicons-arrow-right-24: Observability](observability.md)
 
--   :material-cloud-outline:{ .lg .middle } **Deployable for ~$6/month**
+-   :material-cloud-outline:{ .lg .middle } **Runs for a few $/month**
 
     ---
 
-    Single EC2 spot box + AWS Bedrock + free-tier Supabase / Redpanda Cloud /
-    Vercel / Pinecone. $100 AWS credit covers ~12 months.
+    A second tenant on a shared AWS Lightsail box + AWS Bedrock + free-tier
+    Supabase / Vercel. Effective cost ~$3.50/mo.
 
     [:octicons-arrow-right-24: Deployment](deployment.md)
 
@@ -61,8 +61,8 @@ hide:
 
     ---
 
-    25 work packages organised into parallel tracks; every WP shipped with
-    tests, ADRs for cross-cutting decisions, contracts-first parallelism.
+    Work packages organised into parallel tracks; every WP shipped with tests,
+    ADRs for cross-cutting decisions, contracts-first parallelism.
 
     [:octicons-arrow-right-24: Roadmap](roadmap.md)
 
@@ -71,15 +71,15 @@ hide:
 ## What you can ask the agent
 
 ```text
-"Which Tube line had the worst reliability last week?"
-   → routes to SQL tool → mart_tube_reliability_daily_summary
+"How's the Piccadilly line running right now?"
+   → query_tube_status → live TfL /Line/Mode/{modes}/Status
 
-"What's TfL's strategy for Piccadilly Line upgrades?"
-   → routes to RAG tool → Pinecone over TfL Business Plan + MTS 2018 +
-     Annual Report (Docling-parsed)
+"Plan a journey from Oxford Circus to Bank."
+   → plan_journey_tool → live TfL /Journey/JourneyResults
 
-"Is the 207 bus running on time near Ealing Hospital?"
-   → SQL → bus punctuality proxy from arrivals topic
+"What's TfL's strategy for cycling?"
+   → search_tfl_docs → pgvector over TfL Business Plan + MTS 2018 +
+     Annual Report (PyMuPDF-parsed, Bedrock-embedded)
 ```
 
 ## Why this exists
@@ -87,31 +87,33 @@ hide:
 A portfolio that demonstrates the full data + AI engineering loop on a
 realistic public dataset, not a CRUD demo or a notebook prototype:
 
-- **Streaming that earns its broker.** Four polling endpoints with sub-minute
-  cadence, multiple consumers fanning out from the same topic.
-- **A warehouse modelled properly.** dbt staging → marts with tests, exposures,
-  documentation, and idempotent `merge` incrementality.
-- **An agent grounded in real data and real documents.** SQL tools run typed
-  Pydantic-validated queries; RAG retrieval cites exact PDF chunks.
+- **A live proxy that knows what not to store.** The warehouse was decommissioned
+  after it bricked the free-tier database three times; serving TfL live removed
+  the disk-full failure class entirely (ADR 014).
+- **A reference layer modelled properly.** dbt builds the station dimension with
+  tests, lineage, and documentation, regenerable from empty in one `dbt build`.
+- **An agent grounded in real data and real documents.** Typed,
+  Pydantic-validated tools hit the live TfL API; RAG retrieval cites exact PDF
+  chunks.
 - **Everything traced.** LangSmith answers "why did the agent decide X?";
-  Logfire answers "why is the consumer lagging?".
+  Logfire answers "which TfL endpoint is throttling us?".
 
 ## Tech stack at a glance
 
 | Layer | Choice |
 |-------|--------|
-| Streaming broker | Redpanda (Kafka API) |
-| Warehouse | PostgreSQL 16 / Supabase |
-| Transformations | dbt-core |
-| Orchestration | Apache Airflow 2.10 |
-| Ingestion | Python 3.12 + `httpx` + `aiokafka` |
+| Streaming broker | None — live TfL proxy (ADR 014) |
+| Database | PostgreSQL 16 / Supabase (app-essentials + pgvector) |
+| Transformations | dbt-core (seed + `dim_stations`) |
+| Orchestration | Host one-shot on deploy |
+| Ingestion | Python 3.12 + `httpx` (read-through) |
 | API | FastAPI + `sse-starlette` |
 | Agent | LangGraph 1.x + Pydantic AI |
-| RAG | LlamaIndex + Pinecone + Docling |
+| RAG | LlamaIndex + pgvector + PyMuPDF + Bedrock Titan |
 | Frontend | Next.js 16 + shadcn/ui + Biome |
 | LLM observability | LangSmith |
 | App observability | Logfire |
-| Deploy | AWS EC2 spot + Bedrock + Supabase + Redpanda Cloud + Vercel |
+| Deploy | Shared AWS Lightsail + Bedrock + Supabase + Vercel |
 
 [:octicons-arrow-right-24: Full tech-stack table](stack.md){ .md-button }
 [:octicons-arrow-right-24: Architecture deep-dive](architecture.md){ .md-button .md-button--primary }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -5,11 +5,10 @@ Two hosted tools, clearly separated by concern. No self-hosted telemetry stack.
 ```mermaid
 flowchart LR
     subgraph SRC[Sources of telemetry]
-      INGEST[Producers + Consumers]
       API[FastAPI handlers]
       AGENT[LangGraph agent]
       DB[(Postgres)]
-      HTTP[httpx outbound]
+      HTTP[httpx → TfL Unified API]
     end
 
     subgraph TELEMETRY[Telemetry collectors]
@@ -17,7 +16,6 @@ flowchart LR
       LS[LangSmith<br/>LangChain-native]
     end
 
-    INGEST -.spans + structured logs.-> LF
     API -.spans.-> LF
     DB -.psycopg spans.-> LF
     HTTP -.client spans.-> LF
@@ -33,9 +31,9 @@ flowchart LR
 | How many tokens did this conversation cost? | **LangSmith** |
 | Why did the router pick the SQL tool over RAG? | **LangSmith** |
 | Which TfL endpoint is throttling us with 429s? | **Logfire** |
-| Why is `/reliability/{line_id}` p99 latency high? | **Logfire** |
-| Is the `arrivals` consumer keeping up with the topic? | **Logfire** |
-| Did the Pinecone upsert succeed? | **Logfire** |
+| Why is `/disruptions/recent` p99 latency high? | **Logfire** |
+| Did the station resolver fall back to a live TfL lookup? | **Logfire** |
+| How long did the upstream TfL call take? | **Logfire** |
 
 The split is captured formally in [ADR 004 — Logfire + LangSmith
 split](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/adrs/004-logfire-langsmith-split.md).
@@ -58,7 +56,7 @@ What this gives us out of the box:
 - One span per FastAPI request, with route + status + duration.
 - One span per psycopg query, with the parameterised SQL.
 - One span per httpx outbound request, with the URL and status.
-- Structured logs via `logfire.info("kafka.consume", lag=…, partition=…)`
+- Structured logs via `logfire.info("tfl.request", endpoint=…, status=…)`
   rather than `print()` or bare `logging`.
 
 ### Service boundaries traced
@@ -66,12 +64,9 @@ What this gives us out of the box:
 | Span namespace | Code path |
 |----------------|-----------|
 | `tfl-monitor-api` | FastAPI request handlers |
-| `ingestion.line_status.*` | line-status producer + consumer |
-| `ingestion.arrivals.*` | arrivals producer + consumer |
-| `ingestion.disruptions.*` | disruptions producer + consumer |
-| `kafka.produce`, `kafka.consume` | aiokafka events with lag |
+| `agent.tool.*` | LangGraph tool invocations (status, disruptions, journey, arrivals, RAG) |
 | `httpx.client` | TfL Unified API calls (`app_key` redacted) |
-| `psycopg.*` | Postgres queries |
+| `psycopg.*` | Postgres queries (chat history, `dim_stations`) |
 
 `app_key` is **redacted before the span is emitted** — see
 `src/ingestion/observability.py`.
@@ -100,13 +95,13 @@ sequenceDiagram
     participant U as User
     participant API as /chat/stream
     participant G as LangGraph
-    participant T as Tool (e.g. query_line_reliability)
-    participant L as Sonnet 3.5
+    participant T as Tool (e.g. query_tube_status)
+    participant L as Claude Sonnet
 
     U->>API: POST {message}
     API->>G: agent.astream(...)
     G->>L: LLM call (Sonnet)
-    L-->>G: tool_call(query_line_reliability, {line_id: "Piccadilly"})
+    L-->>G: tool_call(query_tube_status)
     G->>T: invoke
     T-->>G: rows
     G->>L: LLM call with tool result

--- a/docs/pipelines/agent.md
+++ b/docs/pipelines/agent.md
@@ -1,53 +1,54 @@
 # LangGraph agent
 
-A `create_react_agent` over **five typed tools** — four wrap the FastAPI
-fetchers in-process, the fifth is a LlamaIndex retriever fanning out across
-the three Pinecone namespaces. Streaming reaches the browser via SSE.
+A `create_react_agent` over **up to five typed tools** — two read TfL live, two
+plan journeys / arrivals, and one is a LlamaIndex retriever over the pgvector
+strategy corpus. Streaming reaches the browser via SSE.
 
 ## Code map
 
 | Concern | Module |
 |---------|--------|
 | Graph compilation | `src/api/agent/graph.py` |
-| Tool wrappers (4 SQL + 1 RAG) | `src/api/agent/tools.py` |
-| LlamaIndex retriever | `src/api/agent/rag_tool.py` |
-| Pydantic AI normaliser | `src/api/agent/extraction.py` |
+| Tool definitions | `src/api/agent/tools.py` |
+| LlamaIndex retriever | `src/api/agent/rag.py` |
+| Pydantic AI extractor | `src/api/agent/extraction.py` |
+| System prompts | `src/api/agent/prompts.py` |
 | SSE projection | `src/api/agent/streaming.py` |
-| FastAPI route + history | `src/api/main.py` (`/chat/stream`, `/chat/{thread_id}/history`) |
+| History read/write | `src/api/agent/history.py` |
+| FastAPI routes | `src/api/main.py` (`/chat/stream`, `/chat/{thread_id}/history`) |
 | Persistence DDL | `contracts/sql/004_chat.sql` |
 
 ## Tool surface
 
 ```mermaid
 graph LR
-    Q[User question] --> AGENT["create_react_agent<br/>Sonnet 3.5 v2<br/>temperature=0"]
-    AGENT --> T1[query_tube_status<br/>→ /status/live]
-    AGENT --> T2[query_line_reliability<br/>→ /reliability/{line_id}]
-    AGENT --> T3[query_recent_disruptions<br/>→ /disruptions/recent]
-    AGENT --> T4[query_bus_punctuality<br/>→ /bus/{stop_id}/punctuality]
-    AGENT --> T5[search_tfl_docs<br/>→ Pinecone retriever]
+    Q[User question] --> AGENT["create_react_agent<br/>Claude Sonnet (Bedrock)<br/>temperature=0"]
+    AGENT --> T1[query_tube_status<br/>→ live TfL status]
+    AGENT --> T2[query_recent_disruptions<br/>→ live TfL disruptions]
+    AGENT --> T3[plan_journey_tool<br/>→ TfL JourneyResults]
+    AGENT --> T4[get_arrivals_tool<br/>→ TfL Arrivals]
+    AGENT --> T5[search_tfl_docs<br/>→ pgvector retriever]
 
-    T2 -.normalise.-> EXT["Pydantic AI<br/>Haiku 3.5<br/>LineId extractor"]
-
-    T1 --> WH[(analytics.* via fetchers)]
-    T2 --> WH
-    T3 --> WH
-    T4 --> WH
-    T5 --> PC[(Pinecone<br/>3 namespaces)]
+    T1 --> CLIENT[(TflClient → live TfL)]
+    T2 --> CLIENT
+    T3 --> CLIENT
+    T4 --> CLIENT
+    T5 --> VEC[(pgvector<br/>tfl_strategy_docs)]
 ```
 
-Each tool is a typed LangChain `@tool` that calls the same fetcher functions
-backing the REST endpoints — there is **one source of truth per query** and
-the agent does not duplicate SQL. Tool docstrings declare assumptions that
-should reach the model:
+`make_tools` registers conditionally: the four TfL tools appear only when a
+`TflClient` is wired (graceful degradation when `TFL_APP_KEY` is unset), and
+`search_tfl_docs` appears only when a retriever is supplied. Every `TflClient`
+call inside a `@tool` body is wrapped in `try/except` returning a friendly
+string — LangGraph re-raises non-`ToolException` errors and would otherwise
+crash the stream (ADR 010). Tool docstrings declare assumptions that should
+reach the model (e.g. journey endpoints deref a hub id to its rail child).
 
-> `query_bus_punctuality(stop_id: str)` — *Bus punctuality is a documented
-> proxy: on-time = arrival within 5 min; early = > 5 min in advance; late =
-> negative seconds. Anchored on TfL's published 5-minute bus performance KPI.*
+## Pydantic AI for typed extraction
 
-## Pydantic AI inside one tool
-
-The `LineId` extractor is the only Pydantic AI surface in the project:
+`src/api/agent/extraction.py` is the project's only Pydantic AI surface — a
+cheap Haiku call that returns a validated struct (e.g. a canonical `LineId`
+from free text) without spinning up the full LangGraph machinery:
 
 ```python
 @lru_cache(maxsize=1)
@@ -62,45 +63,30 @@ def _normaliser() -> Agent[None, LineId]:
     )
 ```
 
-Why Pydantic AI for this and not LangGraph?
-
-- **Single shot, typed output** — Pydantic AI returns a validated `LineId`
-  directly; LangGraph's full state machine is overkill.
-- **Cheap model** — Haiku 3.5 with a one-shot prompt is ~10× cheaper than
-  asking Sonnet to do this inside the main agent loop.
-- **Cacheable** — `lru_cache(maxsize=1)` keeps the agent client warm across
-  requests within the same FastAPI process.
-
-LangGraph remains the main agent. Pydantic AI is a tool-internal helper —
-not a competing framework.
+LangGraph remains the main agent; Pydantic AI is a tool-internal helper, not a
+competing framework.
 
 ## RAG retriever
 
 ```python
-LlamaIndexRetriever(
-    vector_stores=[
-        PineconeVectorStore(index, namespace="tfl_business_plan"),
-        PineconeVectorStore(index, namespace="mts_2018"),
-        PineconeVectorStore(index, namespace="tfl_annual_report"),
-    ],
-    top_k=4,
-    embedder=OpenAIEmbedding("text-embedding-3-small"),
-)
+# src/api/agent/rag.py
+retriever = build_vector_store(settings).as_retriever(similarity_top_k=4)
 ```
 
-The retriever supports **optional `doc_id` targeting** — if the user mentions
-"Annual Report", the agent passes `doc_id="tfl_annual_report"` and the
-retriever queries that namespace only. A `-1` page sentinel maps onto Docling
-chunks that span tables (no single page).
+The retriever queries the LlamaIndex-managed pgvector store
+(`public.tfl_strategy_docs`, 1024-dim Bedrock Titan vectors). It supports
+**optional `doc_id` targeting** — if the user mentions "Annual Report", the
+agent filters on that `doc_id` metadata value instead of scanning the whole
+corpus. See [RAG ingestion](rag.md).
 
 ## Graceful degradation
 
 ```mermaid
 flowchart TB
-    boot[FastAPI lifespan] --> check{All 3 keys?<br/>ANTHROPIC_API_KEY<br/>OPENAI_API_KEY<br/>PINECONE_API_KEY}
+    boot[FastAPI lifespan] --> check{LLM creds present?}
     check -->|yes| compile[compile_agent → LangGraph]
     compile --> cache[app.state.agent]
-    check -->|missing any| none[app.state.agent = None]
+    check -->|missing| none[app.state.agent = None]
 
     req[/chat/stream POST/] --> read[read app.state.agent]
     read -->|None| err503[503 Service Unavailable]
@@ -111,59 +97,34 @@ flowchart TB
     dburl -->|unset| err503h[503 RFC 7807]
 ```
 
-So a deploy missing one of the three keys still serves history, the live
-status views, the disruption log, and the bus punctuality endpoint — the
-chat just 503s.
+`compile_agent` returns `None` when the LLM credentials are missing, so a deploy
+without them still serves the live status views, the disruption log, and the
+chat history — only `/chat/stream` 503s.
 
 ## SSE projection
 
 LangGraph emits two stream channels — `messages` (token-level deltas) and
-`updates` (tool calls + state changes). `streaming.project` collapses them
-into one frame format the browser consumes:
+`updates` (tool calls + state changes). `streaming.project` collapses them into
+the frame format the browser consumes. On a `plan_journey_tool` /
+`get_arrivals_tool` result it emits a structured `journey` / `arrivals` frame so
+the frontend can render a rich card instead of prose (ADR 011):
 
-```python
-async def project(stream: AsyncIterator[Any]) -> AsyncIterator[Frame]:
-    async for kind, payload in stream:
-        if kind == "messages":
-            yield Frame(type="token", content=payload.content)
-        elif kind == "updates":
-            for tool_name in _tool_calls_from(payload):
-                yield Frame(type="tool", content=tool_name)
-    yield Frame(type="end", content="ok")
+```text
+{type: "token"   | content: "..."}        # streamed answer text
+{type: "tool"    | content: "query_tube_status"}
+{type: "journey" | content: <JourneyView JSON>}
+{type: "arrivals"| content: <ArrivalsView JSON>}
+{type: "end"     | content: "ok" | "error"}
 ```
 
-The projection is the **stable contract** between the agent runtime and the
-frontend. Swapping LangGraph for another framework would only need to keep
-`{type: "token" | "tool" | "end", content: str}` intact.
+The frame set is the **stable contract** between the agent runtime and the
+frontend; swapping LangGraph for another framework only needs to keep it intact.
 
 ## Persistence
 
-```mermaid
-sequenceDiagram
-    participant W as Web
-    participant API as /chat/stream
-    participant DB as analytics.chat_messages
-    participant G as LangGraph
-
-    W->>API: POST {thread_id, message}
-    API->>DB: INSERT (thread_id, role=user, content)
-    API->>G: astream
-    loop tokens
-      G-->>API: messages chunk
-      API-->>W: data: {"type":"token", ...}
-    end
-    G-->>API: updates (tool call)
-    API-->>W: data: {"type":"tool", ...}
-    G-->>API: end
-    API->>DB: INSERT (thread_id, role=assistant, content=concatenated)
-    API-->>W: data: {"type":"end", ...}
-```
-
-The user turn lands **before** the first frame so a connection drop never
-loses the question. The assistant turn lands on stream end with the
-concatenated tokens.
-
-The history endpoint reads back `analytics.chat_messages` ordered by
+The user turn lands **before** the first frame so a connection drop never loses
+the question; the assistant turn lands on stream end with the concatenated
+tokens. The history endpoint reads `analytics.chat_messages` ordered by
 `(thread_id, created_at ASC)` — the contract is documented in
 `contracts/sql/004_chat.sql`.
 
@@ -171,12 +132,10 @@ The history endpoint reads back `analytics.chat_messages` ordered by
 
 | Layer | Coverage |
 |-------|----------|
-| `agent/extraction.py` | LineId normalisation 4 tests (canonical, informal, ambiguous, empty) |
-| `agent/tools.py` | 8 tests across the four SQL tools (happy path, empty, parameter validation, db absent) |
-| `agent/rag_tool.py` | 6 tests (retrieval, doc_id targeting, page sentinel, namespace fan-out, empty, sdk failure) |
-| `agent/graph.py` | 5 tests (compile, no-keys, tool registration, model selection, prompt) |
-| `/chat/stream` route | 6 tests (happy path, 503 no graph, 503 no DATABASE_URL, mid-stream end:error, history insert order, abort) |
-| `/chat/{thread_id}/history` route | 3 tests (happy path, empty, RFC 7807 503) |
-| Integration smokes | 3 (history round-trip, chat-stream end-to-end, history-after-stream) — gated on the four-key combo |
-
-36 unit tests + 3 integration smokes total.
+| `agent/extraction.py` | LineId normalisation (canonical, informal, ambiguous, empty) |
+| `agent/tools.py` | TfL tools — happy path, empty, parameter validation, upstream-failure swallow |
+| `agent/rag.py` | retrieval, `doc_id` targeting, empty corpus, SDK failure |
+| `agent/graph.py` | compile, no-creds, tool registration, model selection |
+| `/chat/stream` route | happy path, 503 no graph, 503 no `DATABASE_URL`, mid-stream `end:error`, journey/arrivals frames |
+| `/chat/{thread_id}/history` route | happy path, empty, RFC 7807 503 |
+| Integration smokes | history round-trip + chat-stream + history-after-stream (gated on credentials) |

--- a/docs/pipelines/api.md
+++ b/docs/pipelines/api.md
@@ -1,6 +1,6 @@
 # FastAPI surface
 
-Eight endpoints, all RFC 7807 errors, a single shared async psycopg pool, and
+Five endpoints, all RFC 7807 errors, a single shared async psycopg pool, and
 **OpenAPI 3.1 as the contract** — the frontend regenerates types from it.
 
 ## Code map
@@ -9,7 +9,9 @@ Eight endpoints, all RFC 7807 errors, a single shared async psycopg pool, and
 |---------|--------|
 | Application factory + lifespan | `src/api/main.py` |
 | Route handlers | `src/api/main.py` (in-line per endpoint) |
-| Postgres pool + fetchers | `src/api/db.py` |
+| Live TfL read-through | `src/api/live.py` |
+| Postgres pool + chat/history fetchers | `src/api/db.py` |
+| Station resolver | `src/api/stations.py` |
 | Pydantic response models | `src/api/schemas.py` |
 | Logfire wiring | `src/api/observability.py` |
 | Agent compilation | `src/api/agent/` |
@@ -19,13 +21,15 @@ Eight endpoints, all RFC 7807 errors, a single shared async psycopg pool, and
 | Method | Path | Source | Notes |
 |--------|------|--------|-------|
 | `GET` | `/health` | static | Liveness — returns build info |
-| `GET` | `/api/v1/status/live` | `raw.line_status` | 15-min freshness window |
-| `GET` | `/api/v1/status/history` | `analytics.stg_line_status` | 30-day cap, `LIMIT 10000` |
-| `GET` | `/api/v1/reliability/{line_id}` | `analytics.mart_tube_reliability_daily` | Aggregate + histogram, 404 on empty window |
-| `GET` | `/api/v1/disruptions/recent` | `analytics.stg_disruptions` | `?limit=50&mode=tube` |
-| `GET` | `/api/v1/bus/{stop_id}/punctuality` | `analytics.stg_arrivals` | 7-day window, on-time/early/late proxy |
+| `GET` | `/api/v1/status/live` | live TfL `/Line/Mode/{modes}/Status` | One status row per line; `502` on upstream failure |
+| `GET` | `/api/v1/disruptions/recent` | live TfL `/Status?detail=true` | `?limit=50&mode=tube`; affected stops resolved to names |
 | `POST` | `/api/v1/chat/stream` | LangGraph agent | SSE: `{type, content}` frames |
 | `GET` | `/api/v1/chat/{thread_id}/history` | `analytics.chat_messages` | Replays a thread |
+
+The `/status/live` and `/disruptions/recent` handlers call `TflClient` directly
+(`src/api/live.py`) — there is no database read on the request path beyond the
+station-name resolver's `dim_stations` fast path. See
+[Live TfL proxy](ingestion.md).
 
 ## Lifespan
 
@@ -34,30 +38,29 @@ sequenceDiagram
     participant Boot as uvicorn
     participant App as FastAPI
     participant DB as Postgres pool
+    participant TFL as TflClient
     participant LLM as compile_agent
 
     Boot->>App: lifespan startup
     alt DATABASE_URL set
       App->>DB: AsyncConnectionPool(min=1, max=4)
-      DB-->>App: open
     else
       App->>App: app.state.pool = None
     end
-    alt All 3 keys present
+    App->>TFL: open shared TflClient on app.state.tfl_client
+    alt LLM creds present
       App->>LLM: compile_agent()
-      LLM-->>App: graph
-      App->>App: app.state.agent = graph
+      LLM-->>App: graph (app.state.agent)
     else
       App->>App: app.state.agent = None
     end
-
     Note over App: serving requests
-    Note over Boot,LLM: lifespan shutdown reverses both
+    Note over Boot,LLM: lifespan shutdown reverses all three
 ```
 
-Each handler reads `app.state.pool` / `app.state.agent` and returns a
-RFC 7807 `503` if the dependency is missing — `make check` and unit tests run
-without any external services.
+Each handler reads `app.state.pool` / `app.state.tfl_client` / `app.state.agent`
+and returns a problem+json error if a dependency is missing — `make check` and
+unit tests run without any external services.
 
 ## Error contract
 
@@ -66,21 +69,20 @@ Every error response is `application/problem+json`:
 ```json
 {
   "type": "about:blank",
-  "title": "Service Unavailable",
-  "status": 503,
-  "detail": "DATABASE_URL not configured",
+  "title": "Bad Gateway",
+  "status": 502,
+  "detail": "Upstream TfL request failed",
   "instance": "/api/v1/status/live"
 }
 ```
 
-The `_problem` helper in `src/api/main.py` wraps the four documented surfaces:
+The `_problem` helper in `src/api/main.py` wraps the documented surfaces:
 
 | Status | When |
 |--------|------|
-| 404 | `reliability` window has no rows; bus stop unknown |
 | 422 | Pydantic validation failure (FastAPI default, RFC 7807-mapped) |
-| 503 | Pool unset (no `DATABASE_URL`) or agent unset (missing key) |
-| 502 | Bedrock / Anthropic upstream failure (mapped from `langchain_*` exceptions) |
+| 502 | Upstream failure — TfL request error, or Bedrock / Anthropic LLM error |
+| 503 | Pool unset (no `DATABASE_URL`) or agent unset (missing LLM credentials) |
 
 ## Pool sizing
 
@@ -97,8 +99,9 @@ Two reasons for the `max=4` ceiling:
 
 1. The Supabase free tier caps connections strictly (~30 across all clients
    sharing the project).
-2. Most queries are single-statement reads that finish in <50 ms, so a small
-   pool sustains the portfolio's RPS comfortably.
+2. The remaining DB reads — chat history and the `dim_stations` resolver fast
+   path — are single-statement and finish in <50 ms, so a small pool sustains
+   the portfolio's RPS comfortably.
 
 ## OpenAPI 3.1 as the source of truth
 
@@ -118,8 +121,8 @@ flowchart LR
     GEN[web/lib/types.ts<br/>regenerated] -->|diff| TS
 ```
 
-So adding a route involves three pinned files: the Pydantic schema, the
-OpenAPI entry, and the TypeScript types. Drift in any direction breaks CI.
+So adding a route involves three pinned files: the Pydantic schema, the OpenAPI
+entry, and the TypeScript types. Drift in any direction breaks CI.
 
 ## Observability
 
@@ -131,22 +134,21 @@ logfire.instrument_psycopg()
 logfire.instrument_httpx()
 ```
 
-Per-request spans cover route + status + latency. Per-query spans cover the
-parameterised SQL + duration. LangSmith captures the agent traces — see
-[Observability](../observability.md).
+Per-request spans cover route + status + latency; `httpx` spans cover the
+outbound TfL calls (`app_key` redacted). LangSmith captures the agent traces —
+see [Observability](../observability.md).
 
 ## Tests
 
-| Suite | Count | Notable |
-|-------|-------|---------|
-| `tests/api/test_stubs.py` | parametrised | Validates that every committed route is implemented (no 501 stubs left) |
-| `tests/api/test_status_live.py` | 5 | Freshness window, RFC 7807 on no pool, ordering |
-| `tests/api/test_reliability.py` | 6 | Histogram shape, 404 empty window, severity ordering |
-| `tests/api/test_disruptions.py` | 6 | `mode` filter via EXISTS, `limit` bounds, `last_update DESC NULLS LAST` |
-| `tests/api/test_bus_punctuality.py` | 5 | Proxy math, RFC 7807 404 on empty stop |
-| `tests/api/test_chat_stream.py` | 6 | SSE happy path, 503 no graph, mid-stream `end:error` |
-| `tests/api/test_chat_history.py` | 3 | Order, empty, 503 |
-| Integration smokes | 11 | Gated on `DATABASE_URL`, run with `-m integration` |
+| Suite | Notable |
+|-------|---------|
+| `tests/api/test_stubs.py` | Every committed route is implemented (no 501 stubs left) |
+| `tests/api/` live endpoints | `status/live` + `disruptions/recent` happy path, empty modes, `502` on upstream failure |
+| `tests/api/test_cors.py` | Apex pin + anchored Vercel-preview regex, attacker-origin reject |
+| `tests/api/` chat | SSE happy path, 503 no graph, mid-stream `end:error`, journey/arrivals frames |
+| `tests/api/` history | Order, empty, RFC 7807 503 |
+| Integration smokes | Gated on `DATABASE_URL`, run with `-m integration` |
 
-`tests/conftest.py::FakeAsyncPool` replaces the live psycopg pool in unit
-tests — the fixture returns predictable rows without a Postgres dependency.
+`tests/conftest.py::FakeAsyncPool` replaces the live psycopg pool in unit tests,
+and `TflClient` calls are faked — no Postgres or TfL dependency in the unit
+suite.

--- a/docs/pipelines/api.md
+++ b/docs/pipelines/api.md
@@ -22,7 +22,7 @@ Five endpoints, all RFC 7807 errors, a single shared async psycopg pool, and
 |--------|------|--------|-------|
 | `GET` | `/health` | static | Liveness — returns build info |
 | `GET` | `/api/v1/status/live` | live TfL `/Line/Mode/{modes}/Status` | One status row per line; `502` on upstream failure |
-| `GET` | `/api/v1/disruptions/recent` | live TfL `/Status?detail=true` | `?limit=50&mode=tube`; affected stops resolved to names |
+| `GET` | `/api/v1/disruptions/recent` | live TfL `/Line/Mode/{modes}/Status?detail=true` | `?limit=50&mode=tube`; affected stops resolved to names |
 | `POST` | `/api/v1/chat/stream` | LangGraph agent | SSE: `{type, content}` frames |
 | `GET` | `/api/v1/chat/{thread_id}/history` | `analytics.chat_messages` | Replays a thread |
 

--- a/docs/pipelines/frontend.md
+++ b/docs/pipelines/frontend.md
@@ -1,37 +1,40 @@
 # Next.js frontend
 
-Three views, all server components by default, types regenerated from the
-OpenAPI contract. Single linter (Biome) and single test runner (Vitest + RTL).
+A single-page dashboard + chat, all server components by default, types
+regenerated from the OpenAPI contract. Single linter (Biome) and single test
+runner (Vitest + RTL).
 
 ## Code map
 
 | Concern | Path |
 |---------|------|
-| App Router routes | `web/app/{page,disruptions,ask}/page.tsx` |
+| App Router route | `web/app/page.tsx` (one-pager; legacy `/disruptions`, `/ask` 308-redirect to `/`) |
 | Server-side fetchers | `web/lib/api/*.ts` |
 | SSE parser + chat fetcher | `web/lib/sse-parser.ts`, `web/lib/api/chat-stream.ts` |
 | Generated TS types | `web/lib/types.ts` (do not edit) |
-| Chat UI | `web/components/chat-view.tsx` |
+| Dashboard + chat UI | `web/components/dashboard/*.tsx` (cards, `chat-panel.tsx`, journey/arrivals cards) |
 | shadcn primitives | `web/components/ui/*.tsx` |
 | Security headers | `web/next.config.ts` |
 | Tests | colocated with each module under `web/__tests__/` |
 
-## Views
+## One-pager dashboard
+
+The four routes collapsed into a single page (TM-E5): live status, disruptions,
+and chat sit side by side, with the legacy paths kept alive via 308 redirects.
 
 ```mermaid
 flowchart LR
-    LANDING[/page.tsx<br/>Network Now/] -->|server fetch| SL[/api/v1/status/live]
-    DISLOG[/disruptions/page.tsx<br/>Disruption Log/] -->|server fetch| DR[/api/v1/disruptions/recent]
-    ASK[/ask/page.tsx<br/>ChatView/] -->|POST SSE| CHAT[/api/v1/chat/stream]
-
-    LANDING -->|nav link| ASK
+    PAGE[/page.tsx<br/>dashboard one-pager/]
+    PAGE -->|poll 30s| SL[/api/v1/status/live]
+    PAGE -->|poll 5min| DR[/api/v1/disruptions/recent]
+    PAGE -->|POST SSE| CHAT[/api/v1/chat/stream]
 ```
 
-| View | Wired endpoint | Highlights |
-|------|----------------|------------|
-| **Network Now** (`/`) | `/api/v1/status/live` | Empty / error states surfaced via `Alert role="alert"`, fetcher catches `ApiError` |
-| **Disruption Log** (`/disruptions`) | `/api/v1/disruptions/recent` | Per-disruption Card with category-tone badge (severe / minor / info / neutral); `closure_text` in destructive Alert |
-| **Ask** (`/ask`) | `/api/v1/chat/stream` | SSE stream → token bubbles, ephemeral "Using tool …" status line |
+| Surface | Wired endpoint | Highlights |
+|---------|----------------|------------|
+| Network status + pulse | `/api/v1/status/live` | Mode tabs, severe/degraded/good tally; empty / error via `Alert role="alert"` |
+| Happening now / coming up / news | `/api/v1/disruptions/recent` | Category-tone cards; `closure_text` callout; resolved station names |
+| Chat panel | `/api/v1/chat/stream` | SSE → token bubbles, ephemeral "Using tool …" line, journey / arrivals cards (ADR 011) |
 
 ## Type generation
 
@@ -126,18 +129,18 @@ pnpm --dir web build
 
 ## Tests
 
-54 web tests covering:
+The Vitest + RTL suite covers:
 
 - **SSE parser** — single frame, multi-frame chunk, partial chunk buffering,
   `:`-comment skip, unknown-type drop, malformed-JSON survival.
 - **Fetchers** — URL/headers/body assertions, RFC 7807 `detail` surfacing,
   network `TypeError` propagation, multi-chunk reader buffering.
-- **Network Now page** — happy path, empty array, `ApiError` alert,
-  non-`ApiError` rejection fallback.
-- **Disruption Log page** — list rendering, category-tone mapping, closure
-  callout shown/hidden, affected-routes list, error fallback.
-- **ChatView** — empty shell, streaming tokens, tool-status lifecycle,
-  503 alert + conversation rollback, mid-stream `end:error` flagging.
+- **Dashboard surfaces** — status cards + network pulse, happening-now / coming-up
+  / news derivations, category-tone mapping, closure callout shown/hidden,
+  resolved station names, empty + error fallbacks.
+- **Chat panel** — empty shell, streaming tokens, tool-status lifecycle,
+  503 alert + conversation rollback, mid-stream `end:error` flagging,
+  journey / arrivals card rendering.
 
 `web/__tests__/setup.ts` initialises `jsdom` and stubs `fetch` per test via
 `vi.stubGlobal`.

--- a/docs/pipelines/index.md
+++ b/docs/pipelines/index.md
@@ -5,34 +5,34 @@ the contract that locks its boundaries, and the tests that protect it.
 
 <div class="grid cards" markdown>
 
--   :material-source-branch:{ .lg .middle } **[Streaming ingestion](ingestion.md)**
+-   :material-source-branch:{ .lg .middle } **[Live TfL proxy](ingestion.md)**
 
-    Async TfL polling → tier-2 Pydantic events → Kafka topics → idempotent
-    `raw.*` writes.
+    Async read-through to the TfL Unified API on demand → tier-2 Pydantic
+    response. No broker, no feed warehouse (ADR 014).
 
--   :material-database-arrow-down:{ .lg .middle } **[dbt warehouse](warehouse.md)**
+-   :material-database-arrow-down:{ .lg .middle } **[Reference data (dbt)](warehouse.md)**
 
-    Staging models with defensive dedup, marts on stable composite grains,
-    exposures that wire marts to API endpoints.
+    A station seed and one `dim_stations` mart, built one-shot on deploy — the
+    fast path for the NaPTAN → station-name resolver.
 
 -   :material-file-document-multiple-outline:{ .lg .middle } **[RAG ingestion](rag.md)**
 
-    Conditional GET on TfL strategy PDFs → Docling parse → OpenAI embeddings
-    → Pinecone namespace per document.
+    Conditional GET on TfL strategy PDFs → PyMuPDF parse → Bedrock Titan
+    embeddings → pgvector, keyed by `doc_id`.
 
 -   :material-graph:{ .lg .middle } **[LangGraph agent](agent.md)**
 
-    Five typed tools (4 SQL + 1 RAG), a Haiku normaliser for `LineId`, and a
-    SSE projection for streaming.
+    Up to five typed tools (live status, disruptions, journey, arrivals, RAG),
+    a Pydantic AI extractor, and a structured SSE projection.
 
 -   :material-api:{ .lg .middle } **[FastAPI surface](api.md)**
 
-    Six endpoints, all RFC 7807 errors, a single async psycopg pool, and
+    Five endpoints, all RFC 7807 errors, a single async psycopg pool, and
     OpenAPI 3.1 as the contract.
 
 -   :material-language-typescript:{ .lg .middle } **[Next.js frontend](frontend.md)**
 
-    Three views (Network Now, Disruption Log, Ask), all server components by
-    default, types regenerated from OpenAPI.
+    A one-pager dashboard + chat, all server components by default, types
+    regenerated from OpenAPI.
 
 </div>

--- a/docs/pipelines/ingestion.md
+++ b/docs/pipelines/ingestion.md
@@ -1,125 +1,89 @@
-# Streaming ingestion
+# Live TfL proxy
 
-The ingestion layer turns four polling endpoints on the TfL Unified API into
-three Kafka topics and three Postgres `raw.*` tables. Every byte that crosses
-a service boundary is a Pydantic v2 model.
+The app reads through to the **TfL Unified API on demand** — there is no broker
+and no feed warehouse (ADR 014). A request to `/status/live` or
+`/disruptions/recent` triggers an async HTTP call to TfL, normalises the
+response with Pydantic v2, and returns it. Nothing is persisted; the disk-full
+class of incident that bricked the warehouse three times is structurally gone.
 
 ## Code map
 
 | Concern | Module |
 |---------|--------|
-| Async HTTP client to TfL | `src/ingestion/tfl_client/` |
-| Producers | `src/ingestion/producers/{line_status,arrivals,disruptions}.py` |
-| Consumers | `src/ingestion/consumers/{line_status,arrivals,disruptions}.py` |
-| Generic consumer + writer | `src/ingestion/consumers/_base.py` |
-| Logfire wiring | `src/ingestion/observability.py` |
+| Async HTTP client to TfL | `src/ingestion/tfl_client/client.py` |
+| Hand-rolled retry (429 / 5xx / timeout) | `src/ingestion/tfl_client/retry.py` |
+| Tier-1 → tier-2 normalisation | `src/ingestion/tfl_client/normalise.py` |
+| Read-through endpoint handlers | `src/api/live.py` |
+| NaPTAN → station-name resolver | `src/api/stations.py` |
+| Logfire wiring | `src/api/observability.py` |
+
+## Read-through flow
+
+```mermaid
+flowchart LR
+    WEB[Next.js dashboard] -->|GET| API[FastAPI<br/>src/api/live.py]
+    API -->|on demand| C[TflClient<br/>httpx + retry]
+    C -->|GET| TFL[TfL Unified API<br/>camelCase JSON]
+    TFL -->|tier-1 parse| N[normalise.py]
+    N -->|tier-2 Pydantic model| API
+    API -->|JSON| WEB
+    C -.upstream failure.-> E[502 problem+json]
+```
+
+| Endpoint | TfL call | Notes |
+|----------|----------|-------|
+| `GET /api/v1/status/live` | `/Line/Mode/{modes}/Status` | One status row per line |
+| `GET /api/v1/disruptions/recent` | `/Line/Mode/{modes}/Status?detail=true` | Walks `Line → lineStatuses[] → disruption` |
+
+`?detail=true` is deliberate: the free-tier `/Disruption` endpoint returns empty
+`affectedRoutes` / `affectedStops`, whereas the detailed status response carries
+the populated fan-out (ADR 007). When TfL fails or times out, the handler
+returns RFC 7807 `502` rather than a stale or empty body.
 
 ## Contracts
 
 ```mermaid
 flowchart LR
     TFL[TfL Unified API<br/>camelCase JSON] -->|httpx GET| C[tfl_client<br/>tier-1 parse]
-    C -->|normalise| T2["tier-2 Pydantic event<br/>snake_case · frozen<br/>UUIDv4 event_id<br/>UTC ingested_at"]
-    T2 -->|aiokafka| K[(Kafka topic)]
-    K -->|generic consumer| W[RawEventWriter]
-    W -->|"INSERT … ON CONFLICT (event_id)"| R[(raw.* JSONB)]
+    C -->|normalise| T2["tier-2 Pydantic model<br/>snake_case · typed"]
+    T2 -->|FastAPI response| WEB[web/lib/types.ts]
 ```
 
 Tier-1 = the wire format from TfL — messy, optional-heavy, evolves at TfL's
-pace. Tier-2 = our internal wire format — flat, frozen, every consumer reads
-one shape.
-
-The normalisation tier-1 → tier-2 is a single-purpose step inside
-`tfl_client/normalise.py`. Synthetic SHA-256 IDs anchor disruptions whose
+pace (`contracts/schemas/tfl_api.py`). Tier-2 = the flat, typed shape the API
+returns, pinned by `contracts/openapi.yaml`. The normalisation step lives in
+`tfl_client/normalise.py`; synthetic SHA-256 IDs anchor disruptions whose
 upstream payload omits a stable identifier.
 
-## Producers
+## Resilience
 
-Three async daemons, one shape:
+`TflClient` wraps every call in a hand-rolled retry policy:
 
-```python
-class LineStatusProducer:
-    POLL_INTERVAL_SECONDS = 30
+- **429** — honour `Retry-After`, exponential backoff.
+- **5xx / timeout** — bounded retries, then surface the failure as `502`.
+- **`app_key` redaction** — the TfL key is stripped before any Logfire span is
+  emitted (`src/api/observability.py`).
 
-    async def run_forever(self) -> None:
-        async for ts in clock_ticks(self.POLL_INTERVAL_SECONDS):
-            payload = await self._client.fetch_line_status()
-            event = normalise_line_status(payload, ingested_at=ts)
-            await self._producer.send(event, key=event.line_id)
-```
+Inside the agent, every `TflClient` call in a `@tool` body is additionally
+wrapped in `try/except` returning a friendly string — LangGraph re-raises
+non-`ToolException` errors and would otherwise crash the chat stream (ADR 010).
 
-| Producer | Cadence | Partition key | `event_type` |
-|----------|---------|---------------|--------------|
-| `LineStatusProducer` | 30 s | `line_id` | `line-status.snapshot` |
-| `ArrivalsProducer` (×5 NaPTAN hubs in one process) | 30 s | `station_id` | `arrivals.snapshot` |
-| `DisruptionsProducer` (×4 modes) | 300 s | `disruption_id` | `disruptions.snapshot` |
+## Station resolution
 
-Producers are idempotent at the broker level: `acks="all"`, `enable_idempotence=true`,
-UUIDv4 `event_id`. A retry never duplicates a row downstream.
-
-## Kafka choice (and why we exploit it)
-
-```mermaid
-flowchart LR
-    P[producer] -->|publish| T[(topic)]
-    T -->|consumer-group A| C1[raw.line_status writer]
-    T -->|future consumer-group B| C2[live dashboard pusher]
-    T -->|future consumer-group C| C3[agent context hydrator]
-```
-
-Three properties earn Kafka its place:
-
-1. **Decoupling** — producer keeps polling while a consumer redeploys.
-2. **Replay** — rewinding a topic re-hydrates the warehouse without
-   re-polling.
-3. **Fan-out** — the same `arrivals` topic feeds both
-   `mart_bus_metrics_daily` and any future stream consumer.
-
-A cron-to-Postgres pipeline would deliver the same rows. It would also lose
-all three properties on day one.
-
-## Consumers
-
-`RawEventConsumer[E]` is generic over the event type; `RawEventWriter(table)`
-writes JSONB rows. The `line-status` consumer became the parametric template
-for arrivals + disruptions in TM-B4 — same code path, different topic.
-
-```python
-async def consume_one(self, msg: ConsumerRecord) -> None:
-    event = self._codec.decode(msg.value)
-    try:
-        await self._writer.write(event)
-    except OperationalError:
-        await self._writer.reconnect()
-        raise   # let the consumer retry the offset
-    await self._consumer.commit({tp: msg.offset + 1})
-```
-
-### Failure isolation
-
-| Failure | Handling | Trace |
-|---------|----------|-------|
-| Poison pill (decode error) | skip + commit | `kafka.consume.skip` |
-| Transient DB error (`OperationalError`) | reconnect + replay offset | `psycopg.reconnect` |
-| Unknown exception | log + replay offset | `kafka.consume.error` |
-
-Idempotency comes from `INSERT … ON CONFLICT (event_id) DO NOTHING` — a replay
-of a successful offset is a no-op at the row level.
-
-### Lag observability
-
-Lag is computed on every `kafka.consume` span and refreshed every
-**50 messages or 30 s** (whichever comes first), so a slow partition cannot
-hide behind a fast one.
+`src/api/stations.py` turns the NaPTAN codes in a disruption payload into
+human-readable station names. The fast path queries the `analytics.dim_stations`
+mart (built from the `tfl_stations` seed); a miss falls back to a live TfL
+`/StopPoint/{naptan_id}` lookup, with a process-lifetime cache that only stores
+confirmed results so a transient TfL hiccup never poisons the dictionary.
 
 ## Tests
 
 | Layer | Coverage |
 |-------|----------|
-| Unit (per producer) | retry on 429, retry on 5xx, retry on timeout, `app_key` redaction, payload normalisation |
-| Unit (per consumer) | poison pill, transient DB, replay-on-error, lag bookkeeping, namespace override |
-| Integration smoke | Producer round-trip with embedded Redpanda + Postgres (gated on `DATABASE_URL` + `KAFKA_BOOTSTRAP_SERVERS`) |
+| `tfl_client/retry.py` | retry on 429, retry on 5xx, retry on timeout, `app_key` redaction |
+| `tfl_client/normalise.py` | tier-1 → tier-2 mapping, synthetic-ID stability |
+| `src/api/live.py` | happy path, empty modes, `502` on upstream failure |
+| `src/api/stations.py` | mart fast path, live fallback, confirmed-404 cache, no cache-poison on 5xx |
 
-Total: ~70 unit tests + 4 integration smokes across the three topics. All
-fixtures live under `tests/fixtures/tfl/` — production code never hits the
+All fixtures live under `tests/fixtures/tfl/` — production code never hits the
 live TfL API in tests.

--- a/docs/pipelines/rag.md
+++ b/docs/pipelines/rag.md
@@ -1,8 +1,8 @@
 # RAG ingestion
 
-Three TfL strategy documents are fetched, parsed, embedded, and upserted into
-Pinecone. The pipeline is **conditional** (only re-downloads what changed) and
-**idempotent** (re-running upserts the same row IDs).
+Three TfL strategy documents are fetched, parsed, embedded, and upserted into a
+**pgvector** table. The pipeline is **conditional** (only re-downloads what
+changed) and **idempotent** (re-running upserts the same chunks).
 
 ## Documents indexed
 
@@ -12,7 +12,7 @@ Pinecone. The pipeline is **conditional** (only re-downloads what changed) and
 | `mts_2018` | Mayor's Transport Strategy 2018 | https://www.london.gov.uk/programmes-strategies/transport/our-vision-transport/mayors-transport-strategy-2018 |
 | `tfl_annual_report` | TfL Annual Report and Statement of Accounts | https://tfl.gov.uk/corporate/publications-and-reports/annual-report |
 
-The landing pages are the citation surface; the resolved CDN URLs are not
+The landing pages are the citation surface; the resolved CDN URLs are not,
 because TfL roll the URL stem yearly (`business-plan-2026` → `2027`).
 
 ## Pipeline
@@ -25,35 +25,37 @@ flowchart LR
 
     subgraph FETCH[Fetch]
       URL -->|If-None-Match + If-Modified-Since| HTTP[httpx GET]
-      HTTP -->|200| LOCAL[data/strategy_docs/]
-      HTTP -->|304| LOCAL
+      HTTP -->|200 / 304| LOCAL[data/strategy_docs/]
     end
 
     subgraph PARSE[Parse]
-      LOCAL --> DOC[Docling DocumentConverter]
-      DOC --> CHUNK[HybridChunker<br/>section + table aware]
+      LOCAL --> DOC[PyMuPDF<br/>text extraction]
+      DOC --> CHUNK[LlamaIndex<br/>SentenceSplitter]
     end
 
     subgraph EMBED[Embed]
-      CHUNK -->|"100 chunks/req"| OAI[OpenAI<br/>text-embedding-3-small]
-      OAI -->|retry on 429| VEC[1536-dim vectors]
+      CHUNK -->|batched| TITAN[AWS Bedrock<br/>Titan v2]
+      TITAN --> VEC[1024-dim vectors]
     end
 
     subgraph UPSERT[Upsert]
-      VEC -->|sha256 id| PC[Pinecone<br/>tfl-strategy-docs]
-      PC -->|namespace per doc_id| NS[(tfl_business_plan<br/>mts_2018<br/>tfl_annual_report)]
+      VEC -->|doc_id metadata| PG[(pgvector<br/>public.tfl_strategy_docs)]
     end
 ```
+
+PyMuPDF replaced Docling (ADR 013) — text extraction is fast and CPU-light, so
+the parse no longer OOMs the shared 2 GB box. Bedrock Titan v2 replaced OpenAI
+embeddings, and pgvector replaced Pinecone, in the TM-32 cutover.
 
 ## Idempotency strategy
 
 | Stage | Mechanism | Why |
 |-------|-----------|-----|
-| Fetch | `If-None-Match` + `If-Modified-Since` from `data/cache/sources_state.json` | TfL serves 304 unless the PDF changed |
-| Parse | Pure function of bytes → no caching needed | Docling output is deterministic |
-| Embed | OpenAI batch endpoint with retry on 429 | Async-batches 100 chunks per request |
-| Upsert | Stable id `sha256("{resolved_url}::{chunk_index}")` | Re-upsert produces the same vector ids |
-| Rollover | Delete-namespace before re-ingest | New URL stem ⇒ wipe stale vectors cleanly |
+| Fetch | `If-None-Match` + `If-Modified-Since` from the sources-state cache | TfL serves 304 unless the PDF changed |
+| Parse | Pure function of bytes → no caching needed | PyMuPDF output is deterministic |
+| Embed | Bedrock `InvokeModel`, batched per request | 1024-dim Titan vectors |
+| Upsert | Stable id keyed on `doc_id` + chunk index | Re-upsert produces the same rows |
+| Rollover | Delete the doc's rows before re-ingest | New URL stem ⇒ wipe stale chunks cleanly |
 
 ## CLI
 
@@ -67,51 +69,56 @@ uv run python -m rag.ingest --refresh-urls
 # Bypass ETag cache and re-download every PDF
 uv run python -m rag.ingest --force-refetch
 
-# Run fetch + parse + embed; skip Pinecone upsert (sizing dry-run)
+# Run fetch + parse only; skip embedding and the pgvector upsert (sizing dry-run)
 uv run python -m rag.ingest --dry-run
 ```
 
-If 1 of 3 documents fails its fetch / parse / embed / upsert cycle, the
-others still complete and the CLI exits non-zero so any future cron / GitHub
-Action surfaces the failure instead of swallowing it.
+If one of the three documents fails its fetch / parse / embed / upsert cycle,
+the others still complete and the CLI exits non-zero so the failure surfaces
+rather than being swallowed.
 
-A weekly Airflow DAG (`airflow/dags/rag_ingest_weekly.py`) re-runs the
-pipeline at `0 3 * * 1`.
+!!! note "Run off-box"
+    Ingest runs on a workstation (or a throwaway larger instance), never the
+    shared 2 GB Lightsail box, pointed at the same Supabase pgvector DSN +
+    Bedrock region. There is **no scheduler** — Airflow was removed (ADR 008)
+    and the corpus changes a few times a year, so ingest is a manual run.
 
-## Cost
-
-A full re-embedding of all three PDFs runs at well under £0.20 one-time at
-the current `text-embedding-3-small` price ($0.02 per 1M tokens).
-**Conditional GETs and stable Pinecone IDs mean steady-state runs incur
-near-zero embedding spend** — most weeks every doc returns 304 and the
-pipeline exits in under a second.
-
-## Pinecone index shape
+## pgvector store shape
 
 | Property | Value |
 |----------|-------|
-| Index name | `tfl-strategy-docs` |
-| Dimension | 1536 |
+| Table | `public.tfl_strategy_docs` |
+| Dimension | 1024 |
+| Embedding model | `amazon.titan-embed-text-v2:0` (Bedrock, `eu-west-2`) |
 | Metric | cosine |
-| Cloud | AWS, `us-east-1` (serverless) |
-| Namespaces | `tfl_business_plan`, `mts_2018`, `tfl_annual_report` |
 | Metadata fields | `doc_id`, `chunk_index`, `page`, `text` |
 
-The agent fans out across all three namespaces by default with optional
-`doc_id` targeting — see [LangGraph agent](agent.md).
+`build_vector_store` (`src/rag/vectorstore.py`) is the single LlamaIndex
+`PGVectorStore` factory shared by ingest (write) and the agent retriever (read),
+so both sides speak the same table and embedding. The agent filters on `doc_id`
+for per-document targeting — see [LangGraph agent](agent.md).
+
+## Cost
+
+A full re-embedding of all three PDFs is a one-time, sub-pound Bedrock spend.
+**Conditional GETs and stable ids mean steady-state runs incur near-zero
+embedding cost** — most runs return 304 for every doc and exit in under a
+second.
 
 ## Tests
 
-28 unit tests with fakes for httpx / Docling / OpenAI / Pinecone:
+30 unit tests with fakes for httpx / PyMuPDF / Bedrock / pgvector:
 
 | Module | Coverage |
 |--------|----------|
 | `sources.py` | landing-page resolver picks the right PDF URL via per-source allowlist |
 | `fetch.py` | 304 short-circuit, 200 with body, ETag round-trip, retry on 5xx |
-| `parse.py` | Docling output → chunks with stable text + page metadata |
-| `embed.py` | Batch sizing, retry on 429, async ordering preserved |
-| `upsert.py` | Id stability, namespace rollover, partial-failure handling |
+| `parse.py` | PyMuPDF text → chunks with stable text + page metadata; default extractor is PyMuPDF |
+| `embeddings.py` | Titan `InvokeModel` body shape, 1024-dim vector, error path |
+| `upsert.py` | Id stability, doc rollover, partial-failure handling |
 | `ingest.py` | Orchestrator argument parsing, exit-non-zero on partial failure |
 
-No live network is hit in unit tests — fakes ride alongside production
+A separate integration test drives `build_vector_store` against a real pgvector
+so the dialect / ORM / `SET`-param class of bug can't regress past the fakes.
+No live network is hit in the unit suite — fakes ride alongside the production
 clients via constructor injection.

--- a/docs/pipelines/warehouse.md
+++ b/docs/pipelines/warehouse.md
@@ -1,153 +1,64 @@
-# dbt warehouse
+# Reference data (dbt)
 
-Three Postgres schemas, ten dbt models, generic + singular tests, and five
-exposures wiring marts to the API endpoints that consume them.
+ADR 014 removed the feed warehouse — the `raw.*` landing tables, the staging
+models, and the reliability / bus / disruptions marts are all gone. What
+remains is a **small, static reference layer**: a station seed and one mart
+built from it. Nothing here grows with feed volume.
 
-## Schema layout
+## What dbt builds now
 
-| Schema | Purpose | Owned by |
-|--------|---------|----------|
-| `raw.*` | Append-only JSONB landing tables | Consumers (`src/ingestion/consumers/`) |
-| `ref.*` | Reference data (lines, stations, modes) | TM-A2 static-ingest DAG (deferred) |
-| `analytics.*` | dbt-built staging + marts | dbt project under `dbt/models/` |
-
-## Lineage
+| Object | Type | Source of truth |
+|--------|------|-----------------|
+| `tfl_stations` | dbt **seed** (`dbt/seeds/tfl_stations.csv`) | `scripts/build_stations_seed.py` (one-off, from `/StopPoint/Mode/{mode}`) |
+| `analytics.dim_stations` | dbt **model** (`dbt/models/marts/dim_stations.sql`) | the seed above |
 
 ```mermaid
-flowchart TB
-    subgraph RAW[raw schema]
-      r1[(raw.line_status)]
-      r2[(raw.arrivals)]
-      r3[(raw.disruptions)]
-    end
-
-    subgraph STG[staging]
-      s1[stg_line_status]
-      s2[stg_arrivals]
-      s3[stg_disruptions]
-    end
-
-    subgraph MART[marts]
-      m1[mart_tube_reliability_daily]
-      m2[mart_tube_reliability_daily_summary]
-      m3[mart_disruptions_daily]
-      m4[mart_bus_metrics_daily]
-    end
-
-    subgraph EXP[exposures]
-      e1[/status/live, /status/history]
-      e2[/reliability/{line_id}]
-      e3[/disruptions/recent]
-      e4[/bus/{stop_id}/punctuality]
-    end
-
-    r1 --> s1 --> m1 --> m2
-    r2 --> s2 --> m4
-    r3 --> s3 --> m3
-
-    s1 --> e1
-    m2 --> e2
-    s3 --> e3
-    s2 --> e4
+flowchart LR
+    SCRIPT[scripts/build_stations_seed.py<br/>one-off scrape] --> SEED[(tfl_stations.csv<br/>~919 rows)]
+    SEED -->|dbt seed| REF[(seed table)]
+    REF -->|dbt run| DIM[(analytics.dim_stations<br/>NaPTAN → name)]
+    DIM -->|fast path| RESOLVER[src/api/stations.py]
+    RESOLVER -.miss.-> TFL[live TfL /StopPoint]
 ```
 
-## Staging models
+`dim_stations` is the fast path for the NaPTAN → station-name resolver
+(`src/api/stations.py`). It is static, so it is built **once per deploy** rather
+than on a schedule.
 
-All three staging models share the same shape:
+## How it runs
 
-- **Materialisation:** `incremental` with `unique_key='event_id'`, `merge`
-  strategy, `on_schema_change='fail'`.
-- **Lookback:** 5 minutes — incremental runs scan the last 5 min of `raw` rows
-  in case a late event arrives.
-- **Defensive dedup:** `row_number() OVER (PARTITION BY event_id ORDER BY
-  ingested_at DESC)` then keep `rn = 1`.
-- **JSONB unnesting:** explicit casts into typed columns (text / int /
-  numeric / timestamptz). No silent JSONB leakage downstream.
+There is no orchestrator. Apache Airflow was removed (ADR 008), and ADR 014
+removed the recurring dbt + retention cron. `scripts/deploy.sh` runs a one-shot
+`dbt seed` + `dbt build` of `dim_stations` after the API container passes its
+health check (`scripts/cron-dbt-run.sh`). The build is **non-fatal**: if it
+fails, the app still serves live data and the resolver falls back to the live
+TfL `/StopPoint` lookup.
 
-Reading the staging models is the cheapest way to understand the wire format
-of each topic.
-
-## Marts
-
-| Model | Grain | Notable columns |
-|-------|-------|-----------------|
-| `mart_tube_reliability_daily` | `(line_id, calendar_date_utc, status_severity)` | `snapshot_count`, `first_observed_at`, `last_observed_at`, `minutes_observed_estimate` |
-| `mart_tube_reliability_daily_summary` | `(line_id, calendar_date_utc)` | `pct_good_service`, `longest_disruption_window_minutes` (gaps-and-islands) |
-| `mart_disruptions_daily` | `(calendar_date_utc, line_id)` | `affected_routes` JSONB fan-out, `distinct_categories`, `max_severity` |
-| `mart_bus_metrics_daily` | `(calendar_date_utc, line_id, station_id)` | Filtered to bus lines via `source('tfl', 'lines')` |
-
-The `mart_tube_reliability_daily_summary` model is the most interesting — it
-runs a gaps-and-islands SQL pattern to compute the longest contiguous
-non-`Good Service` window per line per day:
-
-```sql
-with islands as (
-    select
-        line_id,
-        calendar_date_utc,
-        last_observed_at,
-        sum(case when status_severity = 'Good Service' then 1 else 0 end)
-            over (partition by line_id, calendar_date_utc order by last_observed_at) as island_id
-    from {{ ref('mart_tube_reliability_daily') }}
-)
-select
-    line_id,
-    calendar_date_utc,
-    max(extract(epoch from (last_observed_at - first_observed_at)) / 60.0)
-        as longest_disruption_window_minutes
-from (
-    select
-        line_id,
-        calendar_date_utc,
-        island_id,
-        min(last_observed_at) as first_observed_at,
-        max(last_observed_at) as last_observed_at
-    from islands
-    where status_severity != 'Good Service'
-    group by 1, 2, 3
-) windows
-group by 1, 2
+```bash
+# Manual rebuild on the box (what the deploy step calls):
+ssh ubuntu@13.41.145.33 '/opt/tfl-monitor/scripts/cron-dbt-run.sh'
 ```
+
+## Why keep dbt at all
+
+For one seed and one model, raw SQL would also work. dbt earns its place
+because it ships **tests, lineage, and documentation** with the data for
+near-zero cost, and because regenerating the station reference from scratch is a
+single `dbt build` against any fresh Postgres — useful given the database has
+been recreated from empty more than once.
+
+## The rest of the database
+
+Everything else in Postgres is application state, not a dbt artifact:
+
+| Object | Purpose |
+|--------|---------|
+| pgvector store (`public.data_tfl_strategy_docs`) | RAG retrieval — see [RAG ingestion](rag.md) |
+| `analytics.chat_messages` | chat memory backing `/chat/{thread_id}/history` |
+| `ref.lines`, `ref.stations` | line / station lookup seeds |
 
 ## Tests
 
-| Type | Count | Examples |
-|------|-------|----------|
-| Generic (`unique`, `not_null`, `accepted_values`, relationships) | 14 | `event_id` is unique on every staging model |
-| Singular | 8 | `pct_good_service` is bounded `[0, 100]`; `affected_routes` is valid JSONB; disruption category enum |
-
-Singular tests live under `dbt/tests/` and run via `dbt test`. CI gates the
-parser via `uv run task dbt-parse` on every PR.
-
-## Exposures
-
-Five exposures wire marts to the FastAPI endpoints that consume them, so
-`dbt docs generate` produces a useful lineage graph for a recruiter:
-
-```yaml
-- name: api_status_live
-  type: application
-  url: https://tflmonitor.duckdns.org/api/v1/status/live
-  depends_on: [source('tfl', 'line_status')]
-
-- name: api_reliability_window
-  type: application
-  url: https://tflmonitor.duckdns.org/api/v1/reliability/{line_id}
-  depends_on: [ref('mart_tube_reliability_daily')]
-```
-
-Five total — one per warehouse-backed endpoint.
-
-## Idempotency and lateness
-
-Three properties combine to make every mart re-runnable from scratch:
-
-1. **`merge` materialisation** with `unique_key='event_id'` — re-running a
-   batch updates rows in place rather than appending duplicates.
-2. **5-minute lookback** — staging models scan the last 5 min of `raw` rows
-   to catch late arrivals.
-3. **UTC anchoring** — every `calendar_date_utc` derives from `ingested_at` in
-   UTC, so re-running across timezones yields identical rows.
-
-A nightly `dbt build` (`0 1 * * *` in `airflow/dags/dbt_nightly.py`)
-rebuilds the marts from staging.
+`uv run task dbt-parse` gates the project on every PR. The `dim_stations` model
+and the `tfl_stations` seed carry generic dbt tests (`unique`, `not_null` on the
+NaPTAN key) under `dbt/models/marts/schema.yml` and `dbt/seeds/schema.yml`.

--- a/docs/pipelines/warehouse.md
+++ b/docs/pipelines/warehouse.md
@@ -53,7 +53,7 @@ Everything else in Postgres is application state, not a dbt artifact:
 
 | Object | Purpose |
 |--------|---------|
-| pgvector store (`public.data_tfl_strategy_docs`) | RAG retrieval — see [RAG ingestion](rag.md) |
+| pgvector store (`public.tfl_strategy_docs`) | RAG retrieval — see [RAG ingestion](rag.md) |
 | `analytics.chat_messages` | chat memory backing `/chat/{thread_id}/history` |
 | `ref.lines`, `ref.stations` | line / station lookup seeds |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,10 +7,10 @@ so at most two agents can collide-free at any time.
 
 | Track | Owner directories | Purpose |
 |-------|------------------|---------|
-| **A — infra** | `docker-compose.yml`, `infra/`, `airflow/`, `.github/` | Boots, deploys, schedules |
-| **B — ingestion** | `src/ingestion/` | Producers + consumers + tfl-client |
-| **C — dbt** | `dbt/` | Staging, marts, exposures, tests |
-| **D — api-agent** | `src/api/`, `src/agent/`, `src/rag/` | FastAPI + LangGraph + RAG |
+| **A — infra** | `infra/`, `scripts/`, `.github/` | Boots, deploys (shared Lightsail) |
+| **B — ingestion** | `src/ingestion/tfl_client/` | Async TfL client (read-through) |
+| **C — dbt** | `dbt/` | Station seed + `dim_stations` |
+| **D — api-agent** | `src/api/`, `src/rag/` | FastAPI + LangGraph + RAG |
 | **E — frontend** | `web/` | Next.js dashboard |
 | **F — polish** | top-level docs, `README.md` | Demo, video, polish |
 
@@ -22,72 +22,55 @@ gantt
     title       tfl-monitor delivery timeline (✅ complete · 🚧 next up)
     section Foundations
     TM-000 Contracts + scaffold        :done, 2026-04-22, 1d
-    TM-A1 Compose + Postgres + Redpanda :done, 2026-04-23, 1d
-    TM-C1 dbt scaffold                 :done, 2026-04-23, 1d
-    TM-D1 FastAPI skeleton             :done, 2026-04-26, 1d
     TM-B1 TfL client + fixtures        :done, 2026-04-26, 1d
-    section Streaming
-    TM-B2 line-status producer         :done, 2026-04-27, 1d
-    TM-B3 line-status consumer         :done, 2026-04-28, 1d
-    TM-B4 arrivals + disruptions       :done, 2026-04-28, 1d
-    section Warehouse
-    TM-C2 staging + first mart         :done, 2026-04-28, 1d
-    TM-C3 remaining marts + exposures  :done, 2026-04-28, 1d
-    section API + agent
-    TM-D2 endpoints to Postgres        :done, 2026-04-28, 1d
-    TM-D3 disruptions + bus endpoints  :done, 2026-04-28, 1d
+    TM-D1 FastAPI skeleton             :done, 2026-04-26, 1d
+    section API + RAG + agent
     TM-D4 RAG ingestion                :done, 2026-04-28, 1d
     TM-D5 LangGraph agent              :done, 2026-04-29, 1d
+    TM-32 Bedrock + pgvector cutover   :done, 2026-05-27, 1d
     section Frontend
-    TM-E1a scaffold + Network Now      :done, 2026-04-28, 1d
-    TM-E1b Network Now wired           :done, 2026-04-28, 1d
-    TM-E2 Disruption Log view          :done, 2026-04-28, 1d
-    TM-E3 Chat view + SSE              :done, 2026-04-29, 1d
-    section Orchestration
-    TM-A2 Airflow DAGs                 :done, 2026-04-28, 1d
-    section Deploy + polish
-    TM-A5 AWS Bedrock + EC2 deploy    :active, 2026-04-29, 3d
-    TM-E4 Vercel deploy               :2026-05-02, 1d
-    TM-F1 README polish + demo         :2026-05-03, 2d
+    TM-E5 Dashboard one-pager          :done, 2026-05-12, 1d
+    TM-30 Journey + arrivals tools     :done, 2026-05-27, 1d
+    TM-33 Journey/arrivals chat cards  :done, 2026-05-28, 1d
+    section Deploy
+    TM-A5 Shared Lightsail + Bedrock   :done, 2026-05-19, 1d
+    TM-E4 Vercel deploy                :done, 2026-05-13, 1d
+    section Decommission + polish
+    TM-34 Warehouse → live proxy       :done, 2026-05-28, 1d
+    TM-35 Docs sync (live proxy)       :active, 2026-05-29, 1d
+    TM-F1 README polish + demo         :2026-05-30, 2d
 ```
 
 ## WP ledger
 
 Source of truth: [`PROGRESS.md`](https://github.com/hcslomeu/tfl-monitor/blob/main/PROGRESS.md).
+The highlights below track the live-proxy shape; the full per-WP notes live in
+`PROGRESS.md`.
 
-| Phase | WP | Title | Track | Status |
-|-------|----|-------|-------|--------|
-| 0 | TM-000 | Contracts + scaffold | — | ✅ 2026-04-22 |
-| 1 | TM-A1 | Docker Compose + Postgres + Redpanda + Airflow | A | ✅ 2026-04-23 |
-| 1 | TM-B1 | Async TfL client + fixtures | B | ✅ 2026-04-26 |
-| 2 | TM-C1 | dbt scaffold | C | ✅ 2026-04-23 |
-| 2 | TM-D1 | FastAPI skeleton + Logfire wiring | D | ✅ 2026-04-26 |
-| 3 | TM-B2 | line-status producer | B | ✅ 2026-04-27 |
-| 3 | TM-B3 | line-status consumer | B | ✅ 2026-04-28 |
-| 3 | TM-C2 | dbt staging + first mart | C | ✅ 2026-04-28 |
-| 3 | TM-D2 | Wire endpoints to Postgres | D | ✅ 2026-04-28 |
-| 3 | TM-E1a | Next.js scaffold + Network Now (mocked) | E | ✅ 2026-04-28 |
-| 3 | TM-E1b | Network Now wired to `/status/live` | E | ✅ 2026-04-28 |
-| 4 | TM-B4 | arrivals + disruptions topics | B | ✅ 2026-04-28 |
-| 4 | TM-C3 | Remaining marts + tests + exposures | C | ✅ 2026-04-28 |
-| 4 | TM-D3 | Remaining endpoints | D | ✅ 2026-04-28 |
-| 4 | TM-E2 | Disruption Log view | E | ✅ 2026-04-28 |
-| 5 | TM-A2 | Airflow DAGs | A | ✅ 2026-04-28 |
-| 5 | TM-D4 | RAG ingestion: Docling → Pinecone | D | ✅ 2026-04-28 |
-| 6 | TM-D5 | LangGraph agent (SQL + RAG + Pydantic AI) | D | ✅ 2026-04-29 |
-| 6 | TM-E3 | Chat view with SSE | E | ✅ 2026-04-29 |
-| 7 | TM-A3 | Supabase provisioning | A | 🚧 absorbed into TM-A5 |
-| 7 | TM-A4 | Redpanda Cloud | A | 🚧 absorbed into TM-A5 |
-| 7 | TM-A5 | AWS Bedrock + EC2 deploy | A | 🚧 in progress |
-| 7 | TM-E4 | Vercel deploy | E | ⬜ |
-| 7 | TM-F1 | README polish + demo video + live URL | F | ⬜ |
+| Phase | WP | Title | Status |
+|-------|----|-------|--------|
+| 0 | TM-000 | Contracts + scaffold | ✅ |
+| 1 | TM-B1 | Async TfL client + fixtures | ✅ |
+| 2 | TM-D1 | FastAPI skeleton + Logfire | ✅ |
+| 5 | TM-D4 | RAG ingestion (later migrated to PyMuPDF + Bedrock + pgvector) | ✅ |
+| 6 | TM-D5 | LangGraph agent (SQL + RAG + Pydantic AI) | ✅ |
+| 7 | TM-E5 | Dashboard one-pager + chat | ✅ |
+| 7 | TM-A5 | Shared Lightsail + Bedrock deploy | ✅ |
+| 7 | TM-E4 | Vercel deploy | ✅ |
+| 7 | TM-29 | Station resolver + disruption enrichment | ✅ |
+| 7 | TM-30 | Journey + arrivals agent tools | ✅ |
+| 7 | TM-32 | RAG migration: Bedrock + pgvector | ✅ |
+| 7 | TM-33 | Journey/arrivals chat cards (SSE frames) | ✅ |
+| 7 | TM-34 | Decommission warehouse → live TfL proxy + RAG | ✅ |
+| 7 | TM-35 | Docs sync — mkdocs to live-proxy architecture | 🚧 |
+| 7 | TM-F1 | README polish + demo video + live URL | ⬜ |
 
-## What "in progress" means
-
-A WP is *in progress* once its plan in `.claude/specs/TM-XXX-plan.md` has
-been signed off by the author and Phase 3 (implementation) has started. The
-[TM-A5 plan](https://github.com/hcslomeu/tfl-monitor/blob/main/.claude/specs/TM-A5-plan.md)
-is the latest active document.
+!!! note "Superseded WPs"
+    Earlier streaming + warehouse WPs (line-status / arrivals / disruptions
+    producers + consumers, the `raw.*` → staging → marts dbt models, and the
+    reliability / bus endpoints) shipped and were later **removed by ADR 014**.
+    The Airflow DAGs (TM-A2) were removed by ADR 008, and Docling/OpenAI/Pinecone
+    (TM-D4) were replaced in TM-32. They remain in git history.
 
 ## How a WP closes
 
@@ -95,7 +78,7 @@ Every WP runs through this checklist before being marked `✅`:
 
 - [x] All acceptance criteria from the spec met
 - [x] `uv run task lint` (Ruff + Mypy strict) passes
-- [x] `uv run task test` (Pytest, no integration / no airflow markers) passes
+- [x] `uv run task test` (Pytest) passes
 - [x] `uv run task dbt-parse` passes if `dbt/` or `contracts/sql/` was touched
 - [x] `make check` (Python + TS gates chained) passes end-to-end
 - [x] `PROGRESS.md` updated with completion date and notes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: tfl-monitor
 site_description: >-
-  A real-time data + AI engineering portfolio project — streaming TfL feeds
-  into a dbt-modelled warehouse, with a RAG agent over TfL strategy documents.
+  A real-time data + AI engineering portfolio project — a live Transport for
+  London proxy with a RAG agent over TfL strategy documents.
 site_author: Humberto Slomeu
 site_url: https://hcslomeu.github.io/tfl-monitor/
 
@@ -153,8 +153,8 @@ nav:
       - Observability: observability.md
   - Pipelines:
       - pipelines/index.md
-      - Streaming ingestion: pipelines/ingestion.md
-      - dbt warehouse: pipelines/warehouse.md
+      - Live TfL proxy: pipelines/ingestion.md
+      - Reference data: pipelines/warehouse.md
       - RAG ingestion: pipelines/rag.md
       - LangGraph agent: pipelines/agent.md
       - FastAPI surface: pipelines/api.md


### PR DESCRIPTION
## What

The published mkdocs site under `docs/` still described the streaming pipeline that **ADR 014** removed — Kafka/Redpanda broker, producers/consumers, the `raw.*` warehouse with staging/marts, and the `/reliability`, `/status/history`, `/bus` endpoints. TM-34 already fixed `docs/stack.md`, `docs/adrs.md`, and the package READMEs; this PR closes the rest of the site.

## Changes

- **Rewrote two dead pipeline pages in place** (URLs + nav slots kept):
  - `pipelines/ingestion.md`: *Streaming ingestion* → **Live TfL proxy** (read-through `TflClient`, no broker).
  - `pipelines/warehouse.md`: *dbt warehouse* → **Reference data** (seeds + `dim_stations` only).
- **Rewrote** `architecture.md` (system diagram + component table + ADR list), `index.md` (home cards + tech-stack glance), `roadmap.md` (tracks + gantt + ledger vs `PROGRESS.md`), and `deployment.md` (now shared Lightsail + Caddy + Cloudflare, single `api` container — the old EC2-spot/DuckDNS/Railway plan never shipped).
- **Surgical edits** to `engineering.md`, `observability.md`, `glossary.md`, and `pipelines/{agent,api,index,frontend,rag}.md`: dropped removed tools (`query_line_reliability`, `query_bus_punctuality`) and endpoints; corrected the agent tool surface (status, disruptions, journey, arrivals, RAG).
- **Corrected the RAG stack** wherever it appeared (Docling → PyMuPDF per ADR 013; OpenAI → Bedrock Titan v2 and Pinecone → pgvector per TM-32). These were stale beyond ADR 014 but interwoven with the pages above, so leaving them would have shipped a half-wrong site.
- `mkdocs.yml`: `site_description` + the two renamed nav labels.

## Out of scope / left as-is

- `docs/stack.md` and `docs/adrs.md` — already correct (TM-34).
- `docs/superpowers/*` — point-in-time design docs, outside the nav.
- No code, contract, or dbt changes. Docs only.

## Verification

- `uv run --group docs mkdocs build --strict` → **built clean**, 0 warnings.
- Residual-staleness grep over nav pages is clean (remaining hits are legitimate: `dim_stations` genuinely is a dbt mart, ADR link titles, and explicit "removed/superseded" framing).

## Flags for the author

- **Model version:** `deployment.md` follows `infra/README.md` (Claude Sonnet 4.5 + Haiku 4.5); other pages stay version-agnostic. `stack.md` still says "Sonnet 3.5 v2 / Haiku 3.5" — left untouched here, but the two disagree and may want reconciling in a follow-up.
- Two unrelated frontend WIP files (`web/components/dashboard/journey-card.tsx`, `web/styles/design-system/tfl-monitor.css`) were present uncommitted in the working tree at branch time. They are **not** part of this PR and were left untouched.

Closes TM-35.