### PR TITLE
fix(web): drop inset focus ring over chat composer text

### DIFF
--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -276,11 +276,15 @@
   font-family: var(--font-body); font-size: var(--ui-sm); color: #EEE9DE;
   line-height: 1.5; padding: 4px 0 10px; min-height: 44px;
 }
-/* No inset focus ring on the textarea itself — it overlapped the typed
-   text and hurt readability. Focus is signalled on the composer edge via
-   `.tfl-chatbox:focus-within` (subtle, neutral, never over the text). */
-.tfl-chatbox-ta:focus-visible { outline: none; }
-.tfl-chatbox:focus-within { border-color: #4A4744; }
+/* Focus is signalled by an external ring on the composer container, not an
+   inset outline on the textarea: the old inset ring overlapped the typed text
+   and hurt readability. The ring sits outside the box (box-shadow spread, no
+   inset) so it never touches the text, while keeping a clearly visible,
+   WCAG-AA focus affordance for keyboard users. The textarea already sets
+   `outline: none` in its base styles, so no per-state reset is needed. */
+.tfl-chatbox:focus-within {
+  box-shadow: var(--shadow-card-hover), 0 0 0 2px var(--accent-display);
+}
 .tfl-chatbox-ta::placeholder { color: rgba(238,233,222,0.45); }
 .tfl-chatbox-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 .tfl-chatbox-l { display: flex; gap: 6px; flex-wrap: wrap; }

--- a/web/styles/design-system/tfl-monitor.css
+++ b/web/styles/design-system/tfl-monitor.css
@@ -276,11 +276,11 @@
   font-family: var(--font-body); font-size: var(--ui-sm); color: #EEE9DE;
   line-height: 1.5; padding: 4px 0 10px; min-height: 44px;
 }
-.tfl-chatbox-ta:focus-visible {
-  outline: 2px solid var(--accent-display);
-  outline-offset: -2px;
-  border-radius: var(--radius-sm);
-}
+/* No inset focus ring on the textarea itself — it overlapped the typed
+   text and hurt readability. Focus is signalled on the composer edge via
+   `.tfl-chatbox:focus-within` (subtle, neutral, never over the text). */
+.tfl-chatbox-ta:focus-visible { outline: none; }
+.tfl-chatbox:focus-within { border-color: #4A4744; }
 .tfl-chatbox-ta::placeholder { color: rgba(238,233,222,0.45); }
 .tfl-chatbox-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 .tfl-chatbox-l { display: flex; gap: 6px; flex-wrap: wrap; }


### PR DESCRIPTION
## What

Removes the orange focus ring that appeared **inside** the chat composer, on top of the typed text.

## Why

`.tfl-chatbox-ta:focus-visible` used `outline: 2px solid var(--accent-display)` with `outline-offset: -2px` — an inset ring that overlapped the first line of text and made it hard to read while typing (see issue screenshot).

## How

- Drop the inset outline on the textarea (`outline: none`).
- Signal focus on the composer **edge** instead via `.tfl-chatbox:focus-within`, brightening the container border to a subtle neutral (`#4A4744`) — never over the text.

Keeps a keyboard-visible focus affordance (no a11y regression) while fixing readability. CSS-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)