### PR TITLE
fix(ci): enable Claude auto-review + remove gated review triggers

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,21 +1,32 @@
 name: Claude Code
 
 on:
+  # NOTE: pull_request_review + pull_request_review_comment are intentionally
+  # NOT subscribed. Those two events, when fired by a non-collaborator GitHub
+  # App (e.g. Copilot), get held as `action_required` (manual-approval gate) and
+  # never run — surfacing as a yellow/❌ check on every PR a review bot touches.
+  # The only feature they'd add is "@claude" inside an inline review thread,
+  # which is niche; "@claude" in a normal PR/issue comment still works via the
+  # issue_comment trigger below.
   issue_comment:
-    types: [created]
-  pull_request_review_comment:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  # PR number lives in different payload paths depending on the trigger event:
+  #   pull_request → github.event.pull_request.number
+  #   issue_comment / issues → github.event.issue.number
+  group: claude-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   claude:
+    name: Claude (interactive @claude mention)
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
@@ -39,3 +50,43 @@ jobs:
             actions: read
           claude_args: |
             --model claude-opus-4-7
+
+  claude-auto-review:
+    name: Claude (auto-review on PR open/sync)
+    # Auto-fire on every non-draft same-repo PR open/update. Skip drafts and
+    # fork PRs (repo secrets are not exposed to forks, so CLAUDE_CODE_OAUTH_TOKEN
+    # would be empty and the action would 401).
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.event.pull_request.head.ref, 'vercel/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Claude Code review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-opus-4-7
+          prompt: |
+            Review this pull request. Focus on:
+            - Bugs and logic errors
+            - Security issues (especially command/SQL injection, secrets, auth)
+            - Adherence to conventions in CLAUDE.md
+            - Code quality, clarity, and over-engineering (YAGNI/DRY/KISS)
+            - Test coverage for new behavior
+            Post inline review comments on specific lines where appropriate.
+            Skip stylistic nitpicks that CodeRabbit/Gemini already cover.
+            Be concise — one summary comment + targeted inline comments.


### PR DESCRIPTION
## Problem

The Claude review action never worked in this repo:

- **No auto-review job** — `claude.yml` was the interactive-only template (`@claude` mention only), with no `pull_request` trigger, so Claude never reviewed PRs on open/sync.
- **`action_required` gating** — `pull_request_review` + `pull_request_review_comment` triggers fire on every bot inline-comment. When a non-collaborator GitHub App (e.g. Copilot) fires them, GitHub holds the run as `action_required` (manual-approval gate) → it never runs and shows as a yellow/❌ check on the PR.

## Fix

1. Add the `claude-auto-review` job (fires on `pull_request` open/sync — human-triggered, never gated).
2. Drop the two review-based triggers. They only enabled `@claude` *inside an inline review thread* (niche); `@claude` in a normal PR/issue comment still works via `issue_comment` (which is never gated).

Auto-review skips drafts and fork PRs (fork PRs cannot read repo secrets → would 401).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated code review capability that runs on pull requests, generating concise summaries and delivering targeted inline review comments for new and updated changes.

* **Chores**
  * Refined workflow event triggers to streamline review initiation and improve overall workflow efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hcslomeu/tfl-monitor/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->