### PR TITLE
feat(agent): suppress live conditions for future-dated journeys

### DIFF
--- a/src/api/agent/prompts.py
+++ b/src/api/agent/prompts.py
@@ -24,8 +24,9 @@ Do NOT restate that breakdown in prose — it would duplicate the card.
 Reply with at most one short sentence, plus only a caveat or follow-up
 the data genuinely warrants (e.g. a night-only route, no service found).
 
-Future trips: when the user names a day or time other than now (e.g.
-"tomorrow", "Friday at 6pm"), resolve it against today's date and pass
+Future trips: when the user asks for a departure later today or on a
+future date/time (e.g. "tomorrow", "Friday at 6pm"), resolve it against
+today's date and pass
 plan_journey_tool a departure_time as an ISO-8601 timestamp (e.g.
 "2026-06-03T18:00"), then report only the simplest, fastest route. Do
 NOT call query_tube_status or query_recent_disruptions for a future trip

--- a/src/api/agent/prompts.py
+++ b/src/api/agent/prompts.py
@@ -24,6 +24,14 @@ Do NOT restate that breakdown in prose — it would duplicate the card.
 Reply with at most one short sentence, plus only a caveat or follow-up
 the data genuinely warrants (e.g. a night-only route, no service found).
 
+Future trips: when the user names a day or time other than now (e.g.
+"tomorrow", "Friday at 6pm"), resolve it against today's date and pass
+plan_journey_tool a departure_time, then report only the simplest,
+fastest route. Do NOT call query_tube_status or query_recent_disruptions
+for a future trip — live disruptions describe conditions right now, not
+the trip's time, so reporting them would mislead. If the user gives a
+day but no time, ask for the time before planning rather than guessing.
+
 Pick the smallest tool set that answers. Today is {today}."""
 
 

--- a/src/api/agent/prompts.py
+++ b/src/api/agent/prompts.py
@@ -26,11 +26,12 @@ the data genuinely warrants (e.g. a night-only route, no service found).
 
 Future trips: when the user names a day or time other than now (e.g.
 "tomorrow", "Friday at 6pm"), resolve it against today's date and pass
-plan_journey_tool a departure_time, then report only the simplest,
-fastest route. Do NOT call query_tube_status or query_recent_disruptions
-for a future trip — live disruptions describe conditions right now, not
-the trip's time, so reporting them would mislead. If the user gives a
-day but no time, ask for the time before planning rather than guessing.
+plan_journey_tool a departure_time as an ISO-8601 timestamp (e.g.
+"2026-06-03T18:00"), then report only the simplest, fastest route. Do
+NOT call query_tube_status or query_recent_disruptions for a future trip
+— live disruptions describe conditions right now, not the trip's time,
+so reporting them would mislead. If the user gives a day but no time,
+ask for the time before planning rather than guessing.
 
 Pick the smallest tool set that answers. Today is {today}."""
 

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -38,6 +38,7 @@ def test_future_trip_rule_suppresses_live_conditions() -> None:
     collapsed = " ".join(render(today="2026-06-02").lower().split())
     assert "future trips" in collapsed
     assert "departure_time as an iso-8601 timestamp" in collapsed
+    assert "only the simplest, fastest route" in collapsed
     assert (
         "do not call query_tube_status or query_recent_disruptions for a future trip" in collapsed
     )

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -15,10 +15,16 @@ def test_render_substitutes_today() -> None:
 
 
 def test_render_defaults_today_to_utc_date() -> None:
-    """No argument → today's UTC date is substituted."""
+    """No argument → today's UTC date is substituted.
+
+    Capturing the date either side of ``render()`` tolerates a midnight-UTC
+    rollover landing between the two ``now()`` reads.
+    """
+    before = datetime.now(UTC).date().isoformat()
     out = render()
+    after = datetime.now(UTC).date().isoformat()
     assert "{today}" not in out
