### PR TITLE
fix(web): journey leg line colours + chatbox font bump

### DIFF
--- a/web/components/dashboard/journey-card.tsx
+++ b/web/components/dashboard/journey-card.tsx
@@ -43,9 +43,9 @@ function modeColor(mode: string): string {
  * mode colour.
  */
 function legColor(mode: string, summary: string): string {
-	if (mode === "tube") {
+	if (mode === "tube" && summary) {
 		const match = /^(.*?)\s+line\b/i.exec(summary);
-		const lineColor = match && TUBE_LINE_COLOR[match[1].toLowerCase()];
+		const lineColor = match && TUBE_LINE_COLOR[match[1].trim().toLowerCase()];
 		if (lineColor) {
 			return lineColor;
 		}

--- a/web/components/dashboard/journey-card.tsx
+++ b/web/components/dashboard/journey-card.tsx
@@ -15,8 +15,42 @@ const MODE_COLOR: Record<string, string> = {
 
 const FALLBACK_MODE_COLOR = "#5A6A77";
 
+/** Official TfL line colours, keyed by lowercase line name. */
+const TUBE_LINE_COLOR: Record<string, string> = {
+	bakerloo: "#B36305",
+	central: "#E32017",
+	circle: "#FFD300",
+	district: "#00782A",
+	"hammersmith & city": "#F3A9BB",
+	jubilee: "#A0A5A9",
+	metropolitan: "#9B0056",
+	northern: "#000000",
+	piccadilly: "#003688",
+	victoria: "#0098D4",
+	"waterloo & city": "#95CDBA",
+};
+
 function modeColor(mode: string): string {
 	return MODE_COLOR[mode] ?? FALLBACK_MODE_COLOR;
+}
+
+/**
+ * Pick a leg marker colour.
+ *
+ * Legs carry no line id, so tube legs are coloured from the line name in
+ * the TfL summary ("Central line to Bank" → central → red), keeping the
+ * marker in sync with the named line. Everything else falls back to its
+ * mode colour.
+ */
+function legColor(mode: string, summary: string): string {
+	if (mode === "tube") {
+		const match = /^(.*?)\s+line\b/i.exec(summary);
+		const lineColor = match && TUBE_LINE_COLOR[match[1].toLowerCase()];
+		if (lineColor) {
+			return lineColor;
+		}
+	}
+	return modeColor(mode);
 }
 
 /** Pull "HH:MM" out of a naive (London-local) ISO timestamp. */
@@ -60,7 +94,7 @@ export function JourneyCard({ view }: { view: JourneyView }) {
 					>
 						<span
 							className="tfl-journey-dot"
-							style={{ background: modeColor(leg.mode) }}
+							style={{ background: legColor(leg.mode, leg.summary) }}
 							aria-hidden
 						/>
 						<div className="tfl-journey-leg-body">

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -259,7 +259,7 @@
 }
 .tfl-chatbox .tfl-chatbox-ta { min-height: 22px; padding: 2px 0 4px; }
 .tfl-chatbox .tfl-chatbox-row { gap: 6px; }
-.tfl-chatbox .tfl-chip-sm { padding: 2px 8px; font-size: var(--ui-xs); }
+.tfl-chatbox .tfl-chip-sm { padding: 2px 8px; font-size: calc(var(--ui-xs) + 1px); }
 .tfl-chatbox .tfl-chat-iconbtn { width: 22px; height: 22px; }
 .tfl-chatbox .tfl-chatbox-send { width: 24px; height: 24px; }
 .tfl-chatbox-ta {
@@ -267,7 +267,7 @@
      scale. This accepts iOS Safari's zoom-on-focus (it bumps inputs under
      16px); the visual consistency is preferred over suppressing that zoom. */
   width: 100%; resize: none; border: none; outline: none; background: transparent;
-  font-family: var(--font-body); font-size: var(--ui-sm); color: #EEE9DE;
+  font-family: var(--font-body); font-size: calc(var(--ui-sm) + 1px); color: #EEE9DE;
   line-height: 1.5; padding: 4px 0 10px; min-height: 44px;
 }
 .tfl-chatbox-ta:focus-visible {

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -257,7 +257,7 @@
   border: 1px solid #2A2724;
   box-shadow: var(--shadow-card-hover);
 }
-.tfl-chatbox .tfl-chatbox-ta { min-height: 22px; padding: 2px 0 4px; }
+.tfl-chatbox .tfl-chatbox-ta { min-height: 22px; padding: 2px 0 4px; font-size: calc(var(--ui-sm) + 1px); }
 .tfl-chatbox .tfl-chatbox-row { gap: 6px; }
 .tfl-chatbox .tfl-chip-sm { padding: 2px 8px; font-size: calc(var(--ui-xs) + 1px); }
 .tfl-chatbox .tfl-chat-iconbtn { width: 22px; height: 22px; }
@@ -267,7 +267,7 @@
      scale. This accepts iOS Safari's zoom-on-focus (it bumps inputs under
      16px); the visual consistency is preferred over suppressing that zoom. */
   width: 100%; resize: none; border: none; outline: none; background: transparent;
-  font-family: var(--font-body); font-size: calc(var(--ui-sm) + 1px); color: #EEE9DE;
+  font-family: var(--font-body); font-size: var(--ui-sm); color: #EEE9DE;
   line-height: 1.5; padding: 4px 0 10px; min-height: 44px;
 }
 .tfl-chatbox-ta:focus-visible {


### PR DESCRIPTION
## What

Two frontend aesthetic fixes.

### 1. Journey leg colour mismatch
Leg markers in `JourneyCard` were coloured by transport **mode** (`tube → #0019A8`), so every tube leg rendered the same generic blue regardless of the named line — a Central-line leg showed a Piccadilly-ish blue, with no link between the dot colour and the line in the summary.

Fix: derive tube leg colour from the line name parsed out of the TfL `summary` (`"Central line to Bank" → central → #E32017`) and map to the official TfL line palette. Non-tube legs keep their existing mode colour. No contract/schema change — `JourneyLeg` still carries only `mode`/`summary`/`minutes`.

### 2. Chatbox font size
Bump the chatbox textarea and chips up by 1px (`13→14`, `11→12`), scoped to `.tfl-chatbox` via `calc(token + 1px)` so global type tokens are untouched.

## Verification
- `biome check` clean
- `vitest run` — 118 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)