### PR TITLE
feat(web): add portfolio globe link in footer

### DIFF
--- a/web/components/icons.tsx
+++ b/web/components/icons.tsx
@@ -46,6 +46,14 @@ export const XIcon = brand(
 	<path d="M18 2h3l-7.5 8.6L22 22h-6.7l-5.2-6.8L4.2 22H1.2l8-9.2L1 2h6.8l4.7 6.2L18 2z" />,
 );
 
+export const GlobeIcon = brand(
+	<>
+		<circle cx="12" cy="12" r="10" />
+		<path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+		<path d="M2 12h20" />
+	</>,
+);
+
 export const AtSignIcon = brand(
 	<>
 		<circle cx="12" cy="12" r="4" />

--- a/web/components/layout/footer.tsx
+++ b/web/components/layout/footer.tsx
@@ -32,7 +32,7 @@ export function Footer() {
 						href="https://humbertolomeu.com"
 						target="_blank"
 						rel="noopener noreferrer"
-						aria-label="Retrieverworks"
+						aria-label="Humberto Lomeu — portfolio"
 					>
 						<span className="hl-footer-mark-logo">
 							{/* eslint-disable-next-line @next/next/no-img-element */}

--- a/web/components/layout/footer.tsx
+++ b/web/components/layout/footer.tsx
@@ -1,11 +1,13 @@
 import {
 	GithubIcon,
+	GlobeIcon,
 	LinkedinIcon,
 	UpworkIcon,
 	XIcon,
 } from "@/components/icons";
 
 const socials = [
+	{ label: "Portfolio", href: "https://humbertolomeu.com", Icon: GlobeIcon },
 	{ label: "Github", href: "https://github.com/hcslomeu", Icon: GithubIcon },
 	{
 		label: "LinkedIn",
@@ -27,7 +29,7 @@ export function Footer() {
 				<div className="hl-footer-foot">
 					<a
 						className="hl-footer-mark"
-						href="https://retrieverworks.com"
+						href="https://humbertolomeu.com"
 						target="_blank"
 						rel="noopener noreferrer"
 						aria-label="Retrieverworks"


### PR DESCRIPTION
## Summary

- Adds a globe icon as the first item in the footer social row, linking to https://humbertolomeu.com so portfolio visitors can return to the main site.
- Repoints the footer brand mark from https://retrieverworks.com to https://humbertolomeu.com until retrieverworks.com is ready.

## Changes
- `web/components/icons.tsx` — new `GlobeIcon` built with the existing `brand()` factory (Lucide-style stroke paths), consistent sizing/stroke with sibling icons.
- `web/components/layout/footer.tsx` — globe prepended to the data-driven `socials` array; brand-mark `href` updated.

## Verification
- Ran `next dev` locally and confirmed the footer renders the globe link and the retargeted brand mark.