-    assert f"Today is {datetime.now(UTC).date().isoformat()}." in out
+    assert f"Today is {before}." in out or f"Today is {after}." in out
 
 
 def test_future_trip_rule_suppresses_live_conditions() -> None:
@@ -26,11 +32,13 @@ def test_future_trip_rule_suppresses_live_conditions() -> None:
 
     A trip planned for a future time must route through ``departure_time``
     and must not pull live status/disruptions (which only describe "now"),
-    and a missing time must be asked for rather than guessed.
+    and a missing time must be asked for rather than guessed. Whitespace is
+    collapsed so the assertions are immune to prompt line-wrapping.
     """
-    lowered = render(today="2026-06-02").lower()
-    assert "future trips" in lowered
-    assert "departure_time" in lowered
-    assert "query_tube_status" in lowered
-    assert "query_recent_disruptions" in lowered
-    assert "ask for the time" in lowered
+    collapsed = " ".join(render(today="2026-06-02").lower().split())
+    assert "future trips" in collapsed
+    assert "departure_time as an iso-8601 timestamp" in collapsed
+    assert (
+        "do not call query_tube_status or query_recent_disruptions for a future trip" in collapsed
+    )
+    assert "ask for the time before planning" in collapsed

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -1,0 +1,36 @@
+"""Unit tests for the agent system prompt (``api.agent.prompts``)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from api.agent.prompts import render
+
+
+def test_render_substitutes_today() -> None:
+    """``{today}`` placeholder is replaced and never leaks into the output."""
+    out = render(today="2026-06-02")
+    assert "Today is 2026-06-02." in out
+    assert "{today}" not in out
+
+
+def test_render_defaults_today_to_utc_date() -> None:
+    """No argument → today's UTC date is substituted."""
+    out = render()
+    assert "{today}" not in out
+    assert f"Today is {datetime.now(UTC).date().isoformat()}." in out
+
+
+def test_future_trip_rule_suppresses_live_conditions() -> None:
+    """Future-trip policy must survive prompt edits.
+
+    A trip planned for a future time must route through ``departure_time``
+    and must not pull live status/disruptions (which only describe "now"),
+    and a missing time must be asked for rather than guessed.
+    """
+    lowered = render(today="2026-06-02").lower()
+    assert "future trips" in lowered
+    assert "departure_time" in lowered
+    assert "query_tube_status" in lowered
+    assert "query_recent_disruptions" in lowered
+    assert "ask for the time" in lowered


### PR DESCRIPTION
## What

Teaches the chat agent to treat **future-dated journeys** differently from "leave now" trips.

When the user names a day or time other than now ("tomorrow", "Friday at 6pm"), the agent now:
- resolves it against today's date and passes `plan_journey_tool` a `departure_time` (the TfL client already forwards this as `date`/`time`/`timeIs=Departing`);
- reports only the simplest, fastest route;
- **does not** call `query_tube_status` or `query_recent_disruptions`;
- asks for the time when a day is given without one, rather than guessing.

## Why

TfL only exposes **current** disruptions — there is no forecast of conditions for a future departure. Surfacing today's line status against tomorrow's trip is noise at best and misleading at worst. The correct answer for a future trip is the cleanest route, not live alerts.

## Scope

Prompt-only behavioural change in `src/api/agent/prompts.py` — no new tool, no schema change. The journey infrastructure (`departure_time` → TfL `JourneyResults`) was already in place.

## Tests

`tests/agent/test_prompts.py` — guard test pinning the future-trip rule and the `{today}` substitution so a later prompt edit can't silently drop it. Full agent suite green (42 passed); `uv run task lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved future-trip planning: resolves named days/times against today, requires an explicit time when only a day is given, supplies departure_time in ISO-8601, and returns only the simplest/fastest route while ignoring live-condition checks for future trips.
* **Tests**
  * Added unit tests ensuring today’s placeholder is substituted (using UTC as default) and validating the future-trip prompt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->